### PR TITLE
Refactor unneeded `else` / `elif` when the `if` block has a `break`/`continue`/`return`/`raise` statement

### DIFF
--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -174,11 +174,10 @@ class FpFramerDeframer(FramerDeframer):
                 ):
                     data = data[total_size:]
                     return deframed, data
-                else:
-                    print(
-                        "[WARNING] Checksum validation failed. Have you correctly set '--comm-checksum-type'",
-                        file=sys.stderr,
-                    )
+                print(
+                    "[WARNING] Checksum validation failed. Have you correctly set '--comm-checksum-type'",
+                    file=sys.stderr,
+                )
                 # Bad checksum, rotate 1 and keep looking for non-garbage
                 data = data[1:]
                 continue

--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -164,7 +164,7 @@ class FpFramerDeframer(FramerDeframer):
                 data = data[1:]
                 continue
             # If the pool is large enough to read the whole frame, then read it
-            elif len(data) >= total_size:
+            if len(data) >= total_size:
                 deframed, check = struct.unpack_from(
                     f">{data_size}sI", data, FpFramerDeframer.HEADER_SIZE
                 )

--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -128,25 +128,12 @@ class ChData(sys_data.SysData):
             ch_val = str(self.val_obj.val)
 
         if verbose and csv:
-            return "%s,%s,%s,%d,%s" % (
-                time_str_nice,
-                raw_time_str,
-                ch_name,
-                self.id,
-                ch_val,
-            )
-        elif verbose and not csv:
-            return "%s: %s (%d) %s %s" % (
-                time_str_nice,
-                ch_name,
-                self.id,
-                raw_time_str,
-                ch_val,
-            )
-        elif not verbose and csv:
+            return f"{time_str_nice},{raw_time_str},{ch_name},{self.id},{ch_val}"
+        if verbose and not csv:
+            return f"{time_str_nice}: {ch_name} ({self.id}) {raw_time_str} {ch_val}"
+        if not verbose and csv:
             return f"{time_str_nice},{ch_name},{ch_val}"
-        else:
-            return f"{time_str_nice}: {ch_name} = {ch_val}"
+        return f"{time_str_nice}: {ch_name} = {ch_val}"
 
     def get_val_str(self):
 
@@ -156,10 +143,9 @@ class ChData(sys_data.SysData):
         fmt_str = self.template.get_format_str()
         if self.val_obj is None:
             return ""
-        elif fmt_str:
+        if fmt_str:
             return fmt_str % (self.val_obj.val)
-        else:
-            return str(self.val_obj.val)
+        return str(self.val_obj.val)
 
     def __str__(self):
         """

--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -133,19 +133,12 @@ class CmdData(sys_data.SysData):
             arg_str = " ".join(str(arg_val_list))
 
         if verbose and csv:
-            return "%s,%s,%s,%d,%s" % (time_str, raw_time_str, name, self.id, arg_str)
-        elif verbose and not csv:
-            return "%s: %s (%d) %s : %s" % (
-                time_str,
-                name,
-                self.id,
-                raw_time_str,
-                arg_str,
-            )
-        elif not verbose and csv:
+            return f"{time_str},{raw_time_str},{name},{self.id},{arg_str}"
+        if verbose and not csv:
+            return f"{time_str}: {name} ({self.id}) {raw_time_str} : {arg_str}"
+        if not verbose and csv:
             return f"{time_str},{name},{arg_str}"
-        else:
-            return f"{time_str}: {name} : {arg_str}"
+        return f"{time_str}: {name} : {arg_str}"
 
     def process_args(self, input_values):
         """ Process input arguments """

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -73,8 +73,7 @@ class EventData(sys_data.SysData):
         """
         if verbose:
             return "Time,Raw Time,Name,ID,Severity,Args\n"
-        else:
-            return "Time,Name,Severity,Args\n"
+        return "Time,Name,Severity,Args\n"
 
     def get_str(self, time_zone=None, verbose=False, csv=False):
         """
@@ -107,12 +106,11 @@ class EventData(sys_data.SysData):
 
         if verbose and csv:
             return f"{time_str},{raw_time_str},{name},{self.id},{severity},{arg_str}"
-        elif verbose and not csv:
+        if verbose and not csv:
             return f"{time_str}: {name} ({self.id}) {raw_time_str} {severity} : {arg_str}"
-        elif not verbose and csv:
+        if not verbose and csv:
             return f"{time_str},{name},{severity},{arg_str}"
-        else:
-            return f"{time_str}: {name} {severity} : {arg_str}"
+        return f"{time_str}: {name} {severity} : {arg_str}"
 
     def __str__(self):
         """

