### PR TITLE
file downlink: support multiple send partial writes to same file

### DIFF
--- a/src/fprime_gds/common/files/downlinker.py
+++ b/src/fprime_gds/common/files/downlinker.py
@@ -16,7 +16,7 @@ import os
 import fprime.constants
 import fprime_gds.common.handlers
 from fprime_gds.common.data_types.file_data import FilePacketType
-from fprime_gds.common.files.helpers import FileStates, TransmitFile, file_to_dict
+from fprime_gds.common.files.helpers import FileStates, TransmitFile, TransmitFileState, file_to_dict
 
 LOGGER = logging.getLogger("downlink")
 LOGGER.setLevel(logging.INFO)
@@ -90,7 +90,7 @@ class FileDownlinker(fprime_gds.common.handlers.DataHandler):
             size,
             self.__log_dir,
         )
-        self.active.open("wb+")
+        self.active.open(TransmitFileState.WRITE)
         LOGGER.addHandler(self.active.log_handler)
         message = "Received START packet with metadata:\n"
         message += "\tSize: %d\n"

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -23,6 +23,7 @@ from fprime_gds.common.files.helpers import (
     FileStates,
     Timeout,
     TransmitFile,
+    TransmitFileState,
     file_to_dict,
 )
 
@@ -235,7 +236,7 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
             )
         self.state = FileStates.RUNNING
         self.active = file_obj
-        self.active.open()
+        self.active.open(TransmitFileState.READ)
         self.send(
             StartPacketData(
                 self.get_next_sequence(),


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| file transfer |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| n/a |

---
## Change Description

File downlink was opening files in write mode, which truncates a file if it already exists. This means if a user does multiple `fileDownlink.SEND_PARTIAL` commands to transfer a file in multiple chunks, the subsequent SEND_PARTIAL commands would overwrite the existing file. Open a file in read/write mode instead, which doesn't truncate the existing file. Read/write mode is used instead of append mode because file seeking doesn't work when a file is opened in append mode.

## Testing

Test with Ref app and transfer the ending portion of a file with SEND_PARTIAL. Then transfer the start of the file and verify the md5 checksum of the file matches the source. File uplink functionality should be verified as well.