### PR TITLE
Pass repeated condition to own statement

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -18,11 +18,10 @@ import re
 import sys
 
 import fprime_gds.common.communication.adapters.base
-import fprime_gds.common.communication.checksum
-import fprime_gds.common.logger
-
 # Include basic adapters
 import fprime_gds.common.communication.adapters.ip
+import fprime_gds.common.communication.checksum
+import fprime_gds.common.logger
 import fprime_gds.common.utils.config_manager
 
 try:

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -501,10 +501,11 @@ class GdsParser(ParserBase):
 
         # Handle configuration arguments
         config = fprime_gds.common.utils.config_manager.ConfigManager()
-        if args.config is not None and os.path.isfile(args.config):
-            config.set_configs(args.config)
-        elif args.config is not None:
-            raise ValueError(f"Configuration file {args.config} not found")
+        if args.config is not None:
+            if os.path.isfile(args.config):
+                config.set_configs(args.config)
+            else:
+                raise ValueError(f"Configuration file {args.config} not found")
         args.config = config
         return args
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -291,10 +291,11 @@ def main():
         launchers.append(launch_comm)
 
     # Add app, if possible
-    if settings.get("app", None) is not None and settings.get("adapter", "") == "ip":
-        launchers.append(launch_app)
-    elif settings.get("app", None) is not None:
-        print("[WARNING] App cannot be auto-launched without IP adapter")
+    if settings.get("app", None) is not None:
+        if settings.get("adapter", "") == "ip":
+            launchers.append(launch_app)
+        else:
+            print("[WARNING] App cannot be auto-launched without IP adapter")
 
     # Launch the desired GUI package
     gui = settings.get("gui", "none")

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -4,8 +4,8 @@
 # Runs a deployment. Starts a GUI, a TCPServer, and the deployment application.
 ####
 import os
-import sys
 import platform
+import sys
 import webbrowser
 from pathlib import Path
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| None  |
|**_Affected Architectures(s)_**| None  |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to pass repeated conditions to their own `if` instruction.

## Rationale

Duplicating conditions in an `if/elseif` statement makes things more difficult to read and causes code duplication issues.

Although this increases the number of nested `if` statements, it improves the understanding of the code at first glance.

P.S. I took the opportunity to run `isort` on the two files I modified

## Testing/Review Recommendations

None

## Future Work

None
