### PR TITLE
Codebase formatting with ``f-string``

### DIFF
--- a/src/fastentrypoints.py
+++ b/src/fastentrypoints.py
@@ -66,7 +66,7 @@ def get_args(cls, dist, header=None):  # noqa: D205,D400
         header = cls.get_header()
     spec = str(dist.as_requirement())
     for type_ in "console", "gui":
-        group = type_ + "_scripts"
+        group = f'{type_}_scripts'
         for name, ep in dist.get_entry_map(group).items():
             # ensure_safe_name
             if re.search(r"[\\/]", name):

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -89,8 +89,7 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
                 self.keepalive.start()
         except (ValueError, TypeError) as exc:
             LOGGER.error(
-                "Failed to start keep-alive thread. %s: %s"
-                % (type(exc).__name__, str(exc))
+                f"Failed to start keep-alive thread. {type(exc).__name__}: {str(exc)}"
             )
 
     def close(self):

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -34,9 +34,7 @@ def check_port(address, port):
         socket_trial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         socket_trial.bind((address, port))
     except OSError as err:
-        raise ValueError(
-            "Error with address/port of '{}:{}' : {}".format(address, port, err)
-        )
+        raise ValueError(f"Error with address/port of '{address}:{port}' : {err}")
     finally:
         if socket_trial is not None:
             socket_trial.close()

--- a/src/fprime_gds/common/communication/adapters/uart.py
+++ b/src/fprime_gds/common/communication/adapters/uart.py
@@ -169,22 +169,16 @@ class SerialAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         ports = map(lambda info: info.device, list_ports.comports(include_links=True))
         if not args["device"] in ports:
             raise ValueError(
-                "Serial port '{}' not valid. Available ports: {}".format(
-                    args["device"], ports
-                )
+                f"Serial port '{args["device"]}' not valid. Available ports: {ports}"
             )
         # Note: baud rate may not *always* work. These are a superset
         try:
             baud = int(args["baud"])
         except ValueError:
             raise ValueError(
-                "Serial baud rate '{}' not integer. Use one of: {}".format(
-                    args["baud"], SerialAdapter.BAUDS
-                )
+                f"""Serial baud rate '{args["baud"]}' not integer. Use one of: {SerialAdapter.BAUDS}"""
             )
         if not int(baud) in SerialAdapter.BAUDS:
             raise ValueError(
-                "Serial baud rate '{}' not supported. Use one of: {}".format(
-                    baud, SerialAdapter.BAUDS
-                )
+                f"Serial baud rate '{baud}' not supported. Use one of: {SerialAdapter.BAUDS}"
             )

--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -114,9 +114,7 @@ class FpFramerDeframer(FramerDeframer):
             FpFramerDeframer.TOKEN_TYPE = "B"
             FpFramerDeframer.START_TOKEN = 0xEF
         else:
-            raise ValueError(
-                "Invalid TOKEN_SIZE of {}".format(FpFramerDeframer.TOKEN_SIZE)
-            )
+            raise ValueError(f"Invalid TOKEN_SIZE of {FpFramerDeframer.TOKEN_SIZE}")
         FpFramerDeframer.HEADER_FORMAT = ">" + (FpFramerDeframer.TOKEN_TYPE * 2)
 
     def frame(self, data):
@@ -167,7 +165,7 @@ class FpFramerDeframer(FramerDeframer):
             # If the pool is large enough to read the whole frame, then read it
             elif len(data) >= total_size:
                 deframed, check = struct.unpack_from(
-                    ">{}sI".format(data_size), data, FpFramerDeframer.HEADER_SIZE
+                    f">{data_size}sI", data, FpFramerDeframer.HEADER_SIZE
                 )
                 # If the checksum is valid, return the packet. Otherwise continue to rotate
                 if check == calculate_checksum(

--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -150,9 +150,9 @@ class ChData(sys_data.SysData):
                 ch_val,
             )
         elif not verbose and csv:
-            return "{},{},{}".format(time_str_nice, ch_name, ch_val)
+            return f"{time_str_nice},{ch_name},{ch_val}"
         else:
-            return "{}: {} = {}".format(time_str_nice, ch_name, ch_val)
+            return f"{time_str_nice}: {ch_name} = {ch_val}"
 
     def get_val_str(self):
 

--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -153,9 +153,9 @@ class CmdData(sys_data.SysData):
                 arg_str,
             )
         elif not verbose and csv:
-            return "{},{},{}".format(time_str, name, arg_str)
+            return f"{time_str},{name},{arg_str}"
         else:
-            return "{}: {} : {}".format(time_str, name, arg_str)
+            return f"{time_str}: {name} : {arg_str}"
 
     @staticmethod
     def convert_arg_value(arg_val, arg_type):

--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -194,17 +194,15 @@ class CmdData(sys_data.SysData):
             )
 
     def __str__(self):
-        arg_str = ""
-        for name, typ in zip(self.arg_names, self.args):
-            arg_str += "%s : %s |" % (name, str(typ.val))
-        arg_str = "w/ args | " + arg_str
+        arg_str = "".join(
+            f"{name} : {str(typ.val)} |"
+            for name, typ in zip(self.arg_names, self.args)
+        )
+        arg_str = f"w/ args | {arg_str}"
 
-        arg_info = "%s " % self.template.mnemonic
+        arg_info = f"{self.template.mnemonic} "
 
-        if len(self.args) > 0:
-            return arg_info + arg_str
-        else:
-            return arg_info
+        return arg_info + arg_str if len(self.args) > 0 else arg_info
 
 
 class CommandArgumentException(Exception):

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -106,27 +106,13 @@ class EventData(sys_data.SysData):
             arg_str = format_string_template(format_str, tuple(arg_val_list))
 
         if verbose and csv:
-            return "%s,%s,%s,%d,%s,%s" % (
-                time_str,
-                raw_time_str,
-                name,
-                self.id,
-                severity,
-                arg_str,
-            )
+            return f"{time_str},{raw_time_str},{name},{self.id},{severity},{arg_str}"
         elif verbose and not csv:
-            return "%s: %s (%d) %s %s : %s" % (
-                time_str,
-                name,
-                self.id,
-                raw_time_str,
-                severity,
-                arg_str,
-            )
+            return f"{time_str}: {name} ({self.id}) {raw_time_str} {severity} : {arg_str}"
         elif not verbose and csv:
-            return "{},{},{},{}".format(time_str, name, severity, arg_str)
+            return f"{time_str},{name},{severity},{arg_str}"
         else:
-            return "{}: {} {} : {}".format(time_str, name, severity, arg_str)
+            return f"{time_str}: {name} {severity} : {arg_str}"
 
     def __str__(self):
         """

--- a/src/fprime_gds/common/data_types/pkt_data.py
+++ b/src/fprime_gds/common/data_types/pkt_data.py
@@ -88,10 +88,7 @@ class PktData(SysData):
                 str(self.time),
             )
         elif not csv and not verbose:
-            pkt_str += "{}: {} {{\n".format(
-                self.time.to_readable(time_zone),
-                self.template.get_name(),
-            )
+            pkt_str += f"{self.time.to_readable(time_zone)}: {self.template.get_name()} {{\n"
 
         for i in range(len(self.chs)):
             ch = self.chs[i]

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -120,7 +120,7 @@ class EventDecoder(decoder.Decoder):
                 arg_obj.deserialize(arg_data, offset)
                 arg_results.append(arg_obj)
             except TypeException as e:
-                print("Event decode exception %s" % (e.getMsg()))
+                print(f"Event decode exception {e.getMsg()}")
                 traceback.print_exc()
                 return None
 

--- a/src/fprime_gds/common/encoders/file_encoder.py
+++ b/src/fprime_gds/common/encoders/file_encoder.py
@@ -90,9 +90,7 @@ class FileEncoder(encoder.Encoder):
         elif data.packetType == FilePacketType.END:
             out_data += struct.pack(">I", data.hashValue)
         elif data.packetType != FilePacketType.CANCEL:
-            raise Exception(
-                "Invalid packet type found while encoding: {}".format(data.packetType)
-            )
+            raise Exception(f"Invalid packet type found while encoding: {data.packetType}")
         descriptor = U32Type(DataDescType["FW_PACKET_FILE"].value).serialize()
         length_obj = self.config.get_type("msg_len")
         length_obj.val = len(descriptor) + len(out_data)

--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -199,7 +199,7 @@ class SeqAsciiWriter:
         #
         cmd = "{} (0x{:x})".format(mnemonic, int(opcode))
         for arg in args:
-            cmd += ", %s" % arg[2].val
+            cmd += f", {arg[2].val}"
         return cmd
 
     def write(self, seq_cmds_list):

--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -154,7 +154,7 @@ class SeqBinaryWriter:
         try:
             sequence += U32Type(crc).serialize()
         except TypeMismatchException as typeErr:
-            print("Exception: %s" % typeErr.getMsg())
+            print(f"Exception: {typeErr.getMsg()}")
             raise
 
         # Write the list of command records here

--- a/src/fprime_gds/common/files/helpers.py
+++ b/src/fprime_gds/common/files/helpers.py
@@ -147,9 +147,7 @@ class TransmitFile:
         self.__start = datetime.datetime.utcnow()
         if self.__log_dir is not None:
             self.__log_handler = logging.FileHandler(
-                os.path.join(
-                    self.__log_dir, "{}.log".format(os.path.basename(filepath))
-                ),
+                os.path.join(self.__log_dir, f"{os.path.basename(filepath)}.log"),
                 "a",
             )
 

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -230,9 +230,7 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
         # Prevent multiple uplinks at once
         if self.state != FileStates.IDLE:
             raise FileUplinkerBusyException(
-                "Currently uplinking file '{}' cannot start uplinking '{}'".format(
-                    self.active.source, file_obj.source
-                )
+                f"Currently uplinking file '{self.active.source}' cannot start uplinking '{file_obj.source}'"
             )
         self.state = FileStates.RUNNING
         self.active = file_obj

--- a/src/fprime_gds/common/gds_cli/command_send.py
+++ b/src/fprime_gds/common/gds_cli/command_send.py
@@ -163,7 +163,7 @@ class CommandSendCommand(QueryHistoryCommand):
                 pipeline.dictionaries, command_name
             )
             if close_matches:
-                cls._log("Similar known commands: {}".format(close_matches))
+                cls._log(f"Similar known commands: {close_matches}")
         except NotInitializedException:
             temp = CommandSendCommand.get_command_template(
                 pipeline.dictionaries, command_name
@@ -174,7 +174,7 @@ class CommandSendCommand(QueryHistoryCommand):
             )
             cls._log(cls.get_command_help_message(pipeline.dictionaries, command_name))
         except CommandArgumentsException as err:
-            cls._log("Invalid arguments given; %s" % (str(err)))
+            cls._log(f"Invalid arguments given; {str(err)}")
             cls._log(cls.get_command_help_message(pipeline.dictionaries, command_name))
 
         # ======================================================================

--- a/src/fprime_gds/common/gds_cli/filtering_utils.py
+++ b/src/fprime_gds/common/gds_cli/filtering_utils.py
@@ -31,7 +31,7 @@ class id_predicate(predicates.predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x.id == {}".format(self.id_num)
+        return f"x.id == {self.id_num}"
 
 
 def get_id_predicate(ids: Iterable[int]) -> predicates.predicate:
@@ -79,7 +79,7 @@ class component_predicate(predicates.predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return 'x is in component "{}"'.format(self.comp)
+        return f'x is in component "{self.comp}"'
 
 
 def get_component_predicate(components: Iterable[str]) -> predicates.predicate:
@@ -123,7 +123,7 @@ class contains_search_string(predicates.predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return 'str(x) contains "{}"'.format(self.search_string)
+        return f'str(x) contains "{self.search_string}"'
 
 
 def get_search_predicate(
@@ -219,4 +219,4 @@ class time_to_data_predicate(predicates.predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x = x.get_time(), {}".format(self.time_pred)
+        return f"x = x.get_time(), {self.time_pred}"

--- a/src/fprime_gds/common/gds_cli/misc_utils.py
+++ b/src/fprime_gds/common/gds_cli/misc_utils.py
@@ -114,7 +114,7 @@ def get_cmd_template_string(
 
     cmd_description = item.get_description()
     if cmd_description:
-        cmd_string += "Description: %s\n" % (cmd_description)
+        cmd_string += f"Description: {(cmd_description)}\n" 
 
     for arg in item.get_args():
         arg_name, arg_description, arg_type = arg
@@ -123,12 +123,8 @@ def get_cmd_template_string(
         # Can't compare against actual module, since EnumType is a serializable
         # type from the dictionary
         if type(arg_type).__name__ == "EnumType":
-            arg_description = "%s | %s " % (str(arg_type.keys()), arg_description)
+            arg_description = f"{str(arg_type.keys())} | {arg_description} "
 
-        cmd_string += "\t{} ({}): {}\n".format(
-            arg_name,
-            type(arg_type).__name__,
-            arg_description,
-        )
+        cmd_string += f"\t{arg_name} ({type(arg_type).__name__}): {arg_description}\n"
 
     return cmd_string

--- a/src/fprime_gds/common/loaders/ch_xml_loader.py
+++ b/src/fprime_gds/common/loaders/ch_xml_loader.py
@@ -54,7 +54,7 @@ class ChXmlLoader(XmlLoader):
         ch_section = self.get_xml_section(self.CH_SECT, xml_tree)
         if ch_section is None:
             raise exceptions.GseControllerParsingException(
-                "Xml dict did not have a %s section" % self.CH_SECT
+                f"Xml dict did not have a {self.CH_SECT} section"
             )
 
         id_dict = dict()

--- a/src/fprime_gds/common/loaders/cmd_xml_loader.py
+++ b/src/fprime_gds/common/loaders/cmd_xml_loader.py
@@ -46,7 +46,7 @@ class CmdXmlLoader(XmlLoader):
         cmd_section = self.get_xml_section(self.CMD_SECT, xml_tree)
         if cmd_section is None:
             raise exceptions.GseControllerParsingException(
-                "Xml dict did not have a %s section" % self.EVENT_SECT
+                f"Xml dict did not have a {self.EVENT_SECT} section"
             )
 
         id_dict = dict()
@@ -69,6 +69,6 @@ class CmdXmlLoader(XmlLoader):
             cmd_temp = CmdTemplate(cmd_opcode, cmd_mnemonic, cmd_comp, args, cmd_desc)
 
             id_dict[cmd_opcode] = cmd_temp
-            name_dict["{}.{}".format(cmd_comp, cmd_mnemonic)] = cmd_temp
+            name_dict[f"{cmd_comp}.{cmd_mnemonic}"] = cmd_temp
 
         return id_dict, name_dict

--- a/src/fprime_gds/common/loaders/event_py_loader.py
+++ b/src/fprime_gds/common/loaders/event_py_loader.py
@@ -68,7 +68,7 @@ class EventPyLoader(python_loader.PythonLoader):
                 id_dict[event_dict[self.ID_FIELD]] = event_temp
                 name_dict[event_dict[self.NAME_FIELD]] = event_temp
             except TypeMismatchException as error:
-                print("Type mismatch: %s" % error.getMsg())
+                print(f"Type mismatch: {error.getMsg()}")
                 raise error
 
         return id_dict, name_dict

--- a/src/fprime_gds/common/loaders/event_xml_loader.py
+++ b/src/fprime_gds/common/loaders/event_xml_loader.py
@@ -48,7 +48,7 @@ class EventXmlLoader(XmlLoader):
         event_section = self.get_xml_section(self.EVENT_SECT, xml_tree)
         if event_section is None:
             raise exceptions.GseControllerParsingException(
-                "Xml dict did not have a %s section" % self.EVENT_SECT
+                f"Xml dict did not have a {self.EVENT_SECT} section"
             )
 
         id_dict = dict()

--- a/src/fprime_gds/common/loaders/pkt_xml_loader.py
+++ b/src/fprime_gds/common/loaders/pkt_xml_loader.py
@@ -94,8 +94,7 @@ class PktXmlLoader(XmlLoader):
         packet_list = self.get_xml_tree(path)
         if packet_list.tag != self.PKT_LIST_TAG:
             raise exceptions.GseControllerParsingException(
-                "expected packet list to have tag %s, but found %s"
-                % (self.PKT_LIST_TAG, packet_list.tag)
+                f"expected packet list to have tag {self.PKT_LIST_TAG}, but found {packet_list.tag}"
             )
 
         id_dict = dict()
@@ -115,8 +114,7 @@ class PktXmlLoader(XmlLoader):
 
                 if ch_name not in ch_name_dict:
                     raise exceptions.GseControllerParsingException(
-                        "Channel %s in pkt %s, but cannot be found in channel dictionary"
-                        % (ch_name, pkt_name)
+                        f"Channel {ch_name} in pkt {pkt_name}, but cannot be found in channel dictionary"
                     )
 
                 ch_list.append(ch_name_dict[ch_name])

--- a/src/fprime_gds/common/loaders/python_loader.py
+++ b/src/fprime_gds/common/loaders/python_loader.py
@@ -121,9 +121,9 @@ class PythonLoader(dict_loader.DictLoader):
             mod_name = mf.split(".")[0]
 
             if use_superpkg:
-                import_name = "{}.{}.{}".format(superpkg, pkg, mod_name)
+                import_name = f"{superpkg}.{pkg}.{mod_name}"
             else:
-                import_name = "{}.{}".format(pkg, mod_name)
+                import_name = f"{pkg}.{mod_name}"
 
             m = importlib.import_module(import_name)
 

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -384,9 +384,7 @@ class XmlLoader(dict_loader.DictLoader):
             return BoolType()
         elif type_name == "string":
             if self.STR_LEN_TAG not in xml_item.attrib:
-                print(
-                    "Trying to parse string type, but found %s field" % self.STR_LEN_TAG
-                )
+                print(f"Trying to parse string type, but found {self.STR_LEN_TAG} field")
                 return None
             return StringType(max_string_len=int(xml_item.get(self.STR_LEN_TAG), 0))
         else:
@@ -407,7 +405,7 @@ class XmlLoader(dict_loader.DictLoader):
 
             # Abandon all hope
             raise exceptions.GseControllerParsingException(
-                "Could not find type %s" % type_name
+                f"Could not find type {type_name}"
             )
 
 

--- a/src/fprime_gds/common/logger/data_logger.py
+++ b/src/fprime_gds/common/logger/data_logger.py
@@ -16,11 +16,11 @@ class DataLogger(fprime_gds.common.handlers.DataHandler):
 
         self.logdir = logdir
 
-        self.recv_file = prefix + "recv.bin"
-        self.send_file = prefix + "sent.bin"
-        self.telem_file = prefix + "channel.log"
-        self.event_file = prefix + "event.log"
-        self.command_file = prefix + "command.log"
+        self.recv_file = f'{prefix}recv.bin'
+        self.send_file = f'{prefix}sent.bin'
+        self.telem_file = f'{prefix}channel.log'
+        self.event_file = f'{prefix}event.log'
+        self.command_file = f'{prefix}command.log'
 
         self.verbose = verbose
         self.csv = csv

--- a/src/fprime_gds/common/logger/test_logger.py
+++ b/src/fprime_gds/common/logger/test_logger.py
@@ -104,7 +104,7 @@ class TestLogger:
         date_string = datetime.datetime.fromtimestamp(self.start_time).strftime(
             "%H:%M:%S.%f on %m/%d/%Y"
         )
-        top.append(self.__get_cell("Test began at " + date_string))
+        top.append(self.__get_cell(f"Test began at {date_string}"))
         self.worksheet.append(top)
 
         labels = ["Log Time", "Case ID", "Sender", "Message"]

--- a/src/fprime_gds/common/logger/test_logger.py
+++ b/src/fprime_gds/common/logger/test_logger.py
@@ -79,7 +79,7 @@ class TestLogger:
         date_string = datetime.datetime.fromtimestamp(self.start_time).strftime(
             "%Y-%m-%dT%H:%M:%S"
         )
-        self.filename = os.path.join(output_path, "TestLog_{}.xlsx".format(date_string))
+        self.filename = os.path.join(output_path, f"TestLog_{date_string}.xlsx")
         self.workbook = Workbook(write_only=True)
         self.worksheet = self.workbook.create_sheet()
         self.ws_saved = False
@@ -142,17 +142,13 @@ class TestLogger:
         strings = [timestring, self.case_id, sender, message]
         self.lock.acquire()
         try:
-            print("{} [{}] {}".format(timestring, sender, message))
+            print(f"{timestring} [{sender}] {message}")
             if not self.ws_saved:
                 row = self.__get_ws_row(strings, color, style)
                 self.worksheet.append(row)
         except WorkbookAlreadySaved:
             self.ws_saved = True
-            print(
-                "{} [{}] {}".format(
-                    timestring, "TestLogger", "Workbook has already been saved."
-                )
-            )
+            print(f"{timestring} [TestLogger] Workbook has already been saved.")
         finally:
             self.lock.release()
 

--- a/src/fprime_gds/common/models/common/channel_telemetry.py
+++ b/src/fprime_gds/common/models/common/channel_telemetry.py
@@ -87,7 +87,7 @@ class Channel:
             self.__ch_type.deserialize(ser_data, offset)
             val = self.__ch_type.val
         except TypeException as e:
-            print("Channel deserialize exception %s" % (e.getMsg()))
+            print(f"Channel deserialize exception {e.getMsg()}")
             val = "ERR"
 
         #

--- a/src/fprime_gds/common/models/common/command.py
+++ b/src/fprime_gds/common/models/common/command.py
@@ -194,14 +194,14 @@ if __name__ == "__main__":
             "SomeComponent", "TEST_CMD", 0x123, "Test Command", arglist
         )
     except TypeException as e:
-        print("Exception: %s" % e.getMsg())
+        print(f"Exception: {e.getMsg()}")
     t = U32Type(3)
     t2 = F32Type(123.456)
     try:
         testCommand.setArg("arg1", t)
         testCommand.setArg("arg2", t2)
     except TypeException as e:
-        print("Exception: %s" % e.getMsg())
+        print(f"Exception: {e.getMsg()}")
 
     data = testCommand.serialize()
     type_base.showBytes(data)

--- a/src/fprime_gds/common/models/common/event.py
+++ b/src/fprime_gds/common/models/common/event.py
@@ -87,7 +87,7 @@ class Event:
                 arg_obj.deserialize(ser_data, offset)
                 vals.append(arg_obj.val)
             except TypeException as e:
-                print("Event deserialize exception %s" % (e.getMsg()))
+                print(f"Event deserialize exception {e.getMsg()}")
                 traceback.print_exc()
                 vals.append("ERR")
             offset = offset + arg_obj.getSize()

--- a/src/fprime_gds/common/pipeline/dictionaries.py
+++ b/src/fprime_gds/common/pipeline/dictionaries.py
@@ -93,9 +93,7 @@ class Dictionaries:
             self._channel_id_dict = channel_loader.get_id_dict(dictionary)
             self._channel_name_dict = channel_loader.get_name_dict(dictionary)
         else:
-            raise Exception(
-                "[ERROR] Dictionary '{}' does not exist.".format(dictionary)
-            )
+            raise Exception(f"[ERROR] Dictionary '{dictionary}' does not exist.")
         # Check for packet specification
         if packet_spec is not None:
             packet_loader = fprime_gds.common.loaders.pkt_xml_loader.PktXmlLoader()

--- a/src/fprime_gds/common/templates/ch_template.py
+++ b/src/fprime_gds/common/templates/ch_template.py
@@ -93,7 +93,7 @@ class ChTemplate(data_template.DataTemplate):
         Returns:
             The full name (component.channel) for this channel
         """
