### PR TITLE
Simplify if-expr with `or`keyword

### DIFF
--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -54,7 +54,7 @@ class CmdData(sys_data.SysData):
         self.template = cmd_temp
 
         self.args, errors = self.process_args(cmd_args)
-        self.time = cmd_time if cmd_time else TimeType(TimeBase["TB_DONT_CARE"].value)
+        self.time = cmd_time or TimeType(TimeBase["TB_DONT_CARE"].value)
         self.descriptor = cmd_desc
 
         # If any errors occur, then raise a aggregated error

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -380,7 +380,7 @@ class XmlLoader(dict_loader.DictLoader):
                 print(f"Trying to parse string type, but found {self.STR_LEN_TAG} field")
                 return None
             max_length = int(xml_item.get(self.STR_LEN_TAG, 0))
-            name = f"{ context if context else '' }::{ xml_item.get(self.ARG_NAME_TAG) }String"
+            name = f"{context or ''}::{xml_item.get(self.ARG_NAME_TAG)}String"
             return StringType.construct_type(name, max_length)
         else:
             # First try Serialized types:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  Let CI run |
|**_Unit Tests Pass (y/n)_**|  Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to replace if expressions that compare to the target with the ``or`` keyword, when possible.

## Rationale

In both cases, we end up setting a value if it is true and using a default value otherwise.

The version with the ``or`` keyword is more readable and avoids duplicating the evaluated variable.

Since the left side is evaluated first, this does the job:
- If the answer is ``True``, the variable will be set to that value and the right side will be ignored.
- If the answer is ``False``, the right side is evaluated and the variable takes the value of the old "else".


## Testing/Review Recommendations

void

## Future Work

void