--- a/src/fprime_gds/common/decoders/file_decoder.py
+++ b/src/fprime_gds/common/decoders/file_decoder.py
@@ -50,14 +50,14 @@ class FileDecoder(decoder.Decoder):
             (destPathSize,) = struct.unpack_from(">B", data, sourcePathSize + 10)
             destPath = data[sourcePathSize + 11 : sourcePathSize + destPathSize + 11]
             return [file_data.StartPacketData(seqID, fileSize, sourcePath, destPath),]
-        elif packetType == "DATA":  # Packet Type is DATA
+        if packetType == "DATA":  # Packet Type is DATA
             offset, length = struct.unpack_from(">IH", data, 5)
             dataVar = data[11 : 11 + length]
             return [file_data.DataPacketData(seqID, offset, dataVar),]
-        elif packetType == "END":  # Packet Type is END
+        if packetType == "END":  # Packet Type is END
             hashValue = struct.unpack_from(">I", data, 5)
             return [file_data.EndPacketData(seqID, hashValue),]
-        elif packetType == "CANCEL":  # Packet Type is CANCEL
+        if packetType == "CANCEL":  # Packet Type is CANCEL
             # CANCEL Packets have no data
             return [file_data.CancelPacketData(seqID),]
         # The data was not determined to be any of the packet types so return none

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -90,7 +90,7 @@ class UplinkQueue:
             while found != first:
                 if found.source == source:
                     break
-                elif first is None:
+                if first is None:
                     first = found
             self.queue.put_nowait(found)
             found = self.queue.get_nowait()

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -272,7 +272,7 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
             self.queue.busy.release()  # Allow the queue to continue
             self.__timeout.stop()
             return
-        elif self.state == FileStates.CANCELED:
+        if self.state == FileStates.CANCELED:
             self.send(CancelPacketData(self.get_next_sequence()))
             self.finish()
             return

--- a/src/fprime_gds/common/history/chrono.py
+++ b/src/fprime_gds/common/history/chrono.py
@@ -85,10 +85,9 @@ class ChronologicalHistory(History):
         if repeats:
             self.new_objects.clear()
             return self.objects[index:]
-        else:
-            new = self.new_objects
-            self.new_objects = []
-            return new
+        new = self.new_objects
+        self.new_objects = []
+        return new
 
     def clear(self, start=None):
         """
@@ -197,10 +196,9 @@ class ChronologicalHistory(History):
             while index < len(ordered) and not start(ordered[index]):
                 index += 1
             return index
-        elif isinstance(start, TimeType):
+        if isinstance(start, TimeType):
             index = 0
             while index < len(ordered) and ordered[index].get_time() < start:
                 index += 1
             return index
-        else:
-            return start
+        return start

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -353,53 +353,52 @@ class XmlLoader(dict_loader.DictLoader):
 
         if type_name == "I8":
             return I8Type
-        elif type_name == "I16":
+        if type_name == "I16":
             return I16Type
-        elif type_name == "I32":
+        if type_name == "I32":
             return I32Type
-        elif type_name == "I64":
+        if type_name == "I64":
             return I64Type
-        elif type_name == "U8":
+        if type_name == "U8":
             return U8Type
-        elif type_name == "U16":
+        if type_name == "U16":
             return U16Type
-        elif type_name == "U32":
+        if type_name == "U32":
             return U32Type
-        elif type_name == "U64":
+        if type_name == "U64":
             return U64Type
-        elif type_name == "F32":
+        if type_name == "F32":
             return F32Type
-        elif type_name == "F64":
+        if type_name == "F64":
             return F64Type
-        elif type_name == "bool":
+        if type_name == "bool":
             return BoolType
-        elif type_name == "string":
+        if type_name == "string":
             if self.STR_LEN_TAG not in xml_item.attrib:
                 print(f"Trying to parse string type, but found {self.STR_LEN_TAG} field")
                 return None
             max_length = int(xml_item.get(self.STR_LEN_TAG, 0))
             name = f"{context or ''}::{xml_item.get(self.ARG_NAME_TAG)}String"
             return StringType.construct_type(name, max_length)
-        else:
-            # First try Serialized types:
-            result = self.get_serializable_type(type_name, xml_tree)
-            if result is not None:
-                return result
+        # First try Serialized types:
+        result = self.get_serializable_type(type_name, xml_tree)
+        if result is not None:
+            return result
 
-            # Now try enums:
-            result = self.get_enum_type(type_name, xml_tree)
-            if result is not None:
-                return result
+        # Now try enums:
+        result = self.get_enum_type(type_name, xml_tree)
+        if result is not None:
+            return result
 
-            # Now try arrays:
-            result = self.get_array_type(type_name, xml_tree)
-            if result is not None:
-                return result
+        # Now try arrays:
+        result = self.get_array_type(type_name, xml_tree)
+        if result is not None:
+            return result
 
-            # Abandon all hope
-            raise exceptions.GseControllerParsingException(
-                f"Could not find type {type_name}"
-            )
+        # Abandon all hope
+        raise exceptions.GseControllerParsingException(
+            f"Could not find type {type_name}"
+        )
 
 
 class UnsupportedDictionaryVersionException(Exception):

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -370,8 +370,7 @@ class IntegrationTestAPI(DataHandler):
         self.send_command(command, args)
         if isinstance(channels, list):
             return self.await_telemetry_sequence(channels, start=start, timeout=timeout)
-        else:
-            return self.await_telemetry(channels, start=start, timeout=timeout)
+        return self.await_telemetry(channels, start=start, timeout=timeout)
 
     def send_and_await_event(self, command, args=None, events=None, timeout=5):
         """