-        return "{}.{}".format(self.comp_name, self.name)
+        return f"{self.comp_name}.{self.name}"
 
     def get_id(self):
         return self.id

--- a/src/fprime_gds/common/templates/cmd_template.py
+++ b/src/fprime_gds/common/templates/cmd_template.py
@@ -80,8 +80,8 @@ class CmdTemplate(data_template.DataTemplate):
         Returns:
             The full name (component.channel) for this event
         """
-        return "{}.{}".format(self.comp_name, self.mnemonic)
-
+        return f"{self.comp_name}.{self.mnemonic}"
+    
     def get_comp_name(self):
         return self.comp_name
 

--- a/src/fprime_gds/common/templates/event_template.py
+++ b/src/fprime_gds/common/templates/event_template.py
@@ -87,7 +87,7 @@ class EventTemplate(data_template.DataTemplate):
         Returns:
             The full name (component.channel) for this event
         """
-        return "{}.{}".format(self.comp_name, self.name)
+        return f"{self.comp_name}.{self.name}"
 
     def get_id(self):
         return self.id

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -149,7 +149,7 @@ class IntegrationTestAPI(DataHandler):
             ast_msg = f'{ast_msg} succeeded: {msg}'
             self.__log(ast_msg, TestLogger.GREEN)
         else:
-            ast_msg = ast_msg + " failed: " + msg
+            ast_msg = f'{ast_msg} failed: {msg}'
             self.__log(ast_msg, fail_color)
 
         if not expect:
@@ -1027,7 +1027,7 @@ class IntegrationTestAPI(DataHandler):
             return searcher.get_return_value()
 
         if timeout:
-            self.__log(name + f" now awaiting for at most {timeout} s.")
+            self.__log(f"{name} now awaiting for at most {timeout} s.")
             check_repeats = isinstance(history, ChronologicalHistory)
             try:
                 signal.signal(signal.SIGALRM, self.__timeout_sig_handler)
@@ -1252,13 +1252,13 @@ class IntegrationTestAPI(DataHandler):
         name = name + (" expectation" if expect else " assertion")
         pred_msg = predicates.get_descriptive_string(value, predicate)
         if predicate(value):
-            ast_msg = name + f" succeeded: {msg}\nassert " + pred_msg
+            ast_msg = f"{name} succeeded: {msg}\nassert {pred_msg}"
             self.__log(ast_msg, TestLogger.GREEN)
             if not expect:
                 assert True, pred_msg
             return True
         else:
-            ast_msg = name + f" failed: {msg}\nassert " + pred_msg
+            ast_msg = f"{name} failed: {msg}\nassert {pred_msg}"
             if not expect:
                 self.__log(ast_msg, TestLogger.RED)
                 assert False, pred_msg

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -93,7 +93,7 @@ class IntegrationTestAPI(DataHandler):
             case_name: the name of the test case (str)
             case_id: a short identifier to denote the test case (str or number)
         """
-        msg = "[STARTING CASE] {}".format(case_name)
+        msg = f"[STARTING CASE] {case_name}"
         self.__log(msg, TestLogger.GRAY, TestLogger.BOLD, case_id=case_id)
         self.get_latest_time()  # called in case aggregate histories are cleared by the user
         self.clear_histories()
@@ -146,7 +146,7 @@ class IntegrationTestAPI(DataHandler):
             fail_color = TestLogger.ORANGE
 
         if value:
-            ast_msg = ast_msg + " succeeded: " + msg
+            ast_msg = f'{ast_msg} succeeded: {msg}'
             self.__log(ast_msg, TestLogger.GREEN)
         else:
             ast_msg = ast_msg + " failed: " + msg
@@ -188,7 +188,7 @@ class IntegrationTestAPI(DataHandler):
             self.event_history.clear(e_pred)
             t_pred = predicates.telemetry_predicate(time_pred=time_pred)
             self.telemetry_history.clear(t_pred)
-            msg = "Clearing Test Histories after {}".format(time_stamp)
+            msg = f"Clearing Test Histories after {time_stamp}"
             self.__log(msg, TestLogger.WHITE)
         else:
             self.event_history.clear()
@@ -325,16 +325,14 @@ class IntegrationTestAPI(DataHandler):
             if command in cmd_dict:
                 return cmd_dict[command].get_id()
             else:
-                msg = "The command mnemonic, {}, wasn't in the dictionary".format(
-                    command
-                )
+                msg = f"The command mnemonic, {command}, wasn't in the dictionary"
                 raise KeyError(msg)
         else:
             cmd_dict = self.pipeline.dictionaries.command_id
             if command in cmd_dict:
                 return command
             else:
-                msg = "The command id, {}, wasn't in the dictionary".format(command)
+                msg = f"The command id, {command}, wasn't in the dictionary"
                 raise KeyError(msg)
 
     def send_command(self, command, args=None):
@@ -347,7 +345,7 @@ class IntegrationTestAPI(DataHandler):
         if args is None:
             args = []
 
-        msg = "Sending Command: {} {}".format(command, args)
+        msg = f"Sending Command: {command} {args}"
         self.__log(msg, TestLogger.PURPLE)
         command = self.translate_command_name(command)
         self.pipeline.send_command(command, args)
@@ -487,18 +485,14 @@ class IntegrationTestAPI(DataHandler):
             if channel in ch_dict:
                 return ch_dict[channel].get_id()
             else:
-                msg = "The telemetry mnemonic, {}, wasn't in the dictionary".format(
-                    channel
-                )
+                msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
                 raise KeyError(msg)
         else:
             ch_dict = self.pipeline.dictionaries.channel_id
             if channel in ch_dict:
                 return channel
             else:
-                msg = "The telemetry mnemonic, {}, wasn't in the dictionary".format(
-                    channel
-                )
+                msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
                 raise KeyError(msg)
 
     def get_telemetry_pred(self, channel=None, value=None, time_pred=None):
@@ -714,14 +708,14 @@ class IntegrationTestAPI(DataHandler):
             if event in event_dict:
                 return event_dict[event].get_id()
             else:
-                msg = "The event mnemonic, {}, wasn't in the dictionary".format(event)
+                msg = f"The event mnemonic, {event}, wasn't in the dictionary"
                 raise KeyError(msg)
         else:
             event_dict = self.pipeline.dictionaries.event_id
             if event in event_dict:
                 return event
             else:
-                msg = "The event id, {}, wasn't in the dictionary".format(event)
+                msg = f"The event id, {event}, wasn't in the dictionary"
                 raise KeyError(msg)
 
     def get_event_pred(self, event=None, args=None, severity=None, time_pred=None):
@@ -754,9 +748,7 @@ class IntegrationTestAPI(DataHandler):
 
         if not predicates.is_predicate(severity) and severity is not None:
             if not isinstance(severity, EventSeverity):
-                msg = "Given severity was not a valid Severity Enum Value: {} ({})".format(
-                    severity, type(severity)
-                )
+                msg = f"Given severity was not a valid Severity Enum Value: {severity} ({type(severity)})"
                 raise TypeError(msg)
             severity = predicates.equal_to(severity)
 
@@ -1035,7 +1027,7 @@ class IntegrationTestAPI(DataHandler):
             return searcher.get_return_value()
 
         if timeout:
-            self.__log(name + " now awaiting for at most {} s.".format(timeout))
+            self.__log(name + f" now awaiting for at most {timeout} s.")
             check_repeats = isinstance(history, ChronologicalHistory)
             try:
                 signal.signal(signal.SIGALRM, self.__timeout_sig_handler)
@@ -1050,13 +1042,11 @@ class IntegrationTestAPI(DataHandler):
                             return searcher.get_return_value()
                     time.sleep(0.1)
             except self.TimeoutException:
-                self.__log(
-                    name + " timed out and ended unsuccessfully.", TestLogger.YELLOW
-                )
+                self.__log(f'{name} timed out and ended unsuccessfully.', TestLogger.YELLOW)
             finally:
                 signal.alarm(0)
         else:
-            self.__log(name + " ended unsuccessfully.", TestLogger.YELLOW)
+            self.__log(f'{name} ended unsuccessfully.', TestLogger.YELLOW)
         return searcher.get_return_value()
 
     def find_history_item(self, search_pred, history, start=None, timeout=0):
@@ -1081,9 +1071,7 @@ class IntegrationTestAPI(DataHandler):
                 self.search_pred = search_pred
                 self.repeats = False
                 self.ret_val = None
-                msg = "Beginning an item search for an item that satisfies:\n    {}".format(
-                    self.search_pred
-                )
+                msg = f"Beginning an item search for an item that satisfies:\n    {self.search_pred}"
                 self.log(msg, TestLogger.YELLOW)
 
             def search_current_history(self, items):
@@ -1094,7 +1082,7 @@ class IntegrationTestAPI(DataHandler):
 
             def incremental_search(self, item):
                 if self.search_pred(item):
-                    msg = "History search found the specified item: {}".format(item)
+                    msg = f"History search found the specified item: {item}"
                     self.log(msg, TestLogger.YELLOW)
                     self.ret_val = item
                     return True
@@ -1130,9 +1118,7 @@ class IntegrationTestAPI(DataHandler):
                 self.ret_val = []
                 self.seq_preds = seq_preds.copy()
                 self.repeats = True
-                msg = "Beginning a sequence search of {} items.".format(
-                    len(self.seq_preds)
-                )
+                msg = f"Beginning a sequence search of {len(self.seq_preds)} items."
                 self.log(msg, TestLogger.YELLOW)
 
             def search_current_history(self, items):
@@ -1148,7 +1134,7 @@ class IntegrationTestAPI(DataHandler):
 
             def incremental_search(self, item):
                 if self.seq_preds[0](item):
-                    self.log("Sequence search found the next item: {}".format(item))
+                    self.log(f"Sequence search found the next item: {item}")
                     self.ret_val.append(item)
                     self.seq_preds.pop(0)
                     if len(self.seq_preds) == 0:
@@ -1196,9 +1182,7 @@ class IntegrationTestAPI(DataHandler):
                 self.search_pred = search_pred
                 self.repeats = False
 
-                msg = "Beginning a count search for an amount of items ({}).".format(
-                    self.count_pred
-                )
+                msg = f"Beginning a count search for an amount of items ({self.count_pred})."
                 self.log(msg, TestLogger.YELLOW)
 
             def search_current_history(self, items):
@@ -1208,27 +1192,21 @@ class IntegrationTestAPI(DataHandler):
                 else:
                     for item in items:
                         if search_pred(item):
-                            self.log(
-                                "Count search counted another item: {}".format(item)
-                            )
+                            self.log(f"Count search counted another item: {item}")
                             self.ret_val.append(item)
 
                 if self.count_pred(len(self.ret_val)):
-                    msg = "Count search found a correct amount: {}".format(
-                        len(self.ret_val)
-                    )
+                    msg = f"Count search found a correct amount: {len(self.ret_val)}"
                     self.log(msg, TestLogger.YELLOW)
                     return True
                 return False
 
             def incremental_search(self, item):
                 if self.search_pred(item):
-                    self.log("Count search counted another item: {}".format(item))
+                    self.log(f"Count search counted another item: {item}")
                     self.ret_val.append(item)
                     if self.count_pred(len(self.ret_val)):
-                        msg = "Count search found a correct amount: {}".format(
-                            len(self.ret_val)
-                        )
+                        msg = f"Count search found a correct amount: {len(self.ret_val)}"
                         self.log(msg, TestLogger.YELLOW)
                         return True
                 return False
@@ -1274,13 +1252,13 @@ class IntegrationTestAPI(DataHandler):
         name = name + (" expectation" if expect else " assertion")
         pred_msg = predicates.get_descriptive_string(value, predicate)
         if predicate(value):
-            ast_msg = name + " succeeded: {}\nassert ".format(msg) + pred_msg
+            ast_msg = name + f" succeeded: {msg}\nassert " + pred_msg
             self.__log(ast_msg, TestLogger.GREEN)
             if not expect:
                 assert True, pred_msg
             return True
         else:
-            ast_msg = name + " failed: {}\nassert ".format(msg) + pred_msg
+            ast_msg = name + f" failed: {msg}\nassert " + pred_msg
             if not expect:
                 self.__log(ast_msg, TestLogger.RED)
                 assert False, pred_msg
@@ -1295,13 +1273,10 @@ class IntegrationTestAPI(DataHandler):
             data: object to store
         """
         if self.event_log_filter(data):
