### PR TITLE
lestarch: fixing fprime-gds for compliance with v3.1.1 of fprime-tools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ integrated configuration with ground in-the-loop.
         "pexpect>=4.8.0, <5.0.0",
         "pytest>=6.2.4, <7.0.0",
         "flask_restful>=0.3.8, <1.0.0",
-        "fprime-tools>=3.1.1", # Devel version until release
+        "fprime-tools>=3.1.1",
         "argcomplete>=1.12.3, <2.0.0",
         "Jinja2>=2.11.3, <3.0.0",
     ],

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ integrated configuration with ground in-the-loop.
         "pexpect>=4.8.0, <5.0.0",
         "pytest>=6.2.4, <7.0.0",
         "flask_restful>=0.3.8, <1.0.0",
-        "fprime-tools>=3.1.0a1", # Devel version until release
+        "fprime-tools>=3.1.1", # Devel version until release
         "argcomplete>=1.12.3, <2.0.0",
         "Jinja2>=2.11.3, <3.0.0",
     ],

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -138,11 +138,11 @@ def get_artifacts_root() -> Path:
     except FprimeSettingsException as e:
         print("[ERROR]", e)
         sys.exit(-1)
-    assert "install_dest" in ini_settings, "install_dest not in settings.ini"
+    assert "install_destination" in ini_settings, "install_destination not in settings.ini"
     print(
-        f"""[INFO] Autodetected artifacts root '{ini_settings["install_dest"]}' from deployment settings.ini file."""
+        f"""[INFO] Autodetected artifacts root '{ini_settings["install_destination"]}' from deployment settings.ini file."""
     )
-    return ini_settings["install_dest"]
+    return ini_settings["install_destination"]
 
 
 def find_app(root: Path) -> Path:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

F´ tools v3.1.1 changes "install_dest" to "install_destination".  This bumps fprime-gds into compliance there.