@@ -398,8 +397,7 @@ class IntegrationTestAPI(DataHandler):
         self.send_command(command, args)
         if isinstance(events, list):
             return self.await_event_sequence(events, start=start, timeout=timeout)
-        else:
-            return self.await_event(events, start=start, timeout=timeout)
+        return self.await_event(events, start=start, timeout=timeout)
 
     ######################################################################################
     #   Command Asserts
@@ -431,8 +429,7 @@ class IntegrationTestAPI(DataHandler):
             return self.assert_telemetry_sequence(
                 channels, start=start, timeout=timeout
             )
-        else:
-            return self.assert_telemetry(channels, start=start, timeout=timeout)
+        return self.assert_telemetry(channels, start=start, timeout=timeout)
 
     def send_and_assert_event(self, command, args=None, events=None, timeout=5):
         """
@@ -458,8 +455,7 @@ class IntegrationTestAPI(DataHandler):
         self.send_command(command, args)
         if isinstance(events, list):
             return self.assert_event_sequence(events, start=start, timeout=timeout)
-        else:
-            return self.assert_event(events, start=start, timeout=timeout)
+        return self.assert_event(events, start=start, timeout=timeout)
 
     ######################################################################################
     #   Telemetry Functions
@@ -481,17 +477,16 @@ class IntegrationTestAPI(DataHandler):
             matching = [ch_dict[name].get_id() for name in ch_dict.keys() if name.endswith(f".{channel}")] 
             if channel in ch_dict:
                 return ch_dict[channel].get_id()
-            elif force_component or not matching:
+            if force_component or not matching:
                 msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
                 raise KeyError(msg)
-            else:
-                return matching
-        else:
-            ch_dict = self.pipeline.dictionaries.channel_id
-            if channel in ch_dict:
-                return channel
-            msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
-            raise KeyError(msg)
+            return matching
+        
+        ch_dict = self.pipeline.dictionaries.channel_id
+        if channel in ch_dict:
+            return channel
+        msg = f"The telemetry mnemonic, {channel}, wasn't in the dictionary"
+        raise KeyError(msg)
 
     def get_telemetry_pred(self, channel=None, value=None, time_pred=None):
         """
@@ -703,17 +698,16 @@ class IntegrationTestAPI(DataHandler):
             matching = [event_dict[name].get_id() for name in event_dict.keys() if name.endswith(f".{event}")] 
             if event in event_dict:
                 return event_dict[event].get_id()
-            elif force_component or not matching:
+            if force_component or not matching:
                 msg = f"The event mnemonic, {event}, wasn't in the dictionary"
                 raise KeyError(msg)
-            else:
-                return matching
-        else:
-            event_dict = self.pipeline.dictionaries.event_id
-            if event in event_dict:
-                return event
-            msg = f"The event id, {event}, wasn't in the dictionary"
-            raise KeyError(msg)
+            return matching
+
+        event_dict = self.pipeline.dictionaries.event_id
+        if event in event_dict:
+            return event
+        msg = f"The event id, {event}, wasn't in the dictionary"
+        raise KeyError(msg)
 
     def get_event_pred(self, event=None, args=None, severity=None, time_pred=None):
         """
@@ -1244,14 +1238,13 @@ class IntegrationTestAPI(DataHandler):
             if not expect:
                 assert True, pred_msg
             return True
+        ast_msg = f"{name} failed: {msg}\nassert {pred_msg}"
+        if not expect:
+            self.__log(ast_msg, TestLogger.RED)
+            assert False, pred_msg
         else:
-            ast_msg = f"{name} failed: {msg}\nassert {pred_msg}"
-            if not expect:
-                self.__log(ast_msg, TestLogger.RED)
-                assert False, pred_msg
-            else:
-                self.__log(ast_msg, TestLogger.ORANGE)
-            return False
+            self.__log(ast_msg, TestLogger.ORANGE)
+        return False
 
     def data_callback(self, data, sender=None):
         """