-            msg = "Received EVR: {}".format(data.get_str(verbose=True))
+            msg = f"Received EVR: {data.get_str(verbose=True)}"
             self.__log(msg, TestLogger.BLUE, sender="GDS")
         if self.last_evr is not None and data.get_time() < self.last_evr.get_time():
-            msg = "API detected out of order evrs!"
-            msg = msg + "\nReceived First:{}".format(
-                self.last_evr.get_str(verbose=True)
-            )
-            msg = msg + "\nReceived Second:{}".format(data.get_str(verbose=True))
+            msg = "API detected out of order evrs!" + f"\nReceived First:{self.last_evr.get_str(verbose=True)}"
+            msg += f"\nReceived Second:{data.get_str(verbose=True)}"
             self.__log(msg, TestLogger.ORANGE)
         self.last_evr = data

--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -63,7 +63,7 @@ def get_descriptive_string(value, pred_function):
         value: the argument of the predicate
         pred_function: a predicate function
     """
-    return "F({}), where F(x) evaluates\n\t {}".format(value, pred_function)
+    return f"F({value}), where F(x) evaluates\n\t {pred_function}"
 
 
 ##########################################################################################
@@ -93,7 +93,7 @@ class less_than(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x < {}".format(self.upper_limit)
+        return f"x < {self.upper_limit}"
 
 
 class greater_than(predicate):
@@ -119,7 +119,7 @@ class greater_than(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x > {}".format(self.lower_limit)
+        return f"x > {self.lower_limit}"
 
 
 class equal_to(predicate):
@@ -145,7 +145,7 @@ class equal_to(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x == {}".format(self.expected)
+        return f"x == {self.expected}"
 
 
 class not_equal_to(predicate):
@@ -171,7 +171,7 @@ class not_equal_to(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x != {}".format(self.expected)
+        return f"x != {self.expected}"
 
 
 class less_than_or_equal_to(predicate):
@@ -197,7 +197,7 @@ class less_than_or_equal_to(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x <= {}".format(self.upper_limit)
+        return f"x <= {self.upper_limit}"
 
 
 class greater_than_or_equal_to(predicate):
@@ -223,7 +223,7 @@ class greater_than_or_equal_to(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x >= {}".format(self.lower_limit)
+        return f"x >= {self.lower_limit}"
 
 
 class within_range(predicate):
@@ -252,7 +252,7 @@ class within_range(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "{} <= x <= {}".format(self.lower_limit, self.upper_limit)
+        return f"{self.lower_limit} <= x <= {self.upper_limit}"
 
 
 ##########################################################################################
@@ -282,7 +282,7 @@ class is_a_member_of(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x \u2208 {}".format(self.set)
+        return f"x ∈ {self.set}"
 
 
 class is_not_a_member_of(predicate):
@@ -309,7 +309,7 @@ class is_not_a_member_of(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "x \u2209 {}".format(self.set)
+        return f"x ∉ {self.set}"
 
 
 ##########################################################################################
@@ -351,7 +351,7 @@ class invert(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "\u02DC({}).".format(self.pred)
+        return f"˜({self.pred})."
 
 
 class satisfies_all(predicate):
@@ -380,7 +380,7 @@ class satisfies_all(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "\u2200 P \u2208 A : P(x) is True, when A is {}".format(self.p_list)
+        return f"∀ P ∈ A : P(x) is True, when A is {self.p_list}"
 
 
 class satisfies_any(predicate):
@@ -409,7 +409,7 @@ class satisfies_any(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "\u2203 P \u2208 A : P(x) is True, when A is {}".format(self.p_list)
+        return f"∃ P ∈ A : P(x) is True, when A is {self.p_list}"
 
 
 ##########################################################################################
@@ -454,9 +454,7 @@ class args_predicate(predicate):
         """
         Returns a string outlining the evaluation done by the predicate.
         """
-        return "True IFF \u2200 pi \u2208 P and xi \u2208 x; pi(xi) is True. Where P is {}".format(
-            self.arg_spec
-        )
+        return f"True IFF ∀ pi ∈ P and xi ∈ x; pi(xi) is True. Where P is {self.arg_spec}"
 
 
 class event_predicate(predicate):
@@ -516,13 +514,13 @@ class event_predicate(predicate):
         """
         msg = "True IFF: x is an EventData object"
         if not isinstance(self.id_pred, always_true):
-            msg += " and x's id satisfies ({})".format(self.id_pred)
+            msg += f" and x's id satisfies ({self.id_pred})"
         if not isinstance(self.args_pred, always_true):
-            msg += " and x's args satisfy ({})".format(self.args_pred)
+            msg += f" and x's args satisfy ({self.args_pred})"
         if not isinstance(self.severity_pred, always_true):
-            msg += " and x's severity satisfies ({})".format(self.severity_pred)
+            msg += f" and x's severity satisfies ({self.severity_pred})"
         if not isinstance(self.time_pred, always_true):
-            msg += " and x's time satisfies ({})".format(self.time_pred)
+            msg += f" and x's time satisfies ({self.time_pred})"
         return msg
 
 
@@ -573,9 +571,9 @@ class telemetry_predicate(predicate):
         """
         msg = "True IFF: x is a ChData object"
         if not isinstance(self.id_pred, always_true):
-            msg += " and x's id satisfies ({})".format(self.id_pred)
+            msg += f" and x's id satisfies ({self.id_pred})"
         if not isinstance(self.value_pred, always_true):
-            msg += " and x's value satisfies ({})".format(self.value_pred)
+            msg += f" and x's value satisfies ({self.value_pred})"
         if not isinstance(self.time_pred, always_true):
-            msg += " and x's time satisfies ({})".format(self.time_pred)
+            msg += f" and x's time satisfies ({self.time_pred})"
         return msg

--- a/src/fprime_gds/common/tools/seqgen.py
+++ b/src/fprime_gds/common/tools/seqgen.py
@@ -130,7 +130,7 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
     # Write to the output file:
     writer = SeqBinaryWriter(timebase=timebase)
     if not outputFile:
-        outputFile = os.path.splitext(inputFile)[0] + ".bin"
+        outputFile = f'{os.path.splitext(inputFile)[0]}.bin'
     try:
         writer.open(outputFile)
     except:
@@ -191,7 +191,7 @@ def main():
         try:
             timebase = int(opts.timebase, 0)
         except ValueError:
-            print("Could not parse time base %s" % opts.timebase)
+            print(f"Could not parse time base {opts.timebase}")
             return 1
 
     inputfile = opts.sequence

--- a/src/fprime_gds/common/utils/config_manager.py
+++ b/src/fprime_gds/common/utils/config_manager.py
@@ -40,11 +40,7 @@ class ConfigBadTypeException(Exception):
             config_name (string): Name of the config containing the bad type
             type_str (string): Bad type string that caused the error
         """
