### PR TITLE
lestarch: adding hash algorithm selection to CLI

### DIFF
--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -12,6 +12,7 @@ that implement this pattern. The current list of implementation classes are:
 @author lestarch
 """
 import abc
+import sys
 import copy
 import struct
 from .checksum import calculate_checksum
@@ -174,6 +175,9 @@ class FpFramerDeframer(FramerDeframer):
                 ):
                     data = data[total_size:]
                     return deframed, data
+                else:
+                    print("[WARNING] Checksum validation failed. Have you correctly set '--comm-checksum-type'",
+                          file=sys.stderr)
                 # Bad checksum, rotate 1 and keep looking for non-garbage
                 data = data[1:]
                 continue

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -18,6 +18,7 @@ import re
 import sys
 
 import fprime_gds.common.communication.adapters.base
+import fprime_gds.common.communication.checksum
 
 # Include basic adapters
 import fprime_gds.common.communication.adapters.ip
@@ -221,6 +222,15 @@ class CommParser(ParserBase):
             choices=adapters,
             default="ip",
         )
+        parser.add_argument(
+            "--comm-checksum-type",
+            dest="checksum_type",
+            action="store",
+            type=str,
+            help="Setup the checksum algorithm. [default: %(default)s]",
+            choices=[item for item in fprime_gds.common.communication.checksum.CHECKSUM_MAPPING.keys() if item != "default"],
+            default=fprime_gds.common.communication.checksum.CHECKSUM_SELECTION,
+        )
         return parser
 
     @classmethod
@@ -237,6 +247,7 @@ class CommParser(ParserBase):
                 args.adapter, args
             )
         )
+        fprime_gds.common.communication.checksum.CHECKSUM_SELECTION = args.checksum_type
         return args
 
 

--- a/src/fprime_gds/executables/comm.py
+++ b/src/fprime_gds/executables/comm.py
@@ -24,6 +24,7 @@ import signal
 
 # Required adapters built on standard tools
 import fprime_gds.common.communication.adapters.base
+import fprime_gds.common.communication.checksum
 import fprime_gds.common.communication.ground
 import fprime_gds.common.communication.adapters.ip
 import fprime_gds.common.logger
@@ -57,10 +58,12 @@ def main():
         description="F prime communications layer.",
         client=True,
     )
+    fprime_gds.common.communication.checksum = args.checksum_type
     # Create the handling components for either side of this script, adapter for hardware, and ground for the GDS side
     ground = fprime_gds.common.communication.ground.TCPGround(
         args.tts_addr, args.tts_port
     )
+
     adapter = args.comm_adapter
 
     # Set the framing class used and pass it to the uplink and downlink component constructions giving each a separate

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -326,6 +326,8 @@ def launch_comm(comm_adapter, tts_port, connect_address, logs, **all_args):
         "--log-directly",
         "--comm-adapter",
         all_args["adapter"],
+        "--comm-checksum-type",
+        all_args["checksum_type"]
     ]
     # Manufacture arguments for the selected adapter
     for arg in comm_adapter.get_arguments().keys():


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

One can now specify `--comm-checksum-type` to specify the type of checksum to compute.