### PR TITLE
Add decoding for multiple telemetry items per packet

### DIFF
--- a/src/fprime_gds/common/decoders/ch_decoder.py
+++ b/src/fprime_gds/common/decoders/ch_decoder.py
@@ -61,27 +61,34 @@ class ChDecoder(Decoder):
         """
         ptr = 0
 
-        # Decode Ch ID here...
-        self.id_obj.deserialize(data, ptr)
-        ptr += self.id_obj.getSize()
-        ch_id = self.id_obj.val
+        # list for decoded channel values
+        ch_list = []
 
-        # Decode time...
-        ch_time = TimeType()
-        ch_time.deserialize(data, ptr)
-        ptr += ch_time.getSize()
+        while (ptr < len(data)):
 
-        if ch_id in self.__dict:
-            # Retrieve the template instance for this channel
-            ch_temp = self.__dict[ch_id]
+            # Decode Ch ID here...
+            self.id_obj.deserialize(data, ptr)
+            ptr += self.id_obj.getSize()
+            ch_id = self.id_obj.val
 
-            try:
-                val_obj = self.decode_ch_val(data, ptr, ch_temp)
-            except Exception as exc:
-                raise DecodingException(f"Channel {ch_temp.name} failed to decode: {exc}")
-            return ChData(val_obj, ch_time, ch_temp)
-        else:
-            raise DecodingException(f"Channel {ch_id} not found in dictionary")
+            # Decode time...
+            ch_time = TimeType()
+            ch_time.deserialize(data, ptr)
+            ptr += ch_time.getSize()
+
+            if ch_id in self.__dict:
+                # Retrieve the template instance for this channel
+                ch_temp = self.__dict[ch_id]
+
+                try:
+                    val_obj = self.decode_ch_val(data, ptr, ch_temp)
+                except Exception as exc:
+                    raise DecodingException(f"Channel {ch_temp.name} failed to decode: {exc}")
+                ch_list.append(ChData(val_obj, ch_time, ch_temp))
+                ptr += val_obj.getSize()
+            else:
+                raise DecodingException(f"Channel {ch_id} not found in dictionary")
+        return ch_list
 
     @staticmethod
     def decode_ch_val(val_data, offset, template):

--- a/src/fprime_gds/common/decoders/decoder.py
+++ b/src/fprime_gds/common/decoders/decoder.py
@@ -59,7 +59,8 @@ class Decoder(
         except Exception as exc:
             raise DecodingException(str(exc))
         if decoded is not None:
-            self.send_to_all(decoded)
+            for item in decoded:
+                self.send_to_all(item)
             return
         LOGGER.warning("Decoder of type %s produced 'None' decoded object", type(self))
 

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -14,8 +14,6 @@ Example data structure:
 
 @bug No known bugs
 """
-import traceback
-
 from fprime.common.models.serialize import time_type
 from fprime.common.models.serialize.type_exceptions import TypeException
 from fprime_gds.common.data_types import event_data

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -60,7 +60,7 @@ class EventDecoder(decoder.Decoder):
             Parsed version of the event data in the form of a EventData object
             or None if the data is not decodable
         """
-        ptr = 
+        ptr = 0
         
         event_list = []
 
@@ -129,4 +129,4 @@ class EventDecoder(decoder.Decoder):
 
             offset = offset + arg_obj.getSize()
 
-        return tuple (offset, tuple(arg_results))
+        return [offset, tuple(arg_results)]

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -85,8 +85,7 @@ class EventDecoder(decoder.Decoder):
                 # add up argument sizes
                 ptr += size
             else:
-                print("Event decode error: id %d not in dictionary" % event_id)
-                return None
+                raise DecodingException(f"Event {event_id} not found in dictionary")
 
         return event_list
 
@@ -123,9 +122,7 @@ class EventDecoder(decoder.Decoder):
                 arg_obj.deserialize(arg_data, offset)
                 arg_results.append(arg_obj)
             except TypeException as e:
-                print(f"Event decode exception {e.getMsg()}")
-                traceback.print_exc()
-                return None
+                raise DecodingException(f"Event argument decoding failed {e.getMsg()}")
 
             offset = offset + arg_obj.getSize()
 

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -60,27 +60,35 @@ class EventDecoder(decoder.Decoder):
             Parsed version of the event data in the form of a EventData object
             or None if the data is not decodable
         """
