### PR TITLE
Fix pip package source root

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ####
     name="fprime_gds",
     use_scm_version={
-        "root": "..",
+        "root": ".",
         "relative_to": __file__
     },
     license="Apache 2.0 License",
@@ -83,7 +83,7 @@ integrated configuration with ground in-the-loop.
     ####
     entry_points={
         "gui_scripts": ["fprime-gds = fprime_gds.executables.run_deployment:main"],
-        "console_scripts": ["fprime-cli = fprime_gds.executables.fprime_cli:main", 
+        "console_scripts": ["fprime-cli = fprime_gds.executables.fprime_cli:main",
                             "fprime-seqgen = fprime_gds.common.tools.seqgen:main"],
     },
     ####


### PR DESCRIPTION
Note, since there aren't any git tags of fprime-tools, installing fprime-tools locally triggers errors when attempting to install the GDS because the automatically generated fprime-tools version is lower than GDS requirement. This will fix itself after the 2.0 release and a fprime-tools release is tagged.