--- a/src/fprime_gds/common/utils/config_manager.py
+++ b/src/fprime_gds/common/utils/config_manager.py
@@ -110,28 +110,27 @@ class ConfigManager(configparser.ConfigParser):
 
         if type_str == "U8":
             return U8Type()
-        elif type_str == "U16":
+        if type_str == "U16":
             return U16Type()
-        elif type_str == "U32":
+        if type_str == "U32":
             return U32Type()
-        elif type_str == "u64":
+        if type_str == "u64":
             return U64Type()
-        elif type_str == "I8":
+        if type_str == "I8":
             return I8Type()
-        elif type_str == "I16":
+        if type_str == "I16":
             return I16Type()
-        elif type_str == "I32":
+        if type_str == "I32":
             return I32Type()
-        elif type_str == "I64":
+        if type_str == "I64":
             return I64Type()
-        elif type_str == "F32":
+        if type_str == "F32":
             return F32Type()
-        elif type_str == "F64":
+        if type_str == "F64":
             return F64Type()
-        else:
-            # These are types for parsing, so they need to be number types
-            # Other types can be added later
-            raise ConfigBadTypeException(name, type_str)
+        # These are types for parsing, so they need to be number types
+        # Other types can be added later
+        raise ConfigBadTypeException(name, type_str)
 
     def get_file_path(self):
         """

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -178,7 +178,7 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             if not header:
                 break
 
-            elif header == b"Quit":
+            if header == b"Quit":
                 LOCK.acquire()
                 print("Quit received!")
                 SERVER.dest_obj[self.name].put(struct.pack(">I", 0xA5A5A5A5))

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -84,19 +84,18 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             print("Client exited.")
             return
 
+        # Process the data into the cmdQueue
+        self.getCmds(data)
+
+        # Process the cmdQueue
+        self.processQueue()
+
+        if self.registered:
+            print("Registration complete waiting for message.")
+            self.getNewMsg()
         else:
-            # Process the data into the cmdQueue
-            self.getCmds(data)
-
-            # Process the cmdQueue
-            self.processQueue()
-
-            if self.registered:
-                print("Registration complete waiting for message.")
-                self.getNewMsg()
-            else:
-                print("Unable to register client.")
-                return
+            print("Unable to register client.")
+            return
 
         LOCK.acquire()
         del SERVER.dest_obj[self.name]
@@ -237,13 +236,12 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             return header
         if header == b"List\n":
             return b"List"
-        elif header == b"Quit\n":
+        if header == b"Quit\n":
             return b"Quit"
-        elif header[:-1] == b"A5A5":
+        if header[:-1] == b"A5A5":
             header2 = self.recv(4)
             return header + header2
-        else:
-            return
+        return
 
     def readData(self, header):
         """

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -374,8 +374,7 @@ class UploadSet(object):
                 filename=filename,
                 _external=True,
             )
-        else:
-            return base + filename
+        return base + filename
 
     def path(self, filename, folder=None):
         """

--- a/src/fprime_gds/flask/json.py
+++ b/src/fprime_gds/flask/json.py
@@ -179,10 +179,10 @@ class GDSJsonEncoder(flask.json.JSONEncoder):
         """
         if type(obj) in self.JSON_ENCODERS:
             return self.JSON_ENCODERS[type(obj)](obj)
-        elif isinstance(obj, DataTemplate):
+        if isinstance(obj, DataTemplate):
             return getter_based_json(obj)
-        elif isinstance(obj, Enum):
+        if isinstance(obj, Enum):
             return enum_json(obj)
-        elif isinstance(obj, ValueType):
+        if isinstance(obj, ValueType):
             return obj.val
         return flask.json.JSONEncoder.default(self, obj)

--- a/src/fprime_gds/flask/updown.py
+++ b/src/fprime_gds/flask/updown.py
@@ -133,5 +133,4 @@ class FileDownload(flask_restful.Resource):
             return flask.send_from_directory(
                 self.downlinker.directory, os.path.basename(source), as_attachment=True
             )
-        else:
-            return {"files": self.downlinker.current_files()}
+        return {"files": self.downlinker.current_files()}


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| None |
|**_Affected Architectures(s)_**| None |
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| Let CI run |
|**_Unit Tests Pass (y/n)_**| Let CI run |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR aims to refactor unneeded `else` / `elif` when the `if` block has a `break`/`continue`/`return`/`raise` statement.

## Rationale

The use of `else` or `elif` becomes redundant and can be dropped `if` the last statement under the main `if` / `elif` block is a `break`/`continue`/`raise`/`return` statement.

In the case of an `elif` after these statements, it can be written as a separate if block.
For `else` blocks after these statements, the statements can be moved out of the `else`. 

Shuffling the code in this way improves its readability and makes it easier to maintain.

## Testing/Review Recommendations

None

## Future Work

None
