### PR TITLE
Merge several nested `if` conditions into one

### DIFF
--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -49,9 +49,8 @@ def is_predicate(pred):
     if callable(pred):
         sig = signature(pred.__call__)
         arg_count = len(sig.parameters)
-        if arg_count == 1:
-            if hasattr(pred, "__str__"):
-                return True
+        if arg_count == 1 and hasattr(pred, "__str__"):
+            return True
     return False
 
 
@@ -538,10 +537,12 @@ class telemetry_predicate(predicate):
         """
         if not isinstance(telemetry, ChData):
             return False
-        if self.id_pred(telemetry.get_id()):
-            if self.value_pred(telemetry.get_val()):
-                if self.time_pred(telemetry.get_time()):
-                    return True
+        if (
+            self.id_pred(telemetry.get_id())
+            and self.value_pred(telemetry.get_val())
+            and self.time_pred(telemetry.get_time())
+        ):
+            return True
         return False
 
     def __str__(self):

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -191,10 +191,10 @@ def config_for_set(uset, app, defaults=None):
     if defaults is None:
         defaults = dict(dest=None, url=None)
 
-    allow_extns = tuple(config.get(prefix + "ALLOW", ()))
-    deny_extns = tuple(config.get(prefix + "DENY", ()))
-    destination = config.get(prefix + "DEST")
-    base_url = config.get(prefix + "URL")
+    allow_extns = tuple(config.get(f"{prefix}ALLOW", ()))
+    deny_extns = tuple(config.get(f"{prefix}DENY", ()))
+    destination = config.get(f"{prefix}DEST")
+    base_url = config.get(f"{prefix}URL")
 
     if destination is None and uset.default_dest:
         # use the "default_dest" callable

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -196,18 +196,15 @@ def config_for_set(uset, app, defaults=None):
     destination = config.get(prefix + "DEST")
     base_url = config.get(prefix + "URL")
 
-    if destination is None:
-        # the upload set's destination wasn't given
-        if uset.default_dest:
-            # use the "default_dest" callable
-            destination = uset.default_dest(app)
-        if destination is None:  # still
-            # use the default dest from the config
-            if defaults["dest"] is not None:
-                using_defaults = True
-                destination = os.path.join(defaults["dest"], uset.name)
-            else:
-                 raise RuntimeError(f"no destination for set {uset.name}")
+    if destination is None and uset.default_dest:
+        # use the "default_dest" callable
+        destination = uset.default_dest(app)
+    if destination is None:  # still
+        if defaults["dest"] is None:
+            raise RuntimeError(f"no destination for set {uset.name}")
+
+        using_defaults = True
+        destination = os.path.join(defaults["dest"], uset.name)
 
     if base_url is None and using_defaults and defaults["url"]:
         base_url = addslash(defaults["url"]) + uset.name + "/"

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -191,20 +191,23 @@ def config_for_set(uset, app, defaults=None):
     if defaults is None:
         defaults = dict(dest=None, url=None)
 
-    allow_extns = tuple(config.get(f"{prefix}ALLOW", ()))
-    deny_extns = tuple(config.get(f"{prefix}DENY", ()))
-    destination = config.get(f"{prefix}DEST")
-    base_url = config.get(f"{prefix}URL")
+    allow_extns = tuple(config.get(prefix + "ALLOW", ()))
+    deny_extns = tuple(config.get(prefix + "DENY", ()))
+    destination = config.get(prefix + "DEST")
+    base_url = config.get(prefix + "URL")
 
-    if destination is None and uset.default_dest:
-        # use the "default_dest" callable
-        destination = uset.default_dest(app)
-    if destination is None:  # still
-        if defaults["dest"] is None:
-            raise RuntimeError(f"no destination for set {uset.name}")
-
-        using_defaults = True
-        destination = os.path.join(defaults["dest"], uset.name)
+    if destination is None:
+        # the upload set's destination wasn't given
+        if uset.default_dest:
+            # use the "default_dest" callable
+            destination = uset.default_dest(app)
+        if destination is None:  # still
+            # use the default dest from the config
+            if defaults["dest"] is not None:
+                using_defaults = True
+                destination = os.path.join(defaults["dest"], uset.name)
+            else:
+                raise RuntimeError(f"no destination for set {uset.name}")
 
     if base_url is None and using_defaults and defaults["url"]:
         base_url = addslash(defaults["url"]) + uset.name + "/"

--- a/test/fprime_gds/common/testing_fw/api_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/api_unit_test.py
@@ -108,9 +108,8 @@ class APITestCases(unittest.TestCase):
         for item in items:
             if timestep:
                 time.sleep(timestep)
-            if isinstance(item, ChData) or isinstance(item, EventData):
-                if item.time == 0:
-                    item.time = self.t0 + time.time()
+            if isinstance(item, (ChData, EventData)) and item.time == 0:
+                item.time = self.t0 + time.time()
             callback(item)
 
     def fill_history_async(self, callback, items, timestep=1.0):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to merge several nested `if` conditions into one.

misc: use f-string instead of string concatenation x4

## Rationale

Too much nesting can make code difficult to understand, especially in Python, where there are no parentheses to help distinguish levels of nesting.

Reading deeply nested code is difficult because you have to understand which conditions refer to which levels. Therefore, we should try to avoid nesting as much as possible, and the situation where two `if` conditions can be combined using `and` is a straightforward win.

## Testing/Review Recommendations

void

## Future Work

void
