### PR TITLE
Simplify args predicate with `all()`

### DIFF
--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -427,10 +427,7 @@ class args_predicate(predicate):
             actual = [actual]
         if len(actual) != len(self.arg_spec):
             return False
-        for i in range(len(self.arg_spec)):
-            if not self.arg_spec[i](actual[i]):
-                return False
-        return True
+        return all(self.arg_spec[i](actual[i]) for i in range(len(self.arg_spec)))
 
     def __str__(self):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to simplify the determination whether or not the given array satisfies the given argument specification for the predicates.

## Rationale

Using Python's built-in ``all()`` functions is a more concise way to do this than using a for loo.
``all()`` will only return ``True`` if all elements evaluate to ``True``.

## Testing/Review Recommendations

To understand better, use ``any()`` and then reverse the condition to get ``all()``.

## Future Work

void
