### PR TITLE
Avoid loading the entire log files into memory

### DIFF
--- a/src/fprime_gds/common/files/downlinker.py
+++ b/src/fprime_gds/common/files/downlinker.py
@@ -114,7 +114,6 @@ class FileDownlinker(fprime_gds.common.handlers.DataHandler):
         """
         # Initialize all relevant DATA packet attributes into variables from file_data
         offset = data.offset
-        data_bytes = data.dataVar
         if self.state != FileStates.RUNNING:
             LOGGER.warning("Received unexpected data packet for offset: %d", offset)
         else:
@@ -124,6 +123,7 @@ class FileDownlinker(fprime_gds.common.handlers.DataHandler):
                     self.sequence,
                     data.seqID,
                 )
+            data_bytes = data.dataVar
             # Write the data information to the file
             self.active.write(data_bytes, offset)
             self.active.seek = offset + len(data_bytes)

--- a/src/fprime_gds/common/loaders/dict_loader.py
+++ b/src/fprime_gds/common/loaders/dict_loader.py
@@ -112,4 +112,4 @@ class DictLoader:
             for both should be data_template classes. This base class only
             returns empty dictionaries.
         """
-        return dict(), dict(), ("unknown", "unknown")
+        return {}, {}, ("unknown", "unknown")

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -89,7 +89,7 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
         try:
             if logfile is not None:
                 with open(logfile) as file_handle:
-                    for line in file_handle.readlines():
+                    for line in file_handle:
                         print(f"    [LOG] {line.strip()}", file=sys.stderr)
         except Exception:
             pass

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -254,9 +254,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
         FSW receives commands of various lengths.
         """
         data = b""
-        if header == b"List":
-            return b""
-        elif header == b"Quit":
+        if header in [b"List", b"Quit"]:
             return b""
         dst = header.split(b" ")[1].strip(b" ")
         if dst == b"FSW":

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -221,9 +221,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             except OSError as err:
                 if err.errno == errno.ECONNRESET:
                     print(
-                        "Socket error "
-                        + str(err.errno)
-                        + " (Connection reset by peer) occurred on recv()."
+                        f"Socket error {str(err.errno)} (Connection reset by peer) occurred on recv()."
                     )
                 else:
                     print(f"Socket error {str(err.errno)} occurred on recv().")
@@ -237,11 +235,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
         header = self.recv(5)
 
         if len(header) == 0:
-            print(
-                "Header information is empty, client "
-                + self.name.decode(DATA_ENCODING)
-                + " exiting."
-            )
+            print(f"Header information is empty, client {self.name.decode(DATA_ENCODING)} exiting.")
             return header
         if header == b"List\n":
             return b"List"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to use the built-in file iterator rather than calling `readlines()` to read the log files.

PS: I've fixed some other small issues that I felt didn't deserve to be put in a dedicated PR.

## Rationale

It is preferable to do it this way because the `file` object returned by Python when opening a file is a lazy iterator over the lines in that file.

This means that it is not necessary to use `readlines()` to loop through the file. Using built-in iteration is shorter and does not load the entire file into memory with a list object, as `readlines()` does, which can be more efficient.

## Testing/Review Recommendations

[Ref1](https://stackoverflow.com/questions/4533884/is-using-readlines-in-python-bad-code)
[Ref2](https://docs.sourcery.ai/Reference/Built-in-Rules/refactorings/use-file-iterator/)

## Future Work

None
