### PR TITLE
Fixes #23 failing synchronous unload DELETE request

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -44,6 +44,7 @@ backport
 basestring
 batchmode
 baudrate
+beforeunload
 BGR
 Biberstein
 bibtex
@@ -99,7 +100,6 @@ csum
 csv
 ctime
 CTORS
-ctx
 curateable
 curated
 curating
@@ -315,7 +315,6 @@ jsonify
 jumbotron
 kbd
 keepalive
-kets
 keyframes
 keyify
 kinda
@@ -375,7 +374,6 @@ mycompany
 myfile
 mymodule
 myproject
-nagix
 namespace
 nargs
 navbar
@@ -400,7 +398,6 @@ odo
 oga
 ogg
 OMG
-onbeforeunload
 onload
 onreadystatechange
 openpyxl
@@ -680,9 +677,9 @@ xcode
 xhtml
 xhttp
 xl
-xy
 xlsx
 xml
+xy
 yaml
 yml
 zlib

--- a/src/fprime_gds/flask/static/js/gds.js
+++ b/src/fprime_gds/flask/static/js/gds.js
@@ -37,14 +37,12 @@ document.addEventListener("DOMContentLoaded", function(event) {
  * Asynchronous wait
  * Reference: https://stackoverflow.com/questions/6921895/
  */
- const asyncWait = ms => new Promise(resolve => setTimeout(resolve, ms));
+const asyncWait = ms => new Promise(resolve => setTimeout(resolve, ms));
 
- /**
-  * Teardown best effort code.
-  */
- 
- window.addEventListener('beforeunload', (async () => {
-     _loader.destroy();
-     await asyncWait(500);
- })());
- 
+/**
+ * Teardown best effort code.
+ */
+window.addEventListener('beforeunload', (async () => {
+    _loader.destroy();
+    await asyncWait(500);
+})());

--- a/src/fprime_gds/flask/static/js/gds.js
+++ b/src/fprime_gds/flask/static/js/gds.js
@@ -47,3 +47,4 @@ document.addEventListener("DOMContentLoaded", function(event) {
      _loader.destroy();
      await asyncWait(500);
  })());
+ 

--- a/src/fprime_gds/flask/static/js/gds.js
+++ b/src/fprime_gds/flask/static/js/gds.js
@@ -34,8 +34,16 @@ document.addEventListener("DOMContentLoaded", function(event) {
     _loader.setup().then(setupBindings).catch(console.error);
 });
 /**
- * Teardown best effort code.
+ * Asynchronous wait
+ * Reference: https://stackoverflow.com/questions/6921895/
  */
-window.onbeforeunload = function (e) {
-    _loader.destroy();
-};
+ const asyncWait = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+ /**
+  * Teardown best effort code.
+  */
+ 
+ window.addEventListener('beforeunload', (async () => {
+     _loader.destroy();
+     await asyncWait(500);
+ })());

--- a/src/fprime_gds/flask/static/js/loader.js
+++ b/src/fprime_gds/flask/static/js/loader.js
@@ -134,7 +134,9 @@ class Loader {
                 }
             };
             let random = new Date().getTime().toString();
-            xhttp.open(method, endpoint + "?_no_cache=" + random + "&session=" + _self.session, method != "DELETE");
+            let url = endpoint + "?_no_cache=" + random + "&session=" + _self.session;
+            let is_async = true; // all calls will be async
+            xhttp.open(method, url , is_async); 
             if (typeof(data) === "undefined") {
                 xhttp.send();
             } else if (typeof(jsonify) === "undefined" || jsonify) {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' GDS 2.0 |
|**_Affected Component_**|  gds.js |
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**|  #23 |
|**_Has Unit Tests (y/n)_**|  No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Adding asyncWait and async call on beforeunload to delete session.

## Rationale

See #23

## Testing/Review Recommendations

Verified DELETE requests are called on unload page:
![Screen Shot 2021-08-15 at 10 42 02 AM](https://user-images.githubusercontent.com/35859004/129487452-bbf05e81-7485-4c95-af55-e33cd308d7c2.png)

## Future Work

NA
