### PR TITLE
Refactor `convert()` function from `string_util.py`

### DIFF
--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -42,35 +42,31 @@ def format_string_template(format_str, given_values):
     """
 
     def convert(match_obj, ignore_int):
-        if match_obj.group() is not None:
-            flags, width, precision, length, conversion_type = match_obj.groups()
-            format_template = ""
-            if flags:
-                format_template += f"{flags}"
-            if width:
-                format_template += f"{width}"
-            if precision:
-                format_template += f"{precision}"
+        if match_obj.group() is None:
+            return match_obj
+        flags, width, precision, length, conversion_type = match_obj.groups()
+        format_template = ""
+        if flags:
+            format_template += f"{flags}"
+        if width:
+            format_template += f"{width}"
+        if precision:
+            format_template += f"{precision}"
 
-            if conversion_type:
-                if any(
-                    [
-                        str(conversion_type).lower() == "f",
-                        str(conversion_type).lower() == "x",
-                        str(conversion_type).lower() == "o",
-                        str(conversion_type).lower() == "e",
-                    ]
-                ):
-                    format_template += f"{conversion_type}"
-                elif all([not ignore_int, str(conversion_type).lower() == "d"]):
-                    format_template += f"{conversion_type}"
+        if conversion_type:
+            if any(
+                [
+                    str(conversion_type).lower() == "f",
+                    str(conversion_type).lower() == "x",
+                    str(conversion_type).lower() == "o",
+                    str(conversion_type).lower() == "e",
+                ]
+            ):
+                format_template += f"{conversion_type}"
+            elif all([not ignore_int, str(conversion_type).lower() == "d"]):
+                format_template += f"{conversion_type}"
 
-            if format_template == "":
-                template = "{}"
-            else:
-                template = "{:" + format_template + "}"
-            return template
-        return match_obj
+        return "{}" if format_template == "" else "{:" + format_template + "}"
 
     def convert_include_all(match_obj):
         return convert(match_obj, ignore_int=False)

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -15,10 +15,7 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
-if PY3:
-    string_types = (str,)
-else:
-    string_types = (basestring,)
+string_types = (str, ) if PY3 else (basestring, )
 
 import os.path
 import posixpath

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -15,7 +15,10 @@ import sys
 
 PY3 = sys.version_info[0] == 3
 
-string_types = (str, ) if PY3 else (basestring, )
+if PY3:
+    string_types = (str,)
+else:
+    string_types = (basestring,)
 
 import os.path
 import posixpath

--- a/src/fprime_gds/flask/json.py
+++ b/src/fprime_gds/flask/json.py
@@ -108,7 +108,7 @@ def minimal_channel(obj):
     """
     jsonable = {"time": obj.time, "id": obj.id, "val": obj.val_obj.val}
     if hasattr(obj, "display_text"):
-        jsonable.update({"display_text": obj.display_text})
+        jsonable["display_text"] = obj.display_text
     return jsonable
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to
- refactor the `convert` function of `string_util.py` 
- replace conditional assignment to a variable with an `if` expression
- add single value to `dictionary` rather than using `update()`.

misc: use f-string instead of string concatenation x4

## Rationale

- Swap the `if /else` statements to stop reading the function as soon as possible
- Remove the unnecessary `else` statement to limit nested statements
- list comprehension to run faster than building the collection in a loop and in one line.
--
- Python's conditional expression syntax is its version of the ternary operator. Thus, there is only one statement where `x` is defined, instead of having to read two statements plus the `if-else` lines.
--
- Eliminate the overhead of building another dictionary and calling a method.

## Testing/Review Recommendations

void

## Future Work

void
