### PR TITLE
Fix event colors

### DIFF
--- a/src/fprime_gds/flask/static/css/fpstyle.css
+++ b/src/fprime_gds/flask/static/css/fpstyle.css
@@ -5,41 +5,56 @@
  * Events, and  Channels based on severity. These colors should define two pairs, the color, and a .table-hover hover
  * color for use in hover-tables.
  */
+ .table-bordered th, .table-bordered td {
+    border: 1px solid rgba(0, 0, 0, 0.125);
+}
 .fp-color-fatal {
-    background-color: #ff0000;
+    color: #000000;
+    background-color: rgba(251,128,114, 1);
 }
 .table-hover .fp-color-fatal:hover {
-    background-color: #e60000;
+    color: #000000;
+    background-color: rgba(251,128,114, 0.7);
 }
 .fp-color-warn-hi {
-    background-color: #ff8000;
+    color: #000000;
+    background-color: rgba(242,142,44, 1);
 }
 .table-hover .fp-color-warn-hi:hover {
-    background-color: #e67300;
+    color: #000000;
+    background-color: rgb(242,142,44, 0.8);
 }
 .fp-color-warn-lo {
-    background-color: #ffff00;
+    color: #000000;
+    background-color: rgba(237,201,73, 1);
 }
 .table-hover .fp-color-warn-lo:hover {
-    background-color: #e6e600;
+    color: #000000;
+    background-color: rgba(237,201,73, 0.7);
 }
 .fp-color-act-hi {
-    background-color: #0080ff;
+    color: #000000;
+    background-color: rgba(128,177,211, 1);
 }
 .table-hover .fp-color-act-hi:hover {
-    background-color: #0073e6;
+    color: #000000;
+    background-color: rgba(128,177,211, 0.7);
 }
 .fp-color-act-lo {
-    background-color: #808080;
+    color: #000000;
+    background-color: rgba(186,176,171, 1);
 }
 .table-hover .fp-color-act-lo:hover {
-    background-color: #737373;
+    color: #000000;
+    background-color: rgba(186,176,171, 0.7);
 }
 .fp-color-command {
-    background-color: #00ff00;
+    color: #000000;
+    background-color: rgba(127,201,127, 1);
 }
 .table-hover .fp-color-command:hover {
-    background-color: #00e600;
+    color: #000000;
+    background-color: rgba(127,201,127, 0.7);
 }
 .fp-color-logging {
     background-color: #f0fff0;

--- a/src/fprime_gds/flask/static/css/fpstyle.css
+++ b/src/fprime_gds/flask/static/css/fpstyle.css
@@ -6,7 +6,7 @@
  * color for use in hover-tables.
  */
  .table-bordered th, .table-bordered td {
-    border: 1px solid rgba(0, 0, 0, 0.125);
+    border: 1px solid rgba(0, 0, 0, 0.125) !important;
 }
 .fp-color-fatal {
     color: #000000;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' GDS 2.0 |
|**_Affected Component_**|  fpstyle.css events table |
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**| NA |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| NA |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

Updating Event colors to make the background colors less sharp and have better contrast with the text.

## Rationale

Current Event colors are very sharp and in some cases have low contrast with the EVR text making it hard to read the content.
Current Event colors:

![Screen Shot 2021-08-15 at 2 54 18 PM](https://user-images.githubusercontent.com/35859004/129493918-9ef2b236-ceb2-4f7b-9750-4f32ca6020ab.png)

This PR updates the colors to be less aggressive on the eye. The schema used for the colors are adapted from D3 color schema [see here](https://github.com/d3/d3-scale-chromatic)

![Screen Shot 2021-08-15 at 2 37 51 PM](https://user-images.githubusercontent.com/35859004/129493976-b9112bf8-a822-458d-a1c1-499832ee2f9b.png)


## Testing/Review Recommendations

Manually checked the result in Chrome 92.0.4515.131

## Future Work

NA
