### PR TITLE
Fix str format

### DIFF
--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -9,7 +9,7 @@
 
 from fprime.common.models.serialize import time_type
 from fprime_gds.common.data_types import sys_data
-from fprime_gds.common.utils.string_util import format_string
+from fprime_gds.common.utils.string_util import format_string_template
 
 
 class ChData(sys_data.SysData):
@@ -129,7 +129,7 @@ class ChData(sys_data.SysData):
         if self.val_obj is None:
             ch_val = "EMPTY CH OBJ"
         elif fmt_str:
-            ch_val  = format_string(fmt_str, (self.val_obj.val,))
+            ch_val  = format_string_template(fmt_str, (self.val_obj.val,))
         else:
             ch_val = str(self.val_obj.val)
 

--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -9,6 +9,7 @@
 
 from fprime.common.models.serialize import time_type
 from fprime_gds.common.data_types import sys_data
+from fprime_gds.common.utils.string_util import format_string
 
 
 class ChData(sys_data.SysData):
@@ -128,7 +129,7 @@ class ChData(sys_data.SysData):
         if self.val_obj is None:
             ch_val = "EMPTY CH OBJ"
         elif fmt_str:
-            ch_val = fmt_str % (self.val_obj.val)
+            ch_val  = format_string(fmt_str, (self.val_obj.val,))
         else:
             ch_val = str(self.val_obj.val)
 

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -9,7 +9,7 @@
 
 from fprime.common.models.serialize import time_type
 from fprime_gds.common.data_types import sys_data
-from fprime_gds.common.utils.string_util import format_string
+from fprime_gds.common.utils.string_util import format_string_template
 
 
 class EventData(sys_data.SysData):
@@ -103,7 +103,7 @@ class EventData(sys_data.SysData):
             # used to fill in a format string. Convert them to values that can be
             arg_val_list = [arg_obj.val for arg_obj in self.args]
 
