### PR TITLE
Use the built-in type ``set`` to check the membership of a collection of literals

### DIFF
--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -170,9 +170,9 @@ class CmdData(sys_data.SysData):
             )
         if isinstance(arg_type, BoolType):
             value = str(arg_val).lower().strip()
-            if value in ("true", "yes"):
+            if value in {"true", "yes"}:
                 av = True
-            elif value in ("false", "no"):
+            elif value in {"false", "no"}:
                 av = False
             else:
                 raise CommandArgumentException("Argument value is not a valid boolean")


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to use the built-in type ``set`` to check the membership of a collection of literals.

## Rationale

To determine whether a variable is part of a collection of literals, it is more natural and efficient to define this collection with a ``set`` than with a ``list`` or ``tuple``.

## Testing/Review Recommendations

void

## Future Work

void
