### PR TITLE
Update Github Actions to run on Node 16 instead of Node 12 - Bump to @v3

### DIFF
--- a/.github/workflows/fprime-gds-tests.yml
+++ b/.github/workflows/fprime-gds-tests.yml
@@ -11,7 +11,7 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: "Checkout Repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: Test PyPI


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**| See CI outputs |
|**_Unit Tests Pass (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR updates the NodeJS version of GitHub Actions to [node16](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/), instead of node12.

## Rationale

Node 12 is no longer supported as of [30 Apr 2022](https://endoflife.date/nodejs), as a result, [GitHub has begun](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) the process of deprecating Node 12 for GitHub Actions.

Several of their actions have already migrated, like `checkout`, `upload`/`download-artifacts`.

GitHub asks Actions maintainers to update their actions to work on Node 16 instead of Node 12.

## Testing/Review Recommendations

See if the CI is still on.

## Future Work

None
