### PR TITLE
lestarch: updating fprime-gds to use fprime-tools v3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,7 @@ integrated configuration with ground in-the-loop.
         "pexpect==4.8.0",
         "pytest==6.2.4",
         "flask_restful==0.3.8",
-        "fprime-tools>=2.0.2",
+        "fprime-tools>=3.0.0",
         "argcomplete==1.12.3",
     ],
     extras_require={

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -20,7 +20,7 @@ import fprime_gds.executables.utils
 
 def get_artifacts_root() -> Path:
     try:
-        ini_settings = IniSettings.load(None, Path.cwd())
+        ini_settings = IniSettings.load(None)
     except FprimeLocationUnknownException:
         print(
             "[ERROR] Not in fprime deployment and no artifacts root provided, unable to find dictionary and/or app"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This updates the `fprime-gds` to use the v3.0.0 tool suite and APIs.  Note: this requires the tools to be tagged as v3.0.0, which is in-progress.  CI will pass once that is done.