-        print(
-            "Invalid type string {} read in configuration {}".format(
-                type_str, config_name
-            )
-        )
+        print(f"Invalid type string {type_str} read in configuration {config_name}")
 
 
 class ConfigManager(configparser.ConfigParser):

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -92,7 +92,7 @@ class ParserBase(abc.ABC):
             for parser_base in parser_classes:
                 args = parser_base.handle_arguments(args, **kwargs)
         except ValueError as ver:
-            print("[ERROR] Failed to parse arguments: {}".format(ver), file=sys.stderr)
+            print(f"[ERROR] Failed to parse arguments: {ver}", file=sys.stderr)
             sys.exit(-1)
         return args, parser
 
@@ -109,7 +109,7 @@ class ParserBase(abc.ABC):
         """
         for dirpath, dirs, files in os.walk(deploy):
             for check in files if is_file else dirs:
-                if re.match("^" + str(token) + "$", check):
+                if re.match(f"^{str(token)}$", check):
                     return os.path.join(dirpath, check)
         return None
 
@@ -153,7 +153,7 @@ class ImportParser(ParserBase):
                 globals()[module] = importlib.import_module(module)
             except ImportError as ime:
                 print(
-                    "[WARNING] Failed to import '{}' with error {}".format(module, ime),
+                    f"[WARNING] Failed to import '{module}' with error {ime}",
                     file=sys.stderr,
                 )
         return args
@@ -195,14 +195,12 @@ class CommParser(ParserBase):
                 getattr(adapter, "get_arguments", None)
             ):
                 print(
-                    "[WARNING] '{}' does not have 'get_arguments' method, skipping.".format(
-                        adapter_name
-                    ),
+                    f"[WARNING] '{adapter_name}' does not have 'get_arguments' method, skipping.",
                     file=sys.stderr,
                 )
                 continue
             comm_parser = argparse.ArgumentParser(
-                description="'{}' parser".format(adapter_name), add_help=False
+                description=f"'{adapter_name}' parser", add_help=False
             )
             # Add arguments for the parser
             for argument in adapter.get_arguments().keys():
@@ -455,16 +453,14 @@ class GdsParser(ParserBase):
         args = copy.copy(args)
         # Find dictionary setting via "dictionary" argument or the "deploy" argument
         if args.dictionary is not None and not os.path.exists(args.dictionary):
-            raise ValueError(
-                "Dictionary file {} does not exist".format(args.dictionary)
-            )
+            raise ValueError(f"Dictionary file {args.dictionary} does not exist")
 
         # Handle configuration arguments
         config = fprime_gds.common.utils.config_manager.ConfigManager()
         if args.config is not None and os.path.isfile(args.config):
             config.set_configs(args.config)
         elif args.config is not None:
-            raise ValueError("Configuration file {} not found".format(args.config))
+            raise ValueError(f"Configuration file {args.config} not found")
         args.config = config
         return args
 
@@ -528,11 +524,9 @@ class BinaryDeployment(ParserBase):
             return args
         args = copy.copy(args)
         if args.app is not None and not os.path.isfile(args.app):
-            raise ValueError("F prime binary '{}' does not exist".format(args.app))
+            raise ValueError(f"F prime binary '{args.app}' does not exist")
         if args.root_dir is not None and not os.path.isdir(args.root_dir):
             raise ValueError(
-                "F prime artifacts root directory '{}' does not exist".format(
-                    args.root_dir
-                )
+                f"F prime artifacts root directory '{args.root_dir}' does not exist"
             )
         return args

--- a/src/fprime_gds/executables/fprime_cli.py
+++ b/src/fprime_gds/executables/fprime_cli.py
@@ -79,16 +79,14 @@ def add_search_arguments(parser: argparse.ArgumentParser, command_name: str):
         "--list",
         dest="is_printing_list",
         action="store_true",
-        help="list all possible %s types the current F Prime instance could produce, based on the %s dictionary, sorted by %s type ID"
-        % (command_name[:-1], command_name, command_name[:-1]),
+        help=f"list all possible {command_name[:-1]} types the current F Prime instance could produce, based on the {command_name} dictionary, sorted by {command_name[:-1]} type ID",
     )
     parser.add_argument(
         "-i",
         "--ids",
         nargs="+",
         type=int,
-        help='only show %s matching the given type ID(s) "ID"; can provide multiple IDs to show all given types'
-        % (command_name),
+        help=f'only show {command_name} matching the given type ID(s) "ID"; can provide multiple IDs to show all given types',
         metavar="ID",
     )
     parser.add_argument(
@@ -96,24 +94,21 @@ def add_search_arguments(parser: argparse.ArgumentParser, command_name: str):
         "--components",
         nargs="+",
         type=str,
-        help='only show %s from the given component name "COMP"; can provide multiple components to show %s from all components given'
-        % (command_name, command_name),
+        help=f'only show {command_name} from the given component name "COMP"; can provide multiple components to show {command_name} from all components given',
         metavar="COMP",
     )
     parser.add_argument(
         "-s",
         "--search",
         type=str,
-        help='only show %s whose name or output string exactly matches or contains the entire given string "STRING"'
-        % (command_name),
+        help=f'only show {command_name} whose name or output string exactly matches or contains the entire given string "STRING"',
         metavar="STRING",
     )
     parser.add_argument(
         "-j",
         "--json",
         action="store_true",
-        help="return the JSON response of the API call, with %s filtered based on other flags provided"
-        % (command_name),
+        help=f"return the JSON response of the API call, with {command_name} filtered based on other flags provided",
     )
 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -49,7 +49,7 @@ def find_app(root: Path) -> Path:
             files.append(child)
 
     if len(files) == 0:
-        print(f"[ERROR] binary location {bin_dir} does not exist")
+        print(f"[ERROR] App not found in {bin_dir}")
         sys.exit(-1)
 
     if len(files) > 1:

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -31,9 +31,7 @@ def get_artifacts_root() -> Path:
         sys.exit(-1)
     assert "install_dest" in ini_settings, "install_dest not in settings.ini"
     print(
-        "[INFO] Autodetected artifacts root '{}' from deployment settings.ini file.".format(
-            ini_settings["install_dest"]
-        )
+        f"""[INFO] Autodetected artifacts root '{ini_settings["install_dest"]}' from deployment settings.ini file."""
     )
     return ini_settings["install_dest"]
 
@@ -42,7 +40,7 @@ def find_app(root: Path) -> Path:
     bin_dir = root / "bin"
 
     if not bin_dir.exists():
-        print("[ERROR] binary location {} does not exist".format(bin_dir))
+        print(f"[ERROR] binary location {bin_dir} does not exist")
         sys.exit(-1)
 
     files = []
@@ -51,14 +49,12 @@ def find_app(root: Path) -> Path:
             files.append(child)
 
     if len(files) == 0:
-        print("[ERROR] No app found in binary location {}".format(bin_dir))
+        print(f"[ERROR] binary location {bin_dir} does not exist")
         sys.exit(-1)
 
     if len(files) > 1:
         print(
-            "[ERROR] Multiple app candidates in binary location {}. Specify app manually with --app.".format(
-                bin_dir
-            )
+            f"[ERROR] Multiple app candidates in binary location {bin_dir}. Specify app manually with --app."
         )
         sys.exit(-1)
 
@@ -69,7 +65,7 @@ def find_dict(root: Path) -> Path:
     dict_dir = root / "dict"
 
     if not dict_dir.exists():
-        print("[ERROR] dictionary location {} does not exist".format(dict_dir))
+        print(f"[ERROR] dictionary location {dict_dir} does not exist")
         sys.exit(-1)
 
     files = []
@@ -78,16 +74,12 @@ def find_dict(root: Path) -> Path:
             files.append(child)
 
     if len(files) == 0:
-        print(
-            "[ERROR] No xml dictionary found in dictionary location {}".format(dict_dir)
-        )
+        print(f"[ERROR] No xml dictionary found in dictionary location {dict_dir}")
         sys.exit(-1)
 
     if len(files) > 1:
         print(
-            "[ERROR] Multiple xml dictionaries found in dictionary location {}. Specify dictionary manually with --dictionary.".format(
-                dict_dir
-            )
+            f"[ERROR] Multiple xml dictionaries found in dictionary location {dict_dir}. Specify dictionary manually with --dictionary."
         )
         sys.exit(-1)
 
@@ -141,7 +133,7 @@ def parse_args():
             raise ValueError("Must supply --config when using 'wx' GUI.")
     # On ValueError print error, help and exit
     except ValueError as vexc:
-        print("[ERROR] {}".format(str(vexc)), file=sys.stderr, end="\n\n")
+        print(f"[ERROR] {str(vexc)}", file=sys.stderr, end="\n\n")
         parser.print_help(sys.stderr)
         sys.exit(-1)
     return args
@@ -160,25 +152,21 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
     """
     if name is None:
         name = str(cmd)
-    print(
-        "[INFO] Ensuring {} is stable for at least {} seconds".format(name, launch_time)
-    )
+    print(f"[INFO] Ensuring {name} is stable for at least {launch_time} seconds")
     try:
         return fprime_gds.executables.utils.run_wrapped_application(
             cmd, logfile, env, launch_time
         )
     except fprime_gds.executables.utils.AppWrapperException as awe:
-        print("[ERROR] {}.".format(str(awe)), file=sys.stderr)
+        print(f"[ERROR] {str(awe)}.", file=sys.stderr)
         try:
             if logfile is not None:
                 with open(logfile) as file_handle:
                     for line in file_handle.readlines():
-                        print("    [LOG] {}".format(line.strip()), file=sys.stderr)
+                        print(f"    [LOG] {line.strip()}", file=sys.stderr)
         except Exception:
             pass