-        ptr = 0
+        ptr = 
+        
+        event_list = []
 
-        # Decode event ID here...
-        self.id_obj.deserialize(data, ptr)
-        ptr += self.id_obj.getSize()
-        event_id = self.id_obj.val
+        while (ptr < len(data)):
 
-        # Decode time...
-        event_time = time_type.TimeType()
-        event_time.deserialize(data, ptr)
-        ptr += event_time.getSize()
+            # Decode event ID here...
+            self.id_obj.deserialize(data, ptr)
+            ptr += self.id_obj.getSize()
+            event_id = self.id_obj.val
 
-        if event_id in self.__dict:
-            event_temp = self.__dict[event_id]
+            # Decode time...
+            event_time = time_type.TimeType()
+            event_time.deserialize(data, ptr)
+            ptr += event_time.getSize()
 
-            arg_vals = self.decode_args(data, ptr, event_temp)
+            if event_id in self.__dict:
+                event_temp = self.__dict[event_id]
 
-            return event_data.EventData(arg_vals, event_time, event_temp)
-        else:
-            print("Event decode error: id %d not in dictionary" % event_id)
-            return None
+                (size, arg_vals) = self.decode_args(data, ptr, event_temp)
+
+                event_list.append(event_data.EventData(arg_vals, event_time, event_temp))
+                # add up argument sizes
+                ptr += size
+            else:
+                print("Event decode error: id %d not in dictionary" % event_id)
+                return None
+
+        return event_list
 
     @staticmethod
     def decode_args(arg_data, offset, template):
@@ -121,4 +129,4 @@ class EventDecoder(decoder.Decoder):
 
             offset = offset + arg_obj.getSize()
 
-        return tuple(arg_results)
+        return tuple (offset, tuple(arg_results))

--- a/src/fprime_gds/common/decoders/file_decoder.py
+++ b/src/fprime_gds/common/decoders/file_decoder.py
@@ -49,16 +49,16 @@ class FileDecoder(decoder.Decoder):
             sourcePath = data[10 : sourcePathSize + 10]
             (destPathSize,) = struct.unpack_from(">B", data, sourcePathSize + 10)
             destPath = data[sourcePathSize + 11 : sourcePathSize + destPathSize + 11]
-            return file_data.StartPacketData(seqID, fileSize, sourcePath, destPath)
+            return [file_data.StartPacketData(seqID, fileSize, sourcePath, destPath),]
         elif packetType == "DATA":  # Packet Type is DATA
             offset, length = struct.unpack_from(">IH", data, 5)
             dataVar = data[11 : 11 + length]
-            return file_data.DataPacketData(seqID, offset, dataVar)
+            return [file_data.DataPacketData(seqID, offset, dataVar),]
         elif packetType == "END":  # Packet Type is END
             hashValue = struct.unpack_from(">I", data, 5)
-            return file_data.EndPacketData(seqID, hashValue)
+            return [file_data.EndPacketData(seqID, hashValue),]
         elif packetType == "CANCEL":  # Packet Type is CANCEL
             # CANCEL Packets have no data
-            return file_data.CancelPacketData(seqID)
+            return [file_data.CancelPacketData(seqID),]
         # The data was not determined to be any of the packet types so return none
         return None


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Internal JPL |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| y |
|**_Builds Without Errors (y/n)_**| y |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Modify downlink decoders to allow multiple telemetry items per packet.

## Rationale

This enables more efficient packing of telemetry into downlink packets, and is required to allow downlink linking of packetized telemetry.

## Testing/Review Recommendations

Manual testing was performed with telemetry, events, and files.

## Future Work

File downlink processing was updated to repackage the single file buffer into a list, but doesn't currently support multiple file buffers in a single packet.