### PR TITLE
Fixes #21 Event scroll bottom issue

### DIFF
--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -152,9 +152,9 @@ Vue.component("event-list", {
          */
         onScroll(e) {
             let elmH = this.scrollableElm.scrollHeight;
-            let elmT = Math.abs(this.scrollableElm.scrollTop);
+            let elmT = this.scrollableElm.scrollTop;
             let elmC = this.scrollableElm.clientHeight;
-            let isAtBottom = ((elmH - elmT) === elmC) && (elmT !== 0);
+            let isAtBottom = (Math.abs(elmH - elmT - elmC) <= 3.0) && (elmT !== 0);
             
             if (!this.isScrollable()) {
                 // Disabling auto update user scrolls

--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -154,7 +154,7 @@ Vue.component("event-list", {
             let elmH = this.scrollableElm.scrollHeight;
             let elmT = this.scrollableElm.scrollTop;
             let elmC = this.scrollableElm.clientHeight;
-            let isAtBottom = (Math.abs(elmH - elmT - elmC) <= 3.0) && (elmT !== 0);
+            let isAtBottom = (Math.abs(elmH - elmT - elmC) <= 2.0) && (elmT !== 0);
             
             if (!this.isScrollable()) {
                 // Disabling auto update user scrolls


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' GDS 2.0 |
|**_Affected Component_**|  event.js|
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**| #21 |
|**_Has Unit Tests (y/n)_**|  No|
|**_Builds Without Errors (y/n)_**| Y |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

> On systems using display scaling, scrollTop may give you a decimal value.

[Reference MDN scrollTop](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollTop)

To resolve the scroll issue added 2.0 px tolerance.

## Rationale

Since some browsers return sub-pixel values cannot use exact integer number to detect the location of scroll bar.

## Testing/Review Recommendations
Manually verified the fix on both Mac and Pc on Chrome 92.0.4515.131 and FireFox 91.0

## Future Work

NA