-        raise fprime_gds.executables.utils.AppWrapperException(
-            "Failed to run {}".format(name)
-        )
+        raise fprime_gds.executables.utils.AppWrapperException(f"Failed to run {name}")
 
 
 def launch_tts(tts_port, tts_addr, logs, **_):
@@ -231,9 +219,7 @@ def launch_wx(port, dictionary, connect_address, log_dir, config, **_):
         gse_args.extend(["--dictionary", dictionary])
     else:
         print(
-            "[ERROR] Dictionary invalid, must be XML or PY dicts: {}".format(
-                dictionary
-            ),
+            f"[ERROR] Dictionary invalid, must be XML or PY dicts: {dictionary}",
             file=sys.stderr,
         )
     # For macOS, add in the wx wrapper
@@ -299,10 +285,10 @@ def launch_app(app, port, address, logs, **_):
     :return: process
     """
     app_name = os.path.basename(app)
-    logfile = os.path.join(logs, "{}.log".format(app_name))
+    logfile = os.path.join(logs, f"{app_name}.log")
     app_cmd = [os.path.abspath(app), "-p", str(port), "-a", address]
     return launch_process(
-        app_cmd, name="{} Application".format(app_name), logfile=logfile, launch_time=1
+        app_cmd, name=f"{app_name} Application", logfile=logfile, launch_time=1
     )
 
 
@@ -337,8 +323,7 @@ def launch_comm(comm_adapter, tts_port, connect_address, logs, **all_args):
         app_cmd.append(str(all_args[destination]))
     return launch_process(
         app_cmd,
-        name="{} Application".format("comm[{}]".format(all_args["adapter"])),
-        launch_time=1,
+        app_cmd, name=f'comm[{all_args["adapter"]}] Application', launch_time=1
     )
 
 
@@ -368,7 +353,7 @@ def main():
     # elif gui == "none":
     #    print("[WARNING] No GUI specified, running headless", file=sys.stderr)
     else:
-        raise Exception("Invalid GUI specified: {}".format(settings["gui"]))
+        raise Exception(f'Invalid GUI specified: {settings["gui"]}')
     # Launch launchers and wait for the last app to finish
     try:
         procs = []
@@ -380,7 +365,7 @@ def main():
         print("[INFO] CTRL-C received. Exiting.")
     except Exception as exc:
         print(
-            "[INFO] Shutting down F prime due to error. {}".format(str(exc)),
+            f"[INFO] Shutting down F prime due to error. {str(exc)}",
             file=sys.stderr,
         )
         return 1

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -160,7 +160,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             self.registered = True
             self.name = name
             self.id = process_id
-            print("Registered client " + self.name.decode(DATA_ENCODING))
+            print(f"Registered client {self.name.decode(DATA_ENCODING)}")
 
     #################################################
     # New Routines to process the command messages
@@ -226,7 +226,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
                         + " (Connection reset by peer) occurred on recv()."
                     )
                 else:
-                    print("Socket error " + str(err.errno) + " occurred on recv().")
+                    print(f"Socket error {str(err.errno)} occurred on recv().")
         return msg
 
     def readHeader(self):
@@ -278,7 +278,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             data = tlm_packet_size + self.recv(size)
 
         else:
-            raise RuntimeError("unrecognized client %s" % dst.decode(DATA_ENCODING))
+            raise RuntimeError(f"unrecognized client {dst.decode(DATA_ENCODING)}")
         return data
 
     def processNewPkt(self, header, data):
@@ -470,7 +470,7 @@ class DestObj:
             # print "about to send data to " + self.name
             self.socket.send(msg)
         except OSError as err:
-            print("Socket error " + str(err.errno) + " occurred on send().")
+            print(f"Socket error {str(err.errno)} occurred on send().")
 
     def fileno(self):
         """"""

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -108,7 +108,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             GUI_ids.remove(self.id)
         LOCK.release()
 
-        print("Closed %s connection." % self.name.decode(DATA_ENCODING))
+        print(f"Closed {self.name.decode(DATA_ENCODING)} connection.")
         self.registered = False
         self.request.close()
 
@@ -484,8 +484,8 @@ def main(argv=None):
     program_license = "Copyright 2015 user_name (California Institute of Technology)                                            \
                 ALL RIGHTS RESERVED. U.S. Government Sponsorship acknowledged."
     program_version = "v0.1"
-    program_build_date = "%s" % __updated__
-    program_version_string = "%prog {} ({})".format(program_version, program_build_date)
+    program_build_date = f"{__updated__}"
+    program_version_string = f"%prog {program_version} ({program_build_date})"
     program_longdesc = (
         """"""  # optional - give further explanation about what the program does
     )
@@ -530,7 +530,7 @@ def main(argv=None):
         SERVER = server
         LOCK = server.lock_obj
 
-        print("TCP Socket Server listening on host addr {}, port {}".format(HOST, PORT))
+        print(f"TCP Socket Server listening on host addr {HOST}, port {PORT}")
         # Start a thread with the server -- that thread will then start one
         # more thread for each request
         server_thread = threading.Thread(target=server.serve_forever)
@@ -556,7 +556,7 @@ def main(argv=None):
 
     except Exception as e:
         indent = len(program_name) * " "
-        sys.stderr.write(program_name + ": " + repr(e) + "\n")
+        sys.stderr.write(f'{program_name}: {repr(e)}' + "\n")
         sys.stderr.write(indent + "  for help use --help\n")
         return 2
 

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -23,9 +23,7 @@ class ProcessNotStableException(Exception):
     def __init__(self, name, code, lifespan):
         """ Constructor to help with messages"""
         super().__init__(
-            "{} stopped with code {} sooner than {} seconds".format(
-                name, code, lifespan
-            )
+            f"{name} stopped with code {code} sooner than {lifespan} seconds"
         )
 
 
@@ -91,17 +89,15 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
     :return: child process should it be needed.
     """
     # Write out run information for the calling user
-    print("[INFO] Running Application: {}".format(arguments[0]))
+    print(f"[INFO] Running Application: {arguments[0]}")
     # Attempt to open a log file
     file_handler = None
     try:
         if logfile is not None:
-            print("[INFO] Log File: {}".format(logfile))
+            print(f"[INFO] Log File: {logfile}")
             file_handler = open(logfile, "wb", 0)
     except OSError as exc:
-        raise AppWrapperException(
-            "Failed to open: {} with error {}.".format(logfile, str(exc))
-        )
+        raise AppWrapperException(f"Failed to open: {logfile} with error {str(exc)}.")
     # Spawn the process. Uses pexpect, as this will force the process to output data immediately, rather than buffering
     # the output. That way the log file is fully up-to-date.
     try:
@@ -120,5 +116,5 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
         return child
     except Exception as exc:
         raise AppWrapperException(
-            "Failed to run application: {}. Error: {}".format(" ".join(arguments), exc)
+            f'Failed to run application: {" ".join(arguments)}. Error: {exc}'
         )

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -148,7 +148,7 @@ def construct_app():
 try:
     app, _ = construct_app()
 except Exception as exc:
-    print("[ERROR] {}".format(exc), file=sys.stderr)
+    print(f"[ERROR] {exc}", file=sys.stderr)
     sys.exit(1)
 
 

--- a/src/fprime_gds/flask/commands.py
+++ b/src/fprime_gds/flask/commands.py
@@ -111,9 +111,7 @@ class Command(flask_restful.Resource):
         if key is None or int(key, 0) != 0xFEEDCAFE:
             flask_restful.abort(
                 403,
-                message="{} is invalid command key. Supply 0xfeedcafe to run command.".format(
-                    key
-                ),
+                message=f"{key} is invalid command key. Supply 0xfeedcafe to run command.",
             )
         if arg_list is None:
             arg_list = []
@@ -124,5 +122,5 @@ class Command(flask_restful.Resource):
         except fprime_gds.common.data_types.cmd_data.CommandArgumentsException as exc:
             flask_restful.abort(403, message={"errors": exc.errors})
         except KeyError as key_error:
-            flask_restful.abort(403, message="{} is not a valid command".format(key_error))
+            flask_restful.abort(403, message=f"{key_error} is not a valid command")
         return {"message": "success"}

