### PR TITLE
Check for frame key in data with multiple messages

### DIFF
--- a/src/fprime_gds/common/distributor/distributor.py
+++ b/src/fprime_gds/common/distributor/distributor.py
@@ -85,24 +85,24 @@ class Distributor:
         data_left = data
 
         raw_msgs = []
-        # Search data looking for key-frame
-        if self.key_frame is not None:
-            while True:
-                # Check if we have enough data to parse a key
-                # if not, bail on the function
-                if len(data_left) < self.key_obj.getSize():
-                    return data_left, raw_msgs
-                # Check leading key size bytes to see if it is the key
-                self.key_obj.deserialize(data_left, 0)
-                if self.key_obj.val != self.key_frame:
-                    data_left = data_left[1:]
-                    continue
-                # Key found break
-                data_left = data_left[self.key_obj.getSize():]
-                break
-
         # Keep parsing and then break when you can't parse no more
         while True:
+            # Search data looking for key-frame
+            if self.key_frame is not None:
+                while True:
+                    # Check if we have enough data to parse a key
+                    # if not, bail on the function
+                    if len(data_left) < self.key_obj.getSize():
+                        return data_left, raw_msgs
+                    # Check leading key size bytes to see if it is the key
+                    self.key_obj.deserialize(data_left, 0)
+                    if self.key_obj.val != self.key_frame:
+                        data_left = data_left[1:]
+                        continue
+                    # Key found break
+                    data_left = data_left[self.key_obj.getSize():]
+                    break
+
             # Check if we have enough data to parse a length
             if len(data_left) < self.len_obj.getSize():
                 break


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| fprime-gds |
|**_Affected Component_**| common/distributer |
|**_Affected Architectures(s)_**| - |
|**_Related Issue(s)_**| - |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

It seems the current implementation of distributer in fprime-gds shown below assumes one single key_frame per data passed to distributer by on_recv():
https://github.com/fprime-community/fprime-gds/blob/0b2879a09a3b4f7e489ea2076188c0c0bfa99f43/src/fprime_gds/common/distributor/distributor.py#L89-L102

The code looks for the first occurrence of the key_frame and then it tries to read lengths until the end of the data.
 
The issue is when we pass the entire com file only the first message will be decoded. The reset of raw messages will be sliced incorrectly.

To resolve this issue (as proposed by @LeStarch) moved "the 'search for keyframe' block (lines 89-102) into the next while loop (105) as a first step."

## Rationale

The intention is to "find a key frame, unparsed message, then search for keyframe again."

## Testing/Review Recommendations

Ran a custom ComLog parser, passed entire ComLog to the distributer and was able to pars the binary file with no issue.
Ran GDS and was able to see log files in the browser.

## Future Work

On the following line we might be able to replace Python list with generator to avoid loading the entire data into memory before start processing the data:
https://github.com/fprime-community/fprime-gds/blob/0b2879a09a3b4f7e489ea2076188c0c0bfa99f43/src/fprime_gds/common/distributor/distributor.py#L117
