### PR TITLE
Switch from `range(len(...))` to `enumerate(...)`

### DIFF
--- a/src/fprime_gds/common/data_types/pkt_data.py
+++ b/src/fprime_gds/common/data_types/pkt_data.py
@@ -90,8 +90,7 @@ class PktData(SysData):
         elif not csv and not verbose:
             pkt_str += f"{self.time.to_readable(time_zone)}: {self.template.get_name()} {{\n"
 
-        for i in range(len(self.chs)):
-            ch = self.chs[i]
+        for i, ch in enumerate(self.chs):
 
             if not csv:
                 pkt_str += "\t"

--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -79,13 +79,13 @@ class SeqBinaryWriter:
 
         def __print(byteBuffer):
             print("Byte buffer size: %d" % len(byteBuffer))
-            for entry in range(len(byteBuffer)):
+            for entry, item in enumerate(byteBuffer):
                 print(
                     "Byte %d: 0x%02X (%c)"
                     % (
                         entry,
-                        struct.unpack("B", byteBuffer[entry])[0],
-                        struct.unpack("B", byteBuffer[entry])[0],
+                        struct.unpack("B", item)[0],
+                        struct.unpack("B", item)[0],
                     )
                 )
 

--- a/test/fprime_gds/common/history/chronohistory_unit_test.py
+++ b/test/fprime_gds/common/history/chronohistory_unit_test.py
@@ -42,10 +42,10 @@ class HistoryTestCases(unittest.TestCase):
         assert len(expected) == len(
             actual
         ), f"the given list should have had the length {len(expected)}, but instead had {len(actual)}"
-        for i in range(len(expected)):
+        for i, item in enumerate(expected):
             assert (
-                expected[i] is actual[i]
-            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
+                item is actual[i]
+            ), f"the {i} element of the expected list should be {item}, but was {actual[i]}."
 
     def test_push_and_retrieve(self):
         self.assert_lists_equal([], self.cHistory.retrieve())

--- a/test/fprime_gds/common/history/testhistory_unit_test.py
+++ b/test/fprime_gds/common/history/testhistory_unit_test.py
@@ -21,10 +21,10 @@ class HistoryTestCases(unittest.TestCase):
         assert len(expected) == len(
             actual
         ), f"the given list should have had the length {len(expected)}, but instead had {len(actual)}"
-        for i in range(len(expected)):
+        for i, item in enumerate(expected):
             assert (
-                expected[i] == actual[i]
-            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
+                item == actual[i]
+            ), f"the {i} element of the expected list should be {item}, but was {actual[i]}."
 
     def test_push_and_retrieve(self):
         tList = []

--- a/test/fprime_gds/common/testing_fw/api_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/api_unit_test.py
@@ -126,10 +126,10 @@ class APITestCases(unittest.TestCase):
         ), "the given list should have had the length {}, but instead had {}\nExpected {}\nActual{}".format(
             len(expected), len(actual), expected, actual
         )
-        for i in range(len(expected)):
+        for i, item in enumerate(expected):
             assert (
-                expected[i] == actual[i]
-            ), f"the {i} element of the expected list should be {expected[i]}, but was {actual[i]}."
+                item == actual[i]
+            ), f"the {i} element of the expected list should be {item}, but was {actual[i]}."
     
     def get_counter_sequence(self, length):
         seq = []
@@ -717,9 +717,9 @@ class APITestCases(unittest.TestCase):
         results = self.api.await_telemetry_sequence(search_seq)
 
         assert len(results) == len(search_seq), "lists should have the same length"
-        for i in range(len(results)):
-            msg = predicates.get_descriptive_string(results[i], search_seq[i])
-            assert search_seq[i](results[i]), msg
+        for i, item in enumerate(results):
+            msg = predicates.get_descriptive_string(item, search_seq[i])
+            assert search_seq[i](item), msg
 
         t1.join()
         t2.join()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to switch from `range(len(...))` to `enumerate(...)` to access the counter and the value from the iterables at the same time.

## Rationale

It is not Pythonic to use `range(len(...))`. Index based loops do not exist in Python, it uses collection iterators instead.

Python includes an `enumerate` method to add a counter to an iterator. This method allows you to access both the counter and the value of the iterator at the same time. It is therefore recommended to replace `range(len(...))` with `enumerate(...)`.

## Testing/Review Recommendations

void

## Future Work

void