--- a/src/fprime_gds/flask/components.py
+++ b/src/fprime_gds/flask/components.py
@@ -39,9 +39,7 @@ def setup_pipelined_components(
         pipeline = fprime_gds.common.pipeline.standard.StandardPipeline()
         pipeline.setup(config, dictionary, down_store, logging_prefix=log_dir)
         logger.info(
-            "Connecting to GDS at: {}:{} from pid: {}".format(
-                tts_address, tts_port, os.getpid()
-            )
+            f"Connecting to GDS at: {tts_address}:{tts_port} from pid: {os.getpid()}"
         )
         pipeline.connect(tts_address, tts_port)
         __PIPELINE = pipeline

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -187,7 +187,7 @@ def config_for_set(uset, app, defaults=None):
                      settings.
     """
     config = app.config
-    prefix = 'UPLOADED_%s_' % uset.name.upper()
+    prefix = f'UPLOADED_{uset.name.upper()}_'
     using_defaults = False
     if defaults is None:
         defaults = dict(dest=None, url=None)
@@ -208,7 +208,7 @@ def config_for_set(uset, app, defaults=None):
                 using_defaults = True
                 destination = os.path.join(defaults['dest'], uset.name)
             else:
-                raise RuntimeError("no destination for set %s" % uset.name)
+                 raise RuntimeError(f"no destination for set {uset.name}")
 
     if base_url is None and using_defaults and defaults['url']:
         base_url = addslash(defaults['url']) + uset.name + '/'

--- a/src/fprime_gds/flask/sequence.py
+++ b/src/fprime_gds/flask/sequence.py
@@ -67,7 +67,10 @@ class SequenceCompiler(flask_restful.Resource):
         text = args.get("text", "")
         uplink = args.get("uplink", "false") == "true"
         if key is None or int(key, 0) != 0xFEEDCAFE:
-            flask_restful.abort(403, message="{} is invalid command key. Supply 0xfeedcafe to run command.".format(key))
+            flask_restful.abort(
+                403,
+                message=f"{key} is invalid command key. Supply 0xfeedcafe to run command.",
+            )
         elif not re.match(".*\.seq", name) or Path(name).name != name:
             flask_restful.abort(403, message={"error": "Supply filename with .seq suffix", "type": "error"})
         temp_seq_path = self.tempdir / Path(name).name

--- a/src/fprime_gds/flask/updown.py
+++ b/src/fprime_gds/flask/updown.py
@@ -100,16 +100,14 @@ class FileUploads(flask_restful.Resource):
         for key, file in flask.request.files.items():
             try:
                 filename = self.uplink_set.save(file)
-                flask.current_app.logger.info(
-                    "Received file. Saved to: {}".format(filename)
-                )
+                flask.current_app.logger.info(f"Received file. Saved to: {filename}")
                 self.uplinker.enqueue(
                     os.path.join(self.uplink_set.config.destination, filename)
                 )
                 successful.append(key)
             except Exception as exc:
                 flask.current_app.logger.warning(
-                    "Failed to save file {} with error: {}".format(key, exc)
+                    f"Failed to save file {key} with error: {exc}"
                 )
                 failed.append(key)
         return {"successful": successful, "failed": failed}

--- a/test/fprime_gds/common/distributor/test_distributor.py
+++ b/test/fprime_gds/common/distributor/test_distributor.py
@@ -37,47 +37,20 @@ def test_distributor():
 
     assert (
         test_leftover == leftover_data
-    ), "expected leftover data to be %s, but found %s" % (
-        list(leftover_data),
-        list(test_leftover),
-    )
+    ), f"expected leftover data to be {list(leftover_data)}, but found {list(test_leftover)}"
     assert raw_msgs[0] == (
         header_1 + data_1
-    ), "expected first raw_msg to be %s, but found %s" % (
-        list(header_1 + data_1),
-        list(raw_msgs[0]),
-    )
+    ), f"expected first raw_msg to be {list(header_1 + data_1)}, but found {list(raw_msgs[0])}"
     assert raw_msgs[1] == (
         header_2 + data_2
-    ), "expected second raw_msg to be %s, but found %s" % (
-        list(header_2 + data_2),
-        list(raw_msgs[1]),
-    )
+    ), f"expected second raw_msg to be {list(header_2 + data_2)}, but found {list(raw_msgs[1])}"
 
     (test_len_1, test_desc_1, test_msg_1) = dist.parse_raw_msg_api(raw_msgs[0])
     (test_len_2, test_desc_2, test_msg_2) = dist.parse_raw_msg_api(raw_msgs[1])
 
-    assert test_len_1 == length_1, "expected 1st length to be %d but found %d" % (
-        length_1,
-        test_len_1,
-    )
-    assert test_len_2 == length_2, "expected 2nd length to be %d but found %d" % (
-        length_2,
-        test_len_2,
-    )
-    assert test_desc_1 == desc_1, "expected 1st desc to be %d but found %d" % (
-        desc_1,
-        test_desc_1,
-    )
-    assert test_desc_2 == desc_2, "expected 2nd desc to be %d but found %d" % (
-        desc_2,
-        test_desc_2,
-    )
-    assert test_msg_1 == data_1, "expected 1st msg to be {} but found {}".format(
-        list(data_1),
-        list(test_msg_1),
-    )
-    assert test_msg_2 == data_2, "expected 2nd msg to be {} but found {}".format(
-        list(data_2),
-        list(test_msg_2),
-    )
+    assert test_len_1 == length_1, f"expected 1st length to be {length_1} but found {test_len_1}"
+    assert test_len_2 == length_2, f"expected 2nd length to be {length_2} but found {test_len_2}"
+    assert test_desc_1 == desc_1, f"expected 1st desc to be {desc_1} but found {test_desc_1}"
+    assert test_desc_2 == desc_2, f"expected 2nd desc to be {desc_2} but found {test_desc_2}"
+    assert (test_msg_1 == data_1), f"expected 1st msg to be {list(data_1)} but found {list(test_msg_1)}"
+    assert (test_msg_2 == data_2), f"expected 2nd msg to be {list(data_2)} but found {list(test_msg_2)}"

--- a/test/fprime_gds/common/encoders/test_ch_encoder.py
+++ b/test/fprime_gds/common/encoders/test_ch_encoder.py
@@ -44,19 +44,13 @@ def test_ch_encoder():
 
     assert (
         reg_output == reg_expected
-    ), "FAIL: expected regular output to be %s, but found %s" % (
-        list(reg_expected),
-        list(reg_output),
-    )
+    ), f"FAIL: expected regular output to be {list(reg_expected)}, but found {list(reg_output)}"
 
     config_output = enc_config.encode_api(ch_obj)
 
     assert (
         config_output == config_expected
-    ), "FAIL: expected configured output to be %s, but found %s" % (
-        list(config_expected),
-        list(config_output),
-    )
+    ), f"FAIL: expected configured output to be {list(config_expected)}, but found {list(config_output)}"
 
     temp = ChTemplate(102, "test_ch2", "test_comp2", U16Type())
 
@@ -78,16 +72,10 @@ def test_ch_encoder():
 
     assert (
         reg_output == reg_expected
-    ), "FAIL: expected regular output to be %s, but found %s" % (
-        list(reg_expected),
-        list(reg_output),
-    )
+    ), f"FAIL: expected regular output to be {list(reg_expected)}, but found {list(reg_output)}"
 
     config_output = enc_config.encode_api(ch_obj)
 
     assert (
         config_output == config_expected
-    ), "FAIL: expected configured output to be %s, but found %s" % (
-        list(config_expected),
-        list(config_output),
-    )
+    ), f"FAIL: expected configured output to be {list(config_expected)}, but found {list(config_output)}"

--- a/test/fprime_gds/common/encoders/test_event_encoder.py
+++ b/test/fprime_gds/common/encoders/test_event_encoder.py
@@ -52,19 +52,13 @@ def test_event_encoder():
 
     assert (
         reg_output == reg_expected
-    ), "FAIL: expected regular output to be %s, but found %s" % (
-        list(reg_expected),
-        list(reg_output),
-    )
+    ), f"FAIL: expected regular output to be {list(reg_expected)}, but found {list(reg_output)}"
 
     config_output = enc_config.encode_api(event_obj)
 
     assert (
         config_output == config_expected
-    ), "FAIL: expected configured output to be %s, but found %s" % (
-        list(config_expected),
-        list(config_output),
-    )
+    ), f"FAIL: expected configured output to be {list(config_expected)}, but found {list(config_output)}"
 
     temp = EventTemplate(
         102,
@@ -93,16 +87,10 @@ def test_event_encoder():
 
     assert (
         reg_output == reg_expected
-    ), "FAIL: expected regular output to be %s, but found %s" % (
-        list(reg_expected),
-        list(reg_output),
-    )
+    ), f"FAIL: expected regular output to be {list(reg_expected)}, but found {list(reg_output)}"
 
     config_output = enc_config.encode_api(event_obj)
 
     assert (
         config_output == config_expected
-    ), "FAIL: expected configured output to be %s, but found %s" % (
-        list(config_expected),
-        list(config_output),
-    )
+    ), f"FAIL: expected configured output to be {list(config_expected)}, but found {list(config_output)}"

--- a/test/fprime_gds/common/encoders/test_pkt_encoder.py
+++ b/test/fprime_gds/common/encoders/test_pkt_encoder.py
@@ -54,16 +54,10 @@ def test_pkt_encoder():
 
     assert (
         reg_output == reg_expected
-    ), "FAIL: expected regular output to be %s, but found %s" % (
-        list(reg_expected),
-        list(reg_output),
-    )
+    ), f"FAIL: expected regular output to be {list(reg_expected)}, but found {list(reg_output)}"
 
     config_output = enc_config.encode_api(pkt_obj)
 
     assert (
         config_output == config_expected
-    ), "FAIL: expected configured output to be %s, but found %s" % (
-        list(config_expected),
-        list(config_output),
-    )
+    ), f"FAIL: expected configured output to be {list(config_expected)}, but found {list(config_output)}"

--- a/test/fprime_gds/common/history/chronohistory_unit_test.py
+++ b/test/fprime_gds/common/history/chronohistory_unit_test.py
@@ -41,15 +41,11 @@ class HistoryTestCases(unittest.TestCase):
     def assert_lists_equal(expected, actual):
         assert len(expected) == len(
             actual
-        ), "the given list should have had the length {}, but instead had {}".format(
-            len(expected), len(actual)
-        )
+        ), f"the given list should have had the length {len(expected)}, but instead had {len(actual)}"
         for i in range(len(expected)):
             assert (
                 expected[i] is actual[i]
-            ), "the {} element of the expected list should be {}, but was {}.".format(
-                i, expected[i], actual[i]
-            )
+            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
 
     def test_push_and_retrieve(self):
         self.assert_lists_equal([], self.cHistory.retrieve())

--- a/test/fprime_gds/common/history/testhistory_unit_test.py
+++ b/test/fprime_gds/common/history/testhistory_unit_test.py
@@ -20,15 +20,11 @@ class HistoryTestCases(unittest.TestCase):
     def assert_lists_equal(expected, actual):
         assert len(expected) == len(
             actual
-        ), "the given list should have had the length {}, but instead had {}".format(
-            len(expected), len(actual)
-        )
+        ), f"the given list should have had the length {len(expected)}, but instead had {len(actual)}"
         for i in range(len(expected)):
             assert (
                 expected[i] == actual[i]
-            ), "the {} element of the expected list should be {}, but was {}.".format(
-                i, expected[i], actual[i]
-            )
+            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
 
     def test_push_and_retrieve(self):
         tList = []

--- a/test/fprime_gds/common/testing_fw/api_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/api_unit_test.py
@@ -135,10 +135,8 @@ class APITestCases(unittest.TestCase):
         for i in range(len(expected)):
             assert (
                 expected[i] == actual[i]
-            ), "the {} element of the expected list should be {}, but was {}.".format(
-                i, expected[i], actual[i]
-            )
-
+            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
+    
     def get_counter_sequence(self, length):
         seq = []
         for i in range(0, length):
@@ -155,7 +153,7 @@ class APITestCases(unittest.TestCase):
         return seq
 
     def get_severity_event(self, severity="DIAGNOSTIC"):
-        name = "Severity" + severity
+        name = f"Severity{severity}"
         temp = self.pipeline.dictionaries.event_name[name]
         event = EventData(tuple(), TimeType(), temp)
         return event
@@ -188,9 +186,7 @@ class APITestCases(unittest.TestCase):
         item_count = len(evr_hist)
         assert (
             item_count == length
-        ), "Were the correct number of items in the history? ({},{})".format(
-            item_count, length
-        )
+        ), f"Were the correct number of items in the history? ({item_count},{length})"
 
     def test_find_history_item(self):
         self.fill_history(self.tHistory.data_callback, range(0, 50))
@@ -200,17 +196,13 @@ class APITestCases(unittest.TestCase):
         pred = predicates.equal_to(25)
 
         result = self.api.find_history_item(pred, self.tHistory)
-        assert result == 25, "The search should have returned 25, but found {}".format(
-            result
-        )
+        assert result == 25, f"The search should have returned 25, but found {result}"
         result = self.api.find_history_item(pred, self.tHistory, start=50)
-        assert result == 25, "The search should have returned 25, but found {}".format(
-            result
-        )
+        assert result == 25, f"The search should have returned 25, but found {result}"
         result = self.api.find_history_item(pred, self.tHistory, start=80)
         assert (
             result is None
-        ), "The search should have returned None, but found {}".format(result)
+        ), f"The search should have returned None, but found {result}"
 
     def test_find_history_item_timeout(self):
         pred = predicates.equal_to(25)
@@ -218,15 +210,11 @@ class APITestCases(unittest.TestCase):
         listA = range(0, 50)
         self.fill_history_async(self.tHistory.data_callback, listA, 0.01)
         result = self.api.find_history_item(pred, self.tHistory, timeout=1)
-        assert result == 25, "The search should have returned 25, but found {}".format(
-            result
-        )
+        assert result == 25, f"The search should have returned 25, but found {result}"
 
         pred = predicates.equal_to(49)
         result = self.api.find_history_item(pred, self.tHistory, timeout=1)
-        assert result == 49, "The search should have returned 49, but found {}".format(
-            result
-        )
+        assert result == 49, f"The search should have returned 49, but found {result}"
 
         self.tHistory.clear()
 
@@ -236,7 +224,7 @@ class APITestCases(unittest.TestCase):
         result = self.api.find_history_item(pred, self.tHistory, timeout=1)
         assert (
             result is None
-        ), "The search should have returned None, but found {}".format(result)
+        ), f"The search should have returned None, but found {result}"
 
     def test_find_history_sequence(self):
         sequence = []
@@ -247,33 +235,25 @@ class APITestCases(unittest.TestCase):
         results = self.api.find_history_sequence(sequence, self.tHistory)
         assert len(results) == len(
             sequence
-        ), "The search should have found {}, but returned {}".format(
-            range(30, 40, 2), results
-        )
+        ), f"The search should have found {range(30, 40, 2)}, but returned {results}"
         self.assert_lists_equal(range(30, 40, 2), results)
 
         results = self.api.find_history_sequence(sequence, self.tHistory, start=34)
         assert len(results) != len(
             sequence
-        ), "The search should have returned an incomplete list, but found {}".format(
-            results
-        )
+        ), f"The search should have returned an incomplete list, but found {results}"
 
         self.fill_history(self.tHistory.data_callback, range(0, 50))
         results = self.api.find_history_sequence(sequence, self.tHistory, start=34)
         assert len(results) == len(
             sequence
-        ), "The search should have found {}, but returned {}".format(
-            range(30, 40, 2), results
-        )
+        ), f"The search should have found {range(30, 40, 2)}, but returned {results}"
         self.assert_lists_equal(range(30, 40, 2), results)
 
         results = self.api.find_history_sequence(sequence, self.tHistory, start=90)
         assert len(results) != len(
             sequence
-        ), "The search should have returned an incomplete list, but found {}".format(
-            results
-        )
+        ), f"The search should have returned an incomplete list, but found {results}"
 
     def test_find_history_sequence_timeout(self):
         sequence = []
@@ -300,9 +280,7 @@ class APITestCases(unittest.TestCase):
         )
         assert len(results) != len(
             sequence
-        ), "The search should have returned an incomplete list, but found {}".format(
-            results
-        )
+        ), f"The search should have returned an incomplete list, but found {results}"
 
     def test_find_history_count(self):
         count_pred = predicates.greater_than_or_equal_to(10)
@@ -332,9 +310,7 @@ class APITestCases(unittest.TestCase):
         results = self.api.find_history_count(count_pred, self.tHistory)
         assert (
             len(results) < 10
-        ), "The search should have returned an incomplete list, but found {}".format(
-            results
-        )
+        ), f"The search should have returned an incomplete list, but found {results}"
 
         results = self.api.find_history_count(
             count_pred, self.tHistory, search_pred, timeout=2
@@ -356,9 +332,7 @@ class APITestCases(unittest.TestCase):
         )
         assert (
             len(results) < 10
-        ), "The search should have returned an incomplete list, but found {}".format(
-            results
-        )
+        ), f"The search should have returned an incomplete list, but found {results}"
 
     def test_get_latest_fsw_time(self):
         ts0 = self.api.get_latest_time()
@@ -379,9 +353,7 @@ class APITestCases(unittest.TestCase):
         for i in range(1, 10):
             time.sleep(0.1)
             tsi = self.api.get_latest_time()
-            assert tsi > last, "Iter {}: {} should be greater than {}".format(
-                i, tsi, last
-            )
+            assert tsi > last, f"Iter {i}: {tsi} should be greater than {last}"
             last = tsi
 
         t1.join()
@@ -390,7 +362,7 @@ class APITestCases(unittest.TestCase):
         tsn_1 = self.api.get_latest_time()
         assert (
             tsn_1 > last
-        ), "The final timestamp, {}, should be greater than {}.".format(tsn_1, last)
+        ), f"The final timestamp, {tsn_1}, should be greater than {last}."
 
         time.sleep(0.1)
 
@@ -429,11 +401,11 @@ class APITestCases(unittest.TestCase):
         firstC = channelHistory[iC]
 
         self.api.clear_histories(timeE)
-        msg = "The event history should have been reduced by {} elements".format(iE)
+        msg = f"The event history should have been reduced by {iE} elements"
         assert sizeE - iE == eventHistory.size(), msg
         msg = "The element with the timestamp should be first in the history"
         assert firstE is eventHistory[0], msg
-        msg = "The channel history should have been reduced by {} elements".format(iC)
+        msg = f"The channel history should have been reduced by {iC} elements"
         assert sizeC - iC == channelHistory.size(), msg
         msg = "The first element in the history should be the first with a valid time"
         assert firstC is channelHistory[0], msg
@@ -709,23 +681,19 @@ class APITestCases(unittest.TestCase):
         result = self.api.await_telemetry("Counter", 8)
         assert (
             result is not None
-        ), "Await should have found a correct channel update: {}".format(result)
+        ), f"Await should have found a correct channel update: {result}"
 
         time.sleep(1)
 
         self.fill_history_async(self.pipeline.enqueue_telemetry, seq[10:20], 0.01)
         result = self.api.await_telemetry("Counter", 8)
-        assert result is None, "Await should not have found an update: {}".format(
-            result
-        )
+        assert result is None, f"Await should not have found an update: {result}"
 
         self.api.clear_histories()
 
         self.fill_history_async(self.pipeline.enqueue_telemetry, seq, 0.1)
         result = self.api.await_telemetry("Counter", 15, timeout=1)
-        assert result is None, "Await should not have found an update: {}".format(
-            result
-        )
+        assert result is None, f"Await should not have found an update: {result}"
 
     def test_await_telemetry_sequence(self):
         count_seq = self.get_counter_sequence(20)

--- a/test/fprime_gds/common/testing_fw/predicate_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/predicate_unit_test.py
@@ -28,7 +28,7 @@ class PredicateTestCases(unittest.TestCase):
         try:
             pred.__str__()
             print(pred)
-            assert True, "predicate provides string summary: {}".format(str(pred))
+            assert True, f"predicate provides string summary: {str(pred)}"
         except NotImplementedError:
             assert False, "invoking str(pred) was not supported"
 
@@ -212,41 +212,33 @@ class PredicateTestCases(unittest.TestCase):
     def test_args_predicates():
         a_list = ["a", "p", "p", "l", "e"]
         pred = predicates.args_predicate(["a", "p", "p", "l", "e"])
-        assert pred(a_list), "The list {} should have been accepted".format(a_list)
+        assert pred(a_list), f"The list {a_list} should have been accepted"
         a_list[4] = "r"
-        assert not pred(a_list), "The list {} should not have been accepted".format(
-            a_list
-        )
+        assert not pred(a_list), f"The list {a_list} should not have been accepted"
         a_list = ["a", "p", "p", "l"]
-        assert not pred(a_list), "The list {} should not have been accepted".format(
-            a_list
-        )
+        assert not pred(a_list), f"The list {a_list} should not have been accepted"
 
         a_list = ["a", "p", "p", "l", "e"]
         pred = predicates.args_predicate(["a", "p", "p", "l", None])
-        assert pred(a_list), "The list {} should have been accepted".format(a_list)
+        assert pred(a_list), f"The list {a_list} should have been accepted"
         a_list[4] = 7
-        assert pred(a_list), "The list {} should have been accepted".format(a_list)
+        assert pred(a_list), f"The list {a_list} should have been accepted"
         a_list[4] = "r"
-        assert pred(a_list), "The list {} should have been accepted".format(a_list)
+        assert pred(a_list), f"The list {a_list} should have been accepted"
 
         l_pred = predicates.within_range(0, 10)
         pred = predicates.args_predicate([l_pred, 2, 3, 4, 5, 6])
 
         n_list = [1, 2, 3, 4, 5, 6]
-        assert pred(n_list), "The list {} should have been accepted".format(n_list)
+        assert pred(n_list), f"The list {n_list} should have been accepted"
 
         for i in range(0, 10):
             n_list[0] = i
-            assert pred(n_list), "The list {} should have been accepted".format(n_list)
+            assert pred(n_list), f"The list {n_list} should have been accepted"
         n_list[0] = -5
-        assert not pred(n_list), "The list {} should not have been accepted".format(
-            n_list
-        )
+        assert not pred(n_list), f"The list {n_list} should not have been accepted"
         n_list[0] = 15
-        assert not pred(n_list), "The list {} should not have been accepted".format(
-            n_list
-        )
+        assert not pred(n_list), f"The list {n_list} should not have been accepted"
 
         pred = predicates.args_predicate(8)
         assert pred(8), "The value 8 should have been accepted."


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---

## Change Description

- Replace calls to ``string.format()`` with ``f-strings``
- Replace the use of the ``%`` string interpolation operator with ``f-strings`` (only ``%s`` operator for the moment)

## Rationale

According to the [Python documentation](https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting), using the ``%`` operator to format strings can lead to "a variety of quirks that lead to a number of common errors."

[PEP 498](https://peps.python.org/pep-0498/) added F-strings to Python in version 3.6. F-strings are a versatile and powerful method of string formatting. Because the code looks more like the output, they make it shorter and more readable.

## Testing/Review Recommendations

Take a deep breath

## Future Work

Deals with operators other than ``%s`` like ``%d``.
