### PR TITLE
Use the built-in function ``next`` instead of a for-loop

### DIFF
--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -147,11 +147,9 @@ class XmlLoader(dict_loader.DictLoader):
         Returns:
             The xml object of the desired section if found, or None if not
         """
-        for section in xml_root:
-            if section.tag == section_name:
-                return section
-
-        return None
+        return next(
+            (section for section in xml_root if section.tag == section_name), None
+        )
 
     def get_args_list(self, xml_obj, xml_tree, context=None):
         """

--- a/test/fprime_gds/common/testing_fw/api_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/api_unit_test.py
@@ -387,11 +387,14 @@ class APITestCases(unittest.TestCase):
         timeE = firstE.get_time()
 
         sizeC = channelHistory.size()
-        iC = 0
-        for i in range(0, channelHistory.size()):
-            if channelHistory[i].get_time() >= timeE:
-                iC = i
-                break
+        iC = next(
+            (
+                i
+                for i in range(channelHistory.size())
+                if channelHistory[i].get_time() >= timeE
+            ),
+            0,
+        )
         firstC = channelHistory[iC]
 
         self.api.clear_histories(timeE)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| xml_loader.py |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to use the built-in function [next](https://docs.python.org/3/library/functions.html#next) instead of a for-loop in the get_xml_section(section_name, xml_root) function that retrieves the given xml section from the xml tree if it exists.

## Rationale

When we choose the first element of an iterable that satisfies a condition, we can use the following built-in function instead of a for-loop to make our code and intent clearer.

## Testing/Review Recommendations

void

## Future Work

void
