### PR TITLE
lestarch: forcing itsfangerous to 2.0.1 as newer version is broken an…

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -298,6 +298,7 @@ itcl
 iterables
 iterdir
 itertools
+itsdangerous
 ixx
 janamian
 javadoc

--- a/setup.py
+++ b/setup.py
@@ -115,6 +115,7 @@ integrated configuration with ground in-the-loop.
         "flask_restful==0.3.8",
         "fprime-tools>=3.0.0",
         "argcomplete==1.12.3",
+        "itsdangerous==2.0.1" 
     ],
     extras_require={
         # I and T API


### PR DESCRIPTION
…d flask doesn't force a specific version

| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Newer versions of itsdangerous broke last week, and flask does not force a specific version. Thus we have to lock the version within F´ GDS.