### PR TITLE
Refactor `telemetry_predicate.__call__` to save mental load

### DIFF
--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -535,15 +535,17 @@ class telemetry_predicate(predicate):
         Args:
             telemetry: an instance of ChData (object)
         """
-        if not isinstance(telemetry, ChData):
-            return False
-        if (
-            self.id_pred(telemetry.get_id())
-            and self.value_pred(telemetry.get_val())
-            and self.time_pred(telemetry.get_time())
-        ):
-            return True
-        return False
+        return (
+            bool(
+                (
+                    self.id_pred(telemetry.get_id())
+                    and self.value_pred(telemetry.get_val())
+                    and self.time_pred(telemetry.get_time())
+                )
+            )
+            if isinstance(telemetry, ChData)
+            else False
+        )
 
     def __str__(self):
         """

--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -536,16 +536,10 @@ class telemetry_predicate(predicate):
             telemetry: an instance of ChData (object)
         """
         return (
-            bool(
-                (
-                    self.id_pred(telemetry.get_id())
-                    and self.value_pred(telemetry.get_val())
-                    and self.time_pred(telemetry.get_time())
-                )
-            )
-            if isinstance(telemetry, ChData)
-            else False
-        )
+            isinstance(telemetry, ChData)
+            and self.id_pred(telemetry.get_id())
+            and self.value_pred(telemetry.get_val())
+            and self.time_pred(telemetry.get_time())
 
     def __str__(self):
         """

--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -1,4 +1,4 @@
-"""f
+"""
 predicates.py:
 
 This file contains basic predicates as well as event and telemetry predicates used by the

--- a/src/fprime_gds/common/testing_fw/predicates.py
+++ b/src/fprime_gds/common/testing_fw/predicates.py
@@ -1,4 +1,4 @@
-"""
+"""f
 predicates.py:
 
 This file contains basic predicates as well as event and telemetry predicates used by the
@@ -539,7 +539,7 @@ class telemetry_predicate(predicate):
             isinstance(telemetry, ChData)
             and self.id_pred(telemetry.get_id())
             and self.value_pred(telemetry.get_val())
-            and self.time_pred(telemetry.get_time())
+            and self.time_pred(telemetry.get_time()))
 
     def __str__(self):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| void |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to
- refactor the `telemetry_predicate.__call__` function of `predicated.py` with boolean `if` expression identity.

## Rationale

- Instead of using an if expression to evaluate a boolean, you can simply use it directly. This is shorter and clearer. Indeed if-expressions of this form take some time to be mentally analyzed.

## Testing/Review Recommendations

void

## Future Work

void
