### PR TITLE
Remove useless ``else`` & Swap ``if-else`` branches

### DIFF
--- a/src/fprime_gds/common/decoders/ch_decoder.py
+++ b/src/fprime_gds/common/decoders/ch_decoder.py
@@ -71,17 +71,16 @@ class ChDecoder(Decoder):
         ch_time.deserialize(data, ptr)
         ptr += ch_time.getSize()
 
-        if ch_id in self.__dict:
-            # Retrieve the template instance for this channel
-            ch_temp = self.__dict[ch_id]
-
-            try:
-                val_obj = self.decode_ch_val(data, ptr, ch_temp)
-            except Exception as exc:
-                raise DecodingException(f"Channel {ch_temp.name} failed to decode: {exc}")
-            return ChData(val_obj, ch_time, ch_temp)
-        else:
+        if ch_id not in self.__dict:
             raise DecodingException(f"Channel {ch_id} not found in dictionary")
+        # Retrieve the template instance for this channel
+        ch_temp = self.__dict[ch_id]
+
+        try:
+            val_obj = self.decode_ch_val(data, ptr, ch_temp)
+        except Exception as exc:
+            raise DecodingException(f"Channel {ch_temp.name} failed to decode: {exc}")
+        return ChData(val_obj, ch_time, ch_temp)
 
     @staticmethod
     def decode_ch_val(val_data, offset, template):

--- a/src/fprime_gds/common/history/test.py
+++ b/src/fprime_gds/common/history/test.py
@@ -139,10 +139,9 @@ class TestHistory(History):
         Returns:
             the index in the given list that start refers to
         """
-        if predicates.is_predicate(start):
-            index = 0
-            while index < self.size() and not start(self.objects[index]):
-                index += 1
-            return index
-        else:
+        if not predicates.is_predicate(start):
             return start
+        index = 0
+        while index < self.size() and not start(self.objects[index]):
+            index += 1
+        return index

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -324,16 +324,15 @@ class IntegrationTestAPI(DataHandler):
             cmd_dict = self.pipeline.dictionaries.command_name
             if command in cmd_dict:
                 return cmd_dict[command].get_id()
-            else:
-                msg = f"The command mnemonic, {command}, wasn't in the dictionary"
-                raise KeyError(msg)
+            msg = f"The command mnemonic, {command}, wasn't in the dictionary"
         else:
             cmd_dict = self.pipeline.dictionaries.command_id
             if command in cmd_dict:
                 return command
-            else:
-                msg = f"The command id, {command}, wasn't in the dictionary"
-                raise KeyError(msg)
+            msg = f"The command id, {command}, wasn't in the dictionary"
+        raise KeyError(msg)
+
+
 
     def send_command(self, command, args=None):
         """
@@ -495,9 +494,8 @@ class IntegrationTestAPI(DataHandler):
             ch_dict = self.pipeline.dictionaries.channel_id
             if channel in ch_dict:
                 return channel
-            else:
-                msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
-                raise KeyError(msg)
+            msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
+            raise KeyError(msg)
 
     def get_telemetry_pred(self, channel=None, value=None, time_pred=None):
         """
@@ -718,9 +716,8 @@ class IntegrationTestAPI(DataHandler):
             event_dict = self.pipeline.dictionaries.event_id
             if event in event_dict:
                 return event
-            else:
-                msg = f"The event id, {event}, wasn't in the dictionary"
-                raise KeyError(msg)
+            msg = f"The event id, {event}, wasn't in the dictionary"
+            raise KeyError(msg)
 
     def get_event_pred(self, event=None, args=None, severity=None, time_pred=None):
         """

--- a/src/fprime_gds/common/tools/seqgen.py
+++ b/src/fprime_gds/common/tools/seqgen.py
@@ -70,16 +70,7 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
     try:
         for i, descriptor, seconds, useconds, mnemonic, args in parsed_seq:
             try:
-                # Make sure that command is in the command dictionary:
-                if mnemonic in cmd_name_dict:
-                    # Set the command arguments:
-                    try:
-                        cmd_time = TimeType(TimeBase["TB_DONT_CARE"].value, seconds=seconds, useconds=useconds)
-                        cmd_data = CmdData(args, cmd_name_dict[mnemonic], cmd_desc=descriptor, cmd_time=cmd_time)
-                    except CommandArgumentsException as e:
-                        raise SeqGenException(f"Line { i + 1 }: { mnemonic } errored: { ','.join(e.errors) }")
-                    command_list.append(cmd_data)
-                else:
+                if mnemonic not in cmd_name_dict:
                     raise SeqGenException(
                         "Line %d: %s"
                         % (
@@ -89,6 +80,13 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
                             + "' does not match any command in the command dictionary.",
                         )
                     )
