### PR TITLE
Rename first argument of ``class_method`` to ``cls``

### DIFF
--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -100,7 +100,7 @@ class FpFramerDeframer(FramerDeframer):
         FpFramerDeframer.set_constants()
 
     @classmethod
-    def set_constants(clazz):
+    def set_constants(cls):
         """
         Setup the constants for the various token sizes. This will ensure that the system can read the tokens properly.
         This can be changed to make the framing more efficient.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to rename the first argument of a ``class_method`` to ``cls``.

## Rationale

This is a very strong Python convention, and is explicitly stated in [PEP-8](https://peps.python.org/pep-0008/#function-and-method-arguments). Following this convention improves the consistency of the code and makes it easier for developers to understand the intent of the code.

## Testing/Review Recommendations

void

## Future Work

void