-            arg_str = format_string(format_str, tuple(arg_val_list))
+            arg_str = format_string_template(format_str, tuple(arg_val_list))
 
         if verbose and csv:
             return "%s,%s,%s,%d,%s,%s" % (

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -3,6 +3,8 @@ string_util.py
 Utility functions to process strings to be used in FPrime GDS
 @Created March 18, 2021
 @janamian
+
+Note: This function has an identical copy in fprime-tools
 """
 
 import re
@@ -113,5 +115,3 @@ def format_string_template(format_str, given_values):
         msg += f'Err Msg: {str(e)}\n'
         LOGGER.error(msg)
         raise ValueError
-
-

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -10,7 +10,7 @@ Note: This function has an identical copy in fprime-gds
 import re
 import logging
 
-LOGGER = logging.getLogger('string_util_logger')
+LOGGER = logging.getLogger("string_util_logger")
 
 
 def format_string_template(format_str, given_values):
@@ -44,30 +44,31 @@ def format_string_template(format_str, given_values):
     def convert(match_obj, ignore_int):
         if match_obj.group() is not None:
             flags, width, precision, length, conversion_type = match_obj.groups()
-            format_template = ''
+            format_template = ""
             if flags:
-                format_template += f'{flags}'
+                format_template += f"{flags}"
             if width:
-                format_template += f'{width}'
+                format_template += f"{width}"
             if precision:
-                format_template += f'{precision}'
+                format_template += f"{precision}"
 
             if conversion_type:
-                if any([
-                    str(conversion_type).lower() == 'f',
-                    str(conversion_type).lower() == 'x',
-                    str(conversion_type).lower() == 'o',
-                    str(conversion_type).lower() == 'e',
-                ]):
-                    format_template += f'{conversion_type}'
-                elif all([not ignore_int,
-                          str(conversion_type).lower() == 'd']):
-                    format_template += f'{conversion_type}'
+                if any(
+                    [
+                        str(conversion_type).lower() == "f",
+                        str(conversion_type).lower() == "x",
+                        str(conversion_type).lower() == "o",
+                        str(conversion_type).lower() == "e",
+                    ]
+                ):
+                    format_template += f"{conversion_type}"
+                elif all([not ignore_int, str(conversion_type).lower() == "d"]):
+                    format_template += f"{conversion_type}"
 
-            if format_template == '':
-                template = '{}'
+            if format_template == "":
+                template = "{}"
             else:
-                template = '{:' + format_template + '}'
+                template = "{:" + format_template + "}"
             return template
         return match_obj
 
@@ -85,7 +86,7 @@ def format_string_template(format_str, given_values):
     else:
         values = given_values
 
-    pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
+    pattern = "(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"
 
     match = re.compile(pattern)
 
@@ -93,13 +94,13 @@ def format_string_template(format_str, given_values):
     try:
         formatted_str = re.sub(match, convert_include_all, format_str)
         result = formatted_str.format(*values)
-        result = result.replace('%%', '%')
+        result = result.replace("%%", "%")
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. '
-        msg += ' Will ignore integer flags `d` in string template. '
-        msg += f'values: {values}. '
-        msg += f'format_str: {format_str}. '
+        msg = "Value and format string do not match. "
+        msg += " Will ignore integer flags `d` in string template. "
+        msg += f"values: {values}. "
+        msg += f"format_str: {format_str}. "
         LOGGER.warning(msg)
 
     # Second try by not including %d.
@@ -108,12 +109,12 @@ def format_string_template(format_str, given_values):
     try:
         formatted_str = re.sub(match, convert_ignore_int, format_str)
         result = formatted_str.format(*values)
-        result = result.replace('%%', '%')
+        result = result.replace("%%", "%")
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. '
-        msg += f'values: {values}. '
-        msg += f'format_str: {format_str}. '
-        msg += f'Err Msg: {str(e)}\n'
+        msg = "Value and format string do not match. "
+        msg += f"values: {values}. "
+        msg += f"format_str: {format_str}. "
+        msg += f"Err Msg: {str(e)}\n"
         LOGGER.error(msg)
         raise ValueError

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -1,8 +1,6 @@
 """
 string_util.py
-
 Utility functions to process strings to be used in FPrime GDS
-
 @Created March 18, 2021
 @janamian
 """
@@ -10,37 +8,68 @@ Utility functions to process strings to be used in FPrime GDS
 import re
 
 
-def format_string(format_str, values):
+def format_string(format_str, given_values):
     """
     Function to convert C-string style to python format
     without using python interpolation
     Considered the following format for C-string:
     %[flags][width][.precision][length]type
     
-    %:           (?<!%)(?:%%)*%
-    flags:       ([\-\+0\ \#])?
-    width:       (\d+|\*)?
-    .precision:  (\.\*|\.\d+)?
-    length:      `([hLIw]|l{1,2}|I32|I64)?`
-    type:        `([cCdiouxXeEfgGaAnpsSZ])`
+    0- %:                (?<!%)(?:%%)*%
+    1- flags:            ([\-\+0\ \#])?
+    2- width:            (\d+|\*)?
+    3- .precision:       (\.\*|\.\d+)?
+    4- length:          `([hLIw]|l{1,2}|I32|I64)?`
+    5- conversion_type: `([cCdiouxXeEfgGaAnpsSZ])`
     
     Note:
-    This function will keep the flags, width, .precision and length of C-string
+    This function will keep the flags, width, and .precision of C-string
     template. It will remove all types so they could be duck-typed by python 
-    interpreter except for hex type X or x.
+    interpreter except for hex type X or x. lengths will also be removed since
+    they are not meaningful to Python interpreter
+    See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
+    Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363
     """
     def convert(match_obj):
         if match_obj.group() is not None:
-            template = "{:" + match_obj.group()[1:-1]
-            if match_obj.group()[-1].lower() == 'x':
-                template += match_obj.group()[-1]
-            template += "}"
+            flags, width, percision, lenght, conversion_type = match_obj.groups()
+            fmr_str = ''
+            if flags:
+                fmr_str += f'{flags}'
+            if width:
+                fmr_str += f'{width}'
+            if percision:
+                fmr_str += f'{percision}'
+
+            if conversion_type:
+                if any([
+                    str(conversion_type).lower() == 'f',
+                    str(conversion_type).lower() == 'd',
+                    str(conversion_type).lower() == 'x',
+                    str(conversion_type).lower() == 'o',
+                    str(conversion_type).lower() == 'e',
+                    ]):
+                    fmr_str += f'{conversion_type}'
+
+            if fmr_str == '':
+                template = '{}'
+            else:
+                template = '{:' + fmr_str + '}'
             return template
         return match_obj
 
-    pattern = "(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"
+    # Allowing single, list and tuple inputs
+    if not isinstance(given_values, (list, tuple)):
+        values = (given_values, )
+    elif isinstance(given_values, list):
+        values = tuple(given_values)
+    else:
+        values = given_values
+
+    pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
+
     match = re.compile(pattern) 
     formated_str = re.sub(match, convert, format_str)
     result = formated_str.format(*values)
-    result = result.replace("%%", "%")
+    result = result.replace('%%', '%')
     return result

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -24,22 +24,27 @@ def format_string(format_str, given_values):
     
     Note:
     This function will keep the flags, width, and .precision of C-string
-    template. It will remove all types so they could be duck-typed by python 
-    interpreter except for hex type X or x. lengths will also be removed since
-    they are not meaningful to Python interpreter
-    See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
-    Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363
+    template. 
+    
+    It will keep f, d, x, o, and e flags and remove all other types.
+    Other types will be duck-typed by python 
+    interpreter. 
+    
+    lengths will also be removed since they are not meaningful to Python interpreter.
+    `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
+    
+    `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
     def convert(match_obj):
         if match_obj.group() is not None:
-            flags, width, percision, lenght, conversion_type = match_obj.groups()
-            fmr_str = ''
+            flags, width, precision, length, conversion_type = match_obj.groups()
+            format_template = ''
             if flags:
-                fmr_str += f'{flags}'
+                format_template += f'{flags}'
             if width:
-                fmr_str += f'{width}'
-            if percision:
-                fmr_str += f'{percision}'
+                format_template += f'{width}'
+            if precision:
+                format_template += f'{precision}'
 
             if conversion_type:
                 if any([
@@ -49,12 +54,12 @@ def format_string(format_str, given_values):
                     str(conversion_type).lower() == 'o',
                     str(conversion_type).lower() == 'e',
                     ]):
-                    fmr_str += f'{conversion_type}'
+                    format_template += f'{conversion_type}'
 
-            if fmr_str == '':
+            if format_template == '':
                 template = '{}'
             else:
-                template = '{:' + fmr_str + '}'
+                template = '{:' + format_template + '}'
             return template
         return match_obj
 

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -29,17 +29,18 @@ def format_string_template(format_str, given_values):
 
     Note:
     This function will keep the flags, width, and .precision of C-string
-    template. 
+    template.
 
     It will keep f, d, x, o, and e flags and remove all other types.
-    Other types will be duck-typed by python 
-    interpreter. 
+    Other types will be duck-typed by python
+    interpreter.
 
     lengths will also be removed since they are not meaningful to Python interpreter.
     `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
 
     `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
+
     def convert(match_obj, ignore_int):
         if match_obj.group() is not None:
             flags, width, precision, length, conversion_type = match_obj.groups()
@@ -78,7 +79,7 @@ def format_string_template(format_str, given_values):
 
     # Allowing single, list and tuple inputs
     if not isinstance(given_values, (list, tuple)):
-        values = (given_values, )
+        values = (given_values,)
     elif isinstance(given_values, list):
         values = tuple(given_values)
     else:
@@ -87,15 +88,16 @@ def format_string_template(format_str, given_values):
     pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
 
     match = re.compile(pattern)
-    
+
     # First try to include all types
     try:
-        formated_str = re.sub(match, convert_include_all, format_str)
-        result = formated_str.format(*values)
+        formatted_str = re.sub(match, convert_include_all, format_str)
+        result = formatted_str.format(*values)
         result = result.replace('%%', '%')
         return result
     except ValueError as e:
-        msg = 'Value and format string do not match. Will ignore integer flags `d` in string template. '
+        msg = 'Value and format string do not match. '
+        msg += ' Will ignore integer flags `d` in string template. '
         msg += f'values: {values}. '
         msg += f'format_str: {format_str}. '
         LOGGER.warning(msg)
@@ -104,8 +106,8 @@ def format_string_template(format_str, given_values):
     # This will resolve failing ENUMs with %d
     # but will fail on other types.
     try:
-        formated_str = re.sub(match, convert_ignore_int, format_str)
-        result = formated_str.format(*values)
+        formatted_str = re.sub(match, convert_ignore_int, format_str)
+        result = formatted_str.format(*values)
         result = result.replace('%%', '%')
         return result
     except ValueError as e:

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -42,4 +42,5 @@ def format_string(format_str, values):
     match = re.compile(pattern) 
     formated_str = re.sub(match, convert, format_str)
     result = formated_str.format(*values)
+    result = result.replace("%%", "%")
     return result

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -2,9 +2,9 @@
 string_util.py
 Utility functions to process strings to be used in FPrime GDS
 @Created March 18, 2021
-@janamian
+@`janamian`
 
-Note: This function has an identical copy in fprime-tools
+Note: This function has an identical copy in fprime-gds
 """
 
 import re
@@ -19,25 +19,25 @@ def format_string_template(format_str, given_values):
     without using python interpolation
     Considered the following format for C-string:
     %[flags][width][.precision][length]type
-    
+
     0- %:                (?<!%)(?:%%)*%
     1- flags:            ([\-\+0\ \#])?
     2- width:            (\d+|\*)?
     3- .precision:       (\.\*|\.\d+)?
     4- length:          `([hLIw]|l{1,2}|I32|I64)?`
     5- conversion_type: `([cCdiouxXeEfgGaAnpsSZ])`
-    
+
     Note:
     This function will keep the flags, width, and .precision of C-string
     template. 
-    
+
     It will keep f, d, x, o, and e flags and remove all other types.
     Other types will be duck-typed by python 
     interpreter. 
-    
+
     lengths will also be removed since they are not meaningful to Python interpreter.
     `See: https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting`
-    
+
     `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
     def convert(match_obj, ignore_int):
@@ -57,12 +57,12 @@ def format_string_template(format_str, given_values):
                     str(conversion_type).lower() == 'x',
                     str(conversion_type).lower() == 'o',
                     str(conversion_type).lower() == 'e',
-                    ]):
+                ]):
                     format_template += f'{conversion_type}'
                 elif all([not ignore_int,
-                        str(conversion_type).lower() == 'd']):
+                          str(conversion_type).lower() == 'd']):
                     format_template += f'{conversion_type}'
-     
+
             if format_template == '':
                 template = '{}'
             else:
@@ -75,7 +75,6 @@ def format_string_template(format_str, given_values):
 
     def convert_ignore_int(match_obj):
         return convert(match_obj, ignore_int=True)
-    
 
     # Allowing single, list and tuple inputs
     if not isinstance(given_values, (list, tuple)):
@@ -88,6 +87,7 @@ def format_string_template(format_str, given_values):
     pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
 
     match = re.compile(pattern)
+    
     # First try to include all types
     try:
         formated_str = re.sub(match, convert_include_all, format_str)
@@ -99,8 +99,8 @@ def format_string_template(format_str, given_values):
         msg += f'values: {values}. '
         msg += f'format_str: {format_str}. '
         LOGGER.warning(msg)
-        
-    # Second try by not including %d. 
+
+    # Second try by not including %d.
     # This will resolve failing ENUMs with %d
     # but will fail on other types.
     try:

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -6,9 +6,12 @@ Utility functions to process strings to be used in FPrime GDS
 """
 
 import re
+import logging
+
+LOGGER = logging.getLogger('string_util_logger')
 
 
-def format_string(format_str, given_values):
+def format_string_template(format_str, given_values):
     """
     Function to convert C-string style to python format
     without using python interpolation
@@ -35,7 +38,7 @@ def format_string(format_str, given_values):
     
     `Regex Source: https://www.regexlib.com/REDetails.aspx?regexp_id=3363`
     """
-    def convert(match_obj):
+    def convert(match_obj, ignore_int):
         if match_obj.group() is not None:
             flags, width, precision, length, conversion_type = match_obj.groups()
             format_template = ''
@@ -49,19 +52,28 @@ def format_string(format_str, given_values):
             if conversion_type:
                 if any([
                     str(conversion_type).lower() == 'f',
-                    str(conversion_type).lower() == 'd',
                     str(conversion_type).lower() == 'x',
                     str(conversion_type).lower() == 'o',
                     str(conversion_type).lower() == 'e',
                     ]):
                     format_template += f'{conversion_type}'
-
+                elif all([not ignore_int,
+                        str(conversion_type).lower() == 'd']):
+                    format_template += f'{conversion_type}'
+     
             if format_template == '':
                 template = '{}'
             else:
                 template = '{:' + format_template + '}'
             return template
         return match_obj
+
+    def convert_include_all(match_obj):
+        return convert(match_obj, ignore_int=False)
+
+    def convert_ignore_int(match_obj):
+        return convert(match_obj, ignore_int=True)
+    
 
     # Allowing single, list and tuple inputs
     if not isinstance(given_values, (list, tuple)):
@@ -73,8 +85,33 @@ def format_string(format_str, given_values):
 
     pattern = '(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])'
 
-    match = re.compile(pattern) 
-    formated_str = re.sub(match, convert, format_str)
-    result = formated_str.format(*values)
-    result = result.replace('%%', '%')
-    return result
+    match = re.compile(pattern)
+    # First try to include all types
+    try:
+        formated_str = re.sub(match, convert_include_all, format_str)
+        result = formated_str.format(*values)
+        result = result.replace('%%', '%')
+        return result
+    except ValueError as e:
+        msg = 'Value and format string do not match. Will ignore integer flags `d` in string template. '
+        msg += f'values: {values}. '
+        msg += f'format_str: {format_str}. '
+        LOGGER.warning(msg)
+        
+    # Second try by not including %d. 
+    # This will resolve failing ENUMs with %d
+    # but will fail on other types.
+    try:
+        formated_str = re.sub(match, convert_ignore_int, format_str)
+        result = formated_str.format(*values)
+        result = result.replace('%%', '%')
+        return result
+    except ValueError as e:
+        msg = 'Value and format string do not match. '
+        msg += f'values: {values}. '
+        msg += f'format_str: {format_str}. '
+        msg += f'Err Msg: {str(e)}\n'
+        LOGGER.error(msg)
+        raise ValueError
+
+

--- a/src/fprime_gds/flask/channels.py
+++ b/src/fprime_gds/flask/channels.py
@@ -13,7 +13,8 @@ import types
 
 import flask_restful
 import flask_restful.reqparse
-
+from fprime.common.models.serialize.serializable_type import SerializableType
+from fprime.common.models.serialize.array_type import ArrayType
 
 class ChannelDictionary(flask_restful.Resource):
     """
@@ -58,8 +59,19 @@ class ChannelHistory(flask_restful.Resource):
         new_channels = self.history.retrieve(start=args.get("session"))
         self.history.clear()
         for chan in new_channels:
-            # Add the 'display_text' to the event, along with a getter
-            if chan.template.get_format_str() is not None:
+            # Add the 'display_text' to the channel, along with a getter
+            if isinstance(chan.val_obj, (SerializableType, ArrayType)):
+                setattr(
+                    chan,
+                    "display_text",
+                    chan.val_obj.formatted_val
+                )
+
+                def func(this):
+                    return this.display_text
+                setattr(chan, "get_display_text", types.MethodType(func, chan))
+            
+            elif chan.template.get_format_str() is not None:
                 setattr(
                     chan,
                     "display_text",

--- a/src/fprime_gds/flask/events.py
+++ b/src/fprime_gds/flask/events.py
@@ -13,7 +13,7 @@ import types
 
 import flask_restful
 import flask_restful.reqparse
-from fprime_gds.common.utils.string_util import format_string
+from fprime_gds.common.utils.string_util import format_string_template
 
 
 class EventDictionary(flask_restful.Resource):
@@ -63,7 +63,7 @@ class EventHistory(flask_restful.Resource):
             setattr(
                 event,
                 "display_text",
-                format_string(event.template.format_str, tuple([arg.val for arg in event.args])),
+                format_string_template(event.template.format_str, tuple([arg.val for arg in event.args])),
             )
 
             def func(this):

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -6,7 +6,7 @@ Tests format_string util
 """
 
 import unittest
-from fprime_gds.common.utils.string_util import format_string
+from fprime_gds.common.utils.string_util import format_string_template
 
 
 class TestFormatString(unittest.TestCase):
@@ -15,48 +15,48 @@ class TestFormatString(unittest.TestCase):
         template = 'Opcode 0x%04X dispatched to port %d and value %f'
         values = (181, 8, 1.234)
         expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234000'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_value_with_string_input_as_other_types(self):
         template = 'Opcode 0x%04X dispatched to port %u and value %.2f'
         values = (181, '8', 1.234)
         expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.23'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_with_format_spec(self):
         template = 'Opcode 0x%04X dispatched to port %04d and value %0.02f'
         values = (181, 8, 1.234)
         expected = 'Opcode 0x00B5 dispatched to port 0008 and value 1.23'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_bad_case(self):
         template = 'Opcode 0x%04X dispatched to port %04d and value %0.02f'
         values = ('181', '8', '0.123')
         with self.assertRaises(ValueError):
-            self.assertEqual(format_string(template, values))
+            self.assertEqual(format_string_template(template, values))
 
     def test_format_decimal_with_width_flag(self):
         template = 'Decimals: %d %ld'
         values = (1977, 650000)
         expected = 'Decimals: 1977 650000'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_preceding_with_blanks(self):
         template = 'Preceding with blanks: %10d'
         values = (1977, )
         expected = 'Preceding with blanks:       1977'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_preceding_with_zeros(self):
         template = 'Preceding with zeros: %010d'
         values = (1977, )
         expected = 'Preceding with zeros: 0000001977'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_some_different_radices(self):
@@ -65,14 +65,14 @@ class TestFormatString(unittest.TestCase):
         # The alternate form causes a leading octal specifier ('0o') to be inserted before the first digit. This is different than C behavior
         # `See https://docs.python.org/3/library/stdtypes.html#printf-style-bytes-formatting`
         expected = 'Some different radices: 100 64 144 0x64 0o144'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_floats(self):
         template = 'floats: %4.2f %+.0e %E'
         values = (3.1416, 3.1416, 3.1416)
         expected = 'floats: 3.14 +3e+00 3.141600E+00'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_asterisk_width(self):
@@ -80,48 +80,48 @@ class TestFormatString(unittest.TestCase):
         template = 'Width trick: %*d'
         values = (5, 10)
         with self.assertRaises(ValueError):
-            actual = format_string(template, values)
+            actual = format_string_template(template, values)
 
     def test_format_regular_string(self):
         template = '%s'
         values = ('A string', )
         expected = 'A string'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_percent_sign(self):
         template = '%.2f%%'
         values = (1.23456, )
         expected = '1.23%'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_single_value(self):
         template = '%.2f%%'
         values = 1.23456
         expected = '1.23%'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_list_value(self):
         template = '%.2f%%, %.2f%%'
         values = [1.23456, 1.23456]
         expected = '1.23%, 1.23%'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_tuple_value(self):
         template = '%.2f%%, %.2f%%'
         values = (1.23456, 1.23456)
         expected = '1.23%, 1.23%'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_unsigned_flag_with_length_flag(self):
         template = 'Something %lu something %llu something else %lu'
         values = (123456, 123457, 123458)
         expected = 'Something 123456 something 123457 something else 123458'
-        actual = format_string(template, values)
+        actual = format_string_template(template, values)
         self.assertEqual(expected, actual)
 
 if __name__ == '__main__':

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -117,5 +117,12 @@ class TestFormatString(unittest.TestCase):
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 
+    def test_format_unsigned_flag_with_lenght_flag(self):
+        template = 'Something %lu something %llu something else %lu'
+        values = (123456, 123457, 123458)
+        expected = 'Something 123456 something 123457 something else 123458 '
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
 if __name__ == '__main__':
     unittest.main()

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -14,30 +14,108 @@ class TestFormatString(unittest.TestCase):
     def test_format_with_no_issue(self):
         template = 'Opcode 0x%04X dispatched to port %d and value %f'
         values = (181, 8, 1.234)
-        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234'
+        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234000'
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_value_with_string_input_as_other_types(self):
-        template = 'Opcode 0x%04X dispatched to port %d and value %f'
-        values = (181, "8", "1.234")
-        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.234'
+        template = 'Opcode 0x%04X dispatched to port %u and value %.2f'
+        values = (181, '8', 1.234)
+        expected = 'Opcode 0x00B5 dispatched to port 8 and value 1.23'
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_with_format_spec(self):
         template = 'Opcode 0x%04X dispatched to port %04d and value %0.02f'
         values = (181, 8, 1.234)
-        expected = 'Opcode 0x00B5 dispatched to port 0008 and value 1.2'
+        expected = 'Opcode 0x00B5 dispatched to port 0008 and value 1.23'
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 
     def test_format_bad_case(self):
-        template = 'Opcode 0x%04X dispatched with value %f'
-        values = ("181", "0.123")
+        template = 'Opcode 0x%04X dispatched to port %04d and value %0.02f'
+        values = ('181', '8', '0.123')
         with self.assertRaises(ValueError):
             self.assertEqual(format_string(template, values))
 
+    def test_format_decimal_with_width_flag(self):
+        template = 'Decimals: %d %ld'
+        values = (1977, 650000)
+        expected = 'Decimals: 1977 650000'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_preceding_with_blanks(self):
+        template = 'Preceding with blanks: %10d'
+        values = (1977, )
+        expected = 'Preceding with blanks:       1977'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_preceding_with_zeros(self):
+        template = 'Preceding with zeros: %010d'
+        values = (1977, )
+        expected = 'Preceding with zeros: 0000001977'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_some_different_radices(self):
+        template = 'Some different radices: %d %x %o %#x %#o'
+        values = (100, 100, 100, 100, 100)
+        # The alternate form causes a leading octal specifier ('0o') to be inserted before the first digit. This is different than C behavior
+        # See https://docs.python.org/3/library/stdtypes.html#printf-style-bytes-formatting
+        expected = 'Some different radices: 100 64 144 0x64 0o144'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_floats(self):
+        template = 'floats: %4.2f %+.0e %E'
+        values = (3.1416, 3.1416, 3.1416)
+        expected = 'floats: 3.14 +3e+00 3.141600E+00'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_asterisk_width(self):
+        # asterisk `*` is not supported by python string-fromat
+        template = 'Width trick: %*d'
+        values = (5, 10)
+        with self.assertRaises(ValueError):
+            actual = format_string(template, values)
+
+    def test_format_regular_string(self):
+        template = '%s'
+        values = ('A string', )
+        expected = 'A string'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_percent_sign(self):
+        template = '%.2f%%'
+        values = (1.23456, )
+        expected = '1.23%'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_single_value(self):
+        template = '%.2f%%'
+        values = 1.23456
+        expected = '1.23%'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_list_value(self):
+        template = '%.2f%%, %.2f%%'
+        values = [1.23456, 1.23456]
+        expected = '1.23%, 1.23%'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
+
+    def test_format_tuple_value(self):
+        template = '%.2f%%, %.2f%%'
+        values = (1.23456, 1.23456)
+        expected = '1.23%, 1.23%'
+        actual = format_string(template, values)
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -117,7 +117,7 @@ class TestFormatString(unittest.TestCase):
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 
-    def test_format_unsigned_flag_with_lenght_flag(self):
+    def test_format_unsigned_flag_with_length_flag(self):
         template = 'Something %lu something %llu something else %lu'
         values = (123456, 123457, 123458)
         expected = 'Something 123456 something 123457 something else 123458 '

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -120,7 +120,7 @@ class TestFormatString(unittest.TestCase):
     def test_format_unsigned_flag_with_length_flag(self):
         template = 'Something %lu something %llu something else %lu'
         values = (123456, 123457, 123458)
-        expected = 'Something 123456 something 123457 something else 123458 '
+        expected = 'Something 123456 something 123457 something else 123458'
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
 

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -63,7 +63,7 @@ class TestFormatString(unittest.TestCase):
         template = 'Some different radices: %d %x %o %#x %#o'
         values = (100, 100, 100, 100, 100)
         # The alternate form causes a leading octal specifier ('0o') to be inserted before the first digit. This is different than C behavior
-        # See https://docs.python.org/3/library/stdtypes.html#printf-style-bytes-formatting
+        # `See https://docs.python.org/3/library/stdtypes.html#printf-style-bytes-formatting`
         expected = 'Some different radices: 100 64 144 0x64 0o144'
         actual = format_string(template, values)
         self.assertEqual(expected, actual)
@@ -76,7 +76,7 @@ class TestFormatString(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_format_asterisk_width(self):
-        # asterisk `*` is not supported by python string-fromat
+        # asterisk `*` is not supported by python string-format
         template = 'Width trick: %*d'
         values = (5, 10)
         with self.assertRaises(ValueError):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| F' GDS 2.0 |
|**_Affected Component_**| format_string |
|**_Affected Architectures(s)_**| NA |
|**_Related Issue(s)_**| https://github.com/fprime-community/fprime-tools/pull/19/ |
|**_Has Unit Tests (y/n)_**| No |
|**_Builds Without Errors (y/n)_**| Yes |
|**_Unit Tests Pass (y/n)_**| No |
|**_Documentation Included (y/n)_**| No |

---
## Change Description

`%%` flag does not get converted to `%` in EVR output
Precision of floating values in Channel telemetry seems to not get formatted.
If a tlm has a complex value (dict or array) its members will not get formatted.

## Rationale

Values should be formatted according to the given string format.

## Testing/Review Recommendations

Manually tested on F Prime Ref.

Note: This PR should be merged after fprime-tools [PR 19](https://github.com/fprime-community/fprime-tools/pull/19/) to avoid code break.

## Future Work

NA