+                # Set the command arguments:
+                try:
+                    cmd_time = TimeType(TimeBase["TB_DONT_CARE"].value, seconds=seconds, useconds=useconds)
+                    cmd_data = CmdData(args, cmd_name_dict[mnemonic], cmd_desc=descriptor, cmd_time=cmd_time)
+                except CommandArgumentsException as e:
+                    raise SeqGenException(f"Line { i + 1 }: { mnemonic } errored: { ','.join(e.errors) }")
+                command_list.append(cmd_data)
             except SeqGenException as exc:
                 if not cont:
                     raise

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -304,25 +304,24 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
 
         # Process data here...
         head, dst = header.strip(b" ").split(b" ")
-        if head == b"A5A5":  # Packet Header
-            # print "Received Packet: %s %s...\n" % (head,dst)
-            if data == b"":
-                print(" Data is empty, returning.")
-            if b"GUI" in dst:
-                dest_list = GUI_clients
-            elif b"FSW" in dst:
-                dest_list = FSW_clients
-            for dest_elem in dest_list:
-                # print "Locking TCP"
-                LOCK.acquire()
-                if dest_elem in list(SERVER.dest_obj.keys()):
-                    # Send the message here....
-                    # print "Sending TCP msg to ", dest_elem
-
-                    SERVER.dest_obj[dest_elem].put(data)
-                LOCK.release()
-        else:
+        if head != b"A5A5":
             raise RuntimeError("Packet missing A5A5 header")
+        # print "Received Packet: %s %s...\n" % (head,dst)
+        if data == b"":
+            print(" Data is empty, returning.")
+        if b"GUI" in dst:
+            dest_list = GUI_clients
+        elif b"FSW" in dst:
+            dest_list = FSW_clients
+        for dest_elem in dest_list:
+            # print "Locking TCP"
+            LOCK.acquire()
+            if dest_elem in list(SERVER.dest_obj.keys()):
+                # Send the message here....
+                # print "Sending TCP msg to ", dest_elem
+
+                SERVER.dest_obj[dest_elem].put(data)
+            LOCK.release()
 
 
 class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
@@ -410,24 +409,23 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
         dest_list = []
         # Process data here...
         head, dst = header.strip(b" ").split(b" ")
-        if head == b"A5A5":  # Packet Header
-            # print "Received Packet: %s %s...\n" % (head,dst)
-            if data == "":
-                print(" Data is empty, returning.")
-            if b"GUI" in dst:
-                dest_list = GUI_clients
-            else:
-                print("dest? %s" % dst.decode(DATA_ENCODING))
-            for dest_elem in dest_list:
-                LOCK.acquire()
-                if dest_elem in list(SERVER.dest_obj.keys()):
-                    # Send the message here....
-                    # print "Sending UDP msg to ", dest_elem
-
-                    SERVER.dest_obj[dest_elem].put(data)
-                LOCK.release()
-        else:
+        if head != b"A5A5":
             raise RuntimeError("Telemetry missing A5A5 header")
+        # print "Received Packet: %s %s...\n" % (head,dst)
+        if data == "":
+            print(" Data is empty, returning.")
+        if b"GUI" in dst:
+            dest_list = GUI_clients
+        else:
+            print(f"dest? {dst.decode(DATA_ENCODING)}")
+        for dest_elem in dest_list:
+            LOCK.acquire()
+            if dest_elem in list(SERVER.dest_obj.keys()):
+                # Send the message here....
+                # print "Sending UDP msg to ", dest_elem
+
+                SERVER.dest_obj[dest_elem].put(data)
+            LOCK.release()
 
 
 class ThreadedTCPServer(socketserver.ThreadingMixIn, socketserver.TCPServer):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to:

1. Remove the unnecessary else after the guard condition
2. Swap the if and else branches of conditionals.

## Rationale

1. Using a guard condition in this way does not indent the rest of the function. In general, the less indentation one has to deal with, the easier it is to understand the code.
2. This makes it easier to read the function: if the first statement is not satisfied, we leave the function.

## Testing/Review Recommendations

void

## Future Work

void
