### PR TITLE
Update/test api as fixtures

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -6,6 +6,7 @@ abw
 AClass
 ada
 addon
+addoption
 addslash
 ADEBAD
 adrianheine

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ integrated configuration with ground in-the-loop.
             "fprime-cli = fprime_gds.executables.fprime_cli:main",
             "fprime-seqgen = fprime_gds.common.tools.seqgen:main",
         ],
+        "pytest11": ["fprime_test_api = fprime_gds.common.testing_fw.pytest_integration"]
     },
     ####
     # Classifiers:

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -34,7 +34,7 @@ def check_port(address, port):
         socket_trial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         socket_trial.bind((address, port))
     except OSError as err:
-        raise ValueError(f"Error with address/port of '{address}:{port}' : {err}")
+        raise OSError(f"Error with address/port of '{address}:{port}' : {err}")
     finally:
         if socket_trial is not None:
             socket_trial.close()

--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -42,6 +42,7 @@ class StandardPipeline:
         self.distributor = None
         self.client_socket = None
         self.logger = None
+        self.dictionary_path = None
 
         self.__dictionaries = dictionaries.Dictionaries()
         self.__coders = encoding.EncodingDecoding()
@@ -63,11 +64,12 @@ class StandardPipeline:
         :param packet_spec: location of packetized telemetry XML specification.
         """
         assert dictionary is not None and Path(dictionary).is_file(), f"Dictionary {dictionary} does not exist"
+        self.dictionary_path = Path(dictionary)
         # Loads the distributor and client socket
         self.distributor = fprime_gds.common.distributor.distributor.Distributor(config)
         self.client_socket = self.__transport_type()
         # Setup dictionaries encoders and decoders
-        self.dictionaries.load_dictionaries(dictionary, packet_spec)
+        self.dictionaries.load_dictionaries(self.dictionary_path, packet_spec)
         self.coders.setup_coders(
             self.dictionaries, self.distributor, self.client_socket, config
         )

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -36,7 +36,6 @@ class IntegrationTestAPI(DataHandler):
             fsw_order: a flag to determine whether the API histories will maintain FSW time order.
         """
         self.pipeline = pipeline
-        self.fsw_ordered = fsw_order
 
         # these are owned by the GDS and will not be modified by the test API.
         self.aggregate_command_history = pipeline.histories.commands

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -36,6 +36,8 @@ class IntegrationTestAPI(DataHandler):
             fsw_order: a flag to determine whether the API histories will maintain FSW time order.
         """
         self.pipeline = pipeline
+        self.fsw_ordered = fsw_order
+
         # these are owned by the GDS and will not be modified by the test API.
         self.aggregate_command_history = pipeline.histories.commands
         self.aggregate_telemetry_history = pipeline.histories.channels
@@ -63,10 +65,13 @@ class IntegrationTestAPI(DataHandler):
 
         # A predicate used as a filter to choose which events to log automatically
         self.event_log_filter = self.get_event_pred()
-        self.pipeline.coders.register_event_consumer(self)
 
         # Used by the data_callback method to detect if events have been received out of order.
         self.last_evr = None
+
+    def setup(self):
+        """ Set up the API, assumes pipeline is now setup """
+        self.pipeline.coders.register_event_consumer(self)
 
     def teardown(self):
         """
@@ -328,8 +333,6 @@ class IntegrationTestAPI(DataHandler):
             msg = f"The command id, {command}, wasn't in the dictionary"
         raise KeyError(msg)
 
-
-
     def send_command(self, command, args=None):
         """
         Sends the specified command.
@@ -400,6 +403,33 @@ class IntegrationTestAPI(DataHandler):
             return self.await_event_sequence(events, start=start, timeout=timeout)
         else:
             return self.await_event(events, start=start, timeout=timeout)
+
+    def send_and_assert_command(self, command, args=[], max_delay=None, timeout=5, events=None):
+        """
+        This helper will send a command and verify that the command was dispatched and completed
+        within the F' deployment. This helper can retroactively check that the delay between
+        dispatch and completion is less than a maximum allowable delay.
+
+        Args:
+            command: the mnemonic (str) or ID (int) of the command to send
+            args: a list of command arguments.
+            max_delay: the maximum allowable delay between dispatch and completion (int/float)
+            timeout: the number of seconds to wait before terminating the search (int)
+            events: extra event predicates to check between  dispatch and complete
+        Return:
+            returns a list of the EventData objects found by the search
+        """
+        cmd_id = self.translate_command_name(command)
+        dispatch = [self.get_event_pred("cmdDisp.OpCodeDispatched", [cmd_id, None])]
+        complete = [self.get_event_pred("cmdDisp.OpCodeCompleted", [cmd_id])]
+        events = dispatch + (events if events else []) + complete
+        results = self.send_and_assert_event(command, args, events, timeout=timeout)
+        if max_delay is not None:
+            delay = results[1].get_time() - results[0].get_time()
+            msg = f"The delay, {delay}, between the two events should be < {max_delay}"
+            assert delay < max_delay, msg
+        return results
+
 
     ######################################################################################
     #   Command Asserts

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -1,0 +1,115 @@
+""" pytest_integration.py: F´ fixture API fixture
+
+pytest uses fixtures to provide for extra functionality when writing tests. This fixture sets up the F´ stack allowing
+our tests to use a configured test API without needing to create any specific setup to use that API. i.e. write a test
+as follows:
+
+```python
+def test_my_test(fprime_test_api):
+    ''' Perform my test '''
+    fprime_test_api.send_and_assert_command(...)
+```
+
+Here a test (defined by starting the name with test_) uses the fprime_test_api fixture to perform the test.
+
+@author lestarch
+"""
+import sys
+import pytest
+
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+from fprime_gds.executables.cli import StandardPipelineParser
+
+
+SEQUENCE_COUNTER = -1
+
+
+def pytest_addoption(parser):
+    """ Add fprime-gds options to the pytest parser
+
+    Pytest allows users to add options to its parser. These options act very similar to argparse options and thus can be
+    reused from the standard GDS command line processing. Note: pytest restricts the use of short flags (-[a-z]) thus we
+    strip those from the standard cli processing. Long options must be supplied when pytesting.
+
+    Args:
+        parser: pytest style parser. Use "addoption" to add an option to it.
+    """
+    for flags, specifiers in StandardPipelineParser().get_arguments().items():
+        # Reduce flags to only the long option (i.e. --something) form
+        flags = [flag for flag in flags if flag.startswith("--")]
+        parser.addoption(*flags, **specifiers)
+
+
+@pytest.fixture(scope='session')
+def fprime_test_api_session(request):
+    """ Create a session-level fprime test API
+
+    This is a pytest session fixture. Using the options added above, this will parse the necessary options for
+    connecting the standard pipeline to the running GDS. This pipeline is supplied to the fprime test API returned as
+    the result of this fixture. This has several implications:
+      1. APIs all use one connection to the GDS
+      2. APIs and the connections are live across the whole pytest session. See fprime_test_api.
+
+    Note: the implementation uses yield in order to setup the object and tear it down afterwards. This is as-recommended
+    from pytest documentation.
+
+    Args:
+        request: standard pytest-supplied harness used for processing CLI arguments
+
+    Return:
+        fprime test API connected to the GDS.  Note: a second call will shut down that object.
+    """
+    pipeline_parser = StandardPipelineParser()
+    pipeline = None
+    api = None
+    try:
+        # Parse the command line arguments into a client connection
+        arg_ns = pipeline_parser.handle_arguments(request.config.known_args_namespace, client=True)
+
+        # Build a new pipeline with the parsed and processed arguments
+        pipeline = pipeline_parser.pipeline_factory(arg_ns, pipeline)
+
+        # Build and set up the integration test api
+        api = IntegrationTestAPI(pipeline, arg_ns.logs)
+        api.setup()
+
+        # Return the API. Note: the second call here-in will begin after the yield and clean-up after the test
+        yield api
+    # In all cases, whether setup erred or proceeded to the yield, the teardown is now necessary
+    finally:
+        # Attempt to teardown the API to ensure we are clean after the fixture is created
+        try:
+            if api is not None:
+                api.teardown()
+        except Exception as exc:
+            print(f"[WARNING] Exception in API teardown: {exc}", file=sys.stderr)
+        # Attempt to shut down the pipeline connection
+        try:
+            if pipeline is not None:
+                pipeline.disconnect()
+        except Exception as exc:
+            print(f"[WARNING] Exception in pipeline teardown: {exc}", file=sys.stderr)
+
+
+@pytest.fixture(scope='function')
+def fprime_test_api(fprime_test_api_session, request):
+    """ Provide a per-testcase fixture
+
+    Although the test API should exist across all testcases and thus be created at the "session" level, individual test
+    cases need a clean test API that has logged the testcases has started. Thus, the session API is refined into a
+    test case API by performing the test case setup consisting of:
+
+    1. clearing current API history
+    2. logging the test case name
+
+    Args:
+        fprime_test_api_session: session API to adjust for each test case
+        request: pytest supplied request to get test name
+
+    Return:
+        test case specific session (identical to full session)
+    """
+    global SEQUENCE_COUNTER
+    SEQUENCE_COUNTER += 1
+    fprime_test_api_session.start_test_case(request.node.name, SEQUENCE_COUNTER)
+    return fprime_test_api_session

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -29,7 +29,7 @@ def pytest_addoption(parser):
 
     Pytest allows users to add options to its parser. These options act very similar to argparse options and thus can be
     reused from the standard GDS command line processing. Note: pytest restricts the use of short flags (-[a-z]) thus we
-    strip those from the standard cli processing. Long options must be supplied when pytesting.
+    strip those from the standard cli processing. Long options must be supplied when testing using pytest.
 
     Args:
         parser: pytest style parser. Use "addoption" to add an option to it.

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -236,58 +236,6 @@ class CompositeParser(ParserBase):
         return args
 
 
-# class ImportParser(ParserBase):
-#     """
-#     Parser used to import new modules into the F prime namespace. This is how F prime can handle new modules and plugins
-#     by allowing the user to import new Python modules in, which may define new adapters and other items.
-#     """
-#     DESCRIPTION = "Process import arguments allowing for addition of modules"
-#
-#     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
-#         """ Return argument list required to run the import parser
-#
-#         Produce the arguments that can be processed by multiple parsers. i.e. argparse, and pytest parsers are the
-#         intended consumers. Returns dictionary of flag tuples (--flag, -f) to keyword arguments to pass to argparse.
-#
-#         Returns:
-#             dictionary of flag tuple to keyword arguments
-#         """
-#         return {
-#             ("--include", ): {
-#                "action": "append",
-#                "default": [],
-#                "help": "Module name in PYTHONPATH to import. Users may specify multiple --include flags.",
-#             }
-#         }
-#
-#     def handle_arguments(self, args, **kwargs):
-#         """
-#         Handle the import arguments by looping through them and importing each. Errors are printed to the console if an
-#         import failed, but no other effect is realized.
-#
-#         :param args: parsed arguments namespace
-#         :return: args as input, has side effect of new imported modules
-#         """
-#         for module in args.include:
-#             try:
-#                 globals()[module] = importlib.import_module(module)
-#             except ImportError as ime:
-#                 print(
-#                     f"[WARNING] Failed to import '{module}' with error {ime}",
-#                     file=sys.stderr,
-#                 )
-#         return args
-#
-#     @staticmethod
-#     def run_first():
-#         """
-#         Runs this parser once first so that other parsers can benefit from the existing imported libraries. If there is
-#         a problem, the help message will be minimal, but should work.
-#         """
-#         args, _ = ImportParser.get_parser().parse_known_args()
-#         ImportParser.handle_arguments(args)
-
-
 class CommAdapterParser(ParserBase):
     """
     Handles parsing of all of the comm-layer arguments. This means selecting a comm adapter, and passing the arguments

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -51,7 +51,7 @@ GUIS = ["none", "html"]
 
 
 class ParserBase(ABC):
-    """ Base parser for handling fprime commandlines
+    """ Base parser for handling fprime command lines
 
     Parsers must define several functions. They must define "get_parser", which will produce a parser to parse the
     arguments, and an optional "handle_arguments" function to do any necessary processing of the arguments. Note: when
@@ -551,7 +551,7 @@ class StandardPipelineParser(CompositeParser):
 
     @staticmethod
     def pipeline_factory(args_ns, pipeline=None) -> StandardPipeline:
-        """ A factory of the standard pipline given the handled arguments """
+        """ A factory of the standard pipeline given the handled arguments """
         pipeline_arguments = {
             "config": ConfigManager(),
             "dictionary": args_ns.dictionary,

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -7,98 +7,160 @@ code that they are importing.
 
 @author mstarch
 """
-import abc
 import argparse
-import copy
 import datetime
 import errno
-import importlib
+import itertools
 import os
 import re
+import platform
 import sys
 
-import fprime_gds.common.communication.adapters.base
-# Include basic adapters
-import fprime_gds.common.communication.adapters.ip
-import fprime_gds.common.communication.checksum
 import fprime_gds.common.logger
-import fprime_gds.common.utils.config_manager
+# Required to set the checksum as a module variable
+import fprime_gds.common.communication.checksum
 
-try:
-    import fprime_gds.common.communication.adapters.uart
-except ImportError:
-    pass
+from abc import abstractmethod, ABC
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from fprime_gds.common.communication.adapters.base import BaseAdapter
+from fprime_gds.common.communication.adapters.ip import check_port
+from fprime_gds.common.communication.checksum import CHECKSUM_MAPPING, CHECKSUM_SELECTION
+from fprime_gds.common.pipeline.standard import StandardPipeline
+from fprime_gds.common.transport import ThreadedTCPSocketClient
+from fprime_gds.executables.utils import get_artifacts_root, find_dict, find_app
+from fprime_gds.common.utils.config_manager import ConfigManager
+
+# Optional import: ZeroMQ. Requires package: pyzmq
 try:
     import zmq
+    from fprime_gds.common.zmq_transport import ZmqClient
 except ImportError:
     zmq = None
-# Try to import each GUI type, and if it can be imported
-# it will be provided to the user as an option
-GUIS = ["none", "html"]
+    ZmqClient = None
+
+# Optional import: Serial Adapter. Requires package: SerialAdapter
 try:
-    import fprime_gds.wxgui.tools.gds
-
-    GUIS.append("wx")
+    from fprime_gds.common.communication.adapters.uart import SerialAdapter
 except ImportError:
-    pass
+    SerialAdapter = None
 
 
-class ParserBase(abc.ABC):
-    """
+GUIS = ["none", "html"]
+
+
+class ParserBase(ABC):
+    """ Base parser for handling fprime commandlines
+
     Parsers must define several functions. They must define "get_parser", which will produce a parser to parse the
     arguments, and an optional "handle_arguments" function to do any necessary processing of the arguments. Note: when
-    handling arguments, the implementer should copy the incoming namespace if the original values of arguments will be
-    modified.
+    handling arguments.
     """
+    DESCRIPTION = None
 
-    @staticmethod
-    @abc.abstractmethod
-    def get_parser():
+    @property
+    def description(self):
+        """ Return parser description """
+        return self.DESCRIPTION if self.DESCRIPTION else "Unknown command line parser"
+
+    @abstractmethod
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return argument list handled by this parser
+
+        Produce the arguments that can be processed by multiple parsers. i.e. argparse, and pytest parsers are the
+        intended consumers. Returns a tuple of dictionary of flag tuples (--flag, -f) to keyword arguments to pass to
+        argparse and list of arguments calculated by the parser (generated).
+
+        Returns:
+            tuple of dictionary of flag tuple to keyword arguments, list of generated fields
         """
+
+    def get_parser(self) -> argparse.ArgumentParser:
+        """ Return an argument parser to parse arguments here-in
+
         Produce a parser that will handle the given arguments. These parsers can be combined for a CLI for a tool by
         assembling them as parent processors to a parser for the given tool.
-        """
 
-    @classmethod
-    @abc.abstractmethod
-    def handle_arguments(cls, args, **kwargs):
+        Return:
+            argparse parser for supplied arguments
         """
+        parser = argparse.ArgumentParser(
+            description=self.description,
+            add_help=False
+        )
+        for flags, keywords in self.get_arguments().items():
+            parser.add_argument(*flags, **keywords)
+        return parser
+
+    def reproduce_cli_args(self, args_ns):
+        """ Reproduce the list of arguments needed on the command line """
+
+        def flag_member(flags, argparse_inputs) -> Tuple[str, str]:
+            """ Get the best CLI flag and namespace member """
+            best_flag = ([flag for flag in flags if flag.startswith("--")] + list(flags))[0]
+            member = argparse_inputs.get("dest", re.sub(r"^-+", "", best_flag).replace("-", "_"))
+            return best_flag, member
+
+        def cli_arguments(flags, argparse_inputs) -> List[str]:
+            """ Get CLI argument list fro argument entry """
+            best_flag, member = flag_member(flags, argparse_inputs)
+            value = getattr(args_ns, member, None)
+
+            action = argparse_inputs.get("action", "store")
+            assert action in ["store", "store_true", "store_false"], f"{action} not supported by reproduce_cli_args"
+
+            # Handle arguments
+            if (action == "store_true" and value) or (action == "store_false" and not value):
+                return [best_flag]
+            elif action != "store" or value is None:
+                return []
+            return [best_flag] + ([str(value)] if not isinstance(value, list) else [str(item) for item in value])
+
+        cli_pairs = [cli_arguments(flags, argparse_ins) for flags, argparse_ins in self.get_arguments().items()]
+        return list(itertools.chain.from_iterable(cli_pairs))
+
+    @abstractmethod
+    def handle_arguments(self, args, **kwargs):
+        """ Post-process the parser's arguments
+
         Handle arguments from the given parser. The expectation is that the "args" namespace is taken in, processed, and
-        a new namespace object is returned with the processed variants of the arguments. Copy the namespace object when
-        modifying existing arguments.
+        a new namespace object is returned with the processed variants of the arguments.
 
-        :param args: arguments namespace of processed arguments
-        :return: namespace with processed results of arguments.
+        Args:
+            args: arguments namespace of processed arguments
+        Returns: namespace with processed results of arguments.
         """
 
     @staticmethod
     def parse_args(
-        parser_classes, description="No tool description provided", **kwargs
+        parser_classes, description="No tool description provided", arguments=None, **kwargs
     ):
-        """
+        """ Parse and post-process arguments
+
         Create a parser for the given application using the description provided. This will then add all specified
         ParserBase subclasses' get_parser output as parent parses for the created parser. Then all of the handle
         arguments methods will be called, and the final namespace will be returned.
 
-        :param parser_classes: a list of ParserBase subclasses that will be used to
-        :param description: description passed ot the argument parser
-        :return: namespace with all parsed arguments from all provided ParserBase subclasses
+        Args:
+            parser_classes: a list of ParserBase subclasses that will be used to
+            description: description passed ot the argument parser
+            arguments: arguments to process, None to use command line input
+        Returns: namespace with all parsed arguments from all provided ParserBase subclasses
         """
-        if kwargs is None:
-            kwargs = {}
-        created_parsers = [parser_base.get_parser() for parser_base in parser_classes]
-        parser = argparse.ArgumentParser(
-            description=description, parents=created_parsers
-        )
-        args = parser.parse_args()
-        # Handle all arguments
+        composition = CompositeParser(parser_classes, description)
+        parser = composition.get_parser()
         try:
-            for parser_base in parser_classes:
-                args = parser_base.handle_arguments(args, **kwargs)
+            args_ns = parser.parse_args(arguments)
+            args_ns = composition.handle_arguments(args_ns, **kwargs)
         except ValueError as ver:
             print(f"[ERROR] Failed to parse arguments: {ver}", file=sys.stderr)
+            parser.print_help()
             sys.exit(-1)
-        return args, parser
+        except Exception as exc:
+            print(f"[ERROR] {exc}", file=sys.stderr)
+            sys.exit(-1)
+        return args_ns, parser
 
     @staticmethod
     def find_in(token, deploy, is_file=True):
@@ -118,141 +180,165 @@ class ParserBase(abc.ABC):
         return None
 
 
-class ImportParser(ParserBase):
-    """
-    Parser used to import new modules into the F prime namespace. This is how F prime can handle new modules and plugins
-    by allowing the user to import new Python modules in, which may define new adapters and other items.
-    """
+class DetectionParser(ParserBase):
+    """ Parser that detects items from a root/directory or deployment """
 
-    @staticmethod
-    def get_parser():
-        """
-        Creates a parser that reads '--import' arguments to import new modules.  Multiple '--import' are supported.
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Arguments needed for root processing """
+        return {
+            ("-r", "--root"): {
+                "dest": "root_input",
+                "action": "store",
+                "required": False,
+                "type": str,
+                "help": "Root directory of build artifacts, used to automatically find app and dictionary. [default: install_dest field in settings.ini]",
+            }
+        }
 
-        :return: parser that can handle imports
-        """
-        parser = argparse.ArgumentParser(
-            description="Process import arguments allowing for addition of modules",
-            add_help=False,
-        )
-        parser.add_argument(
-            "--include",
-            action="append",
-            default=[],
-            help="Module name in PYTHONPATH to import. Users may specify multiple --include flags.",
-        )
-        return parser
-
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
-        """
-        Handle the import arguments by looping through them and importing each. Errors are printed to the console if an
-        import failed, but no other effect is realized.
-
-        :param args: parsed arguments namespace
-        :return: args as input, has side effect of new imported modules
-        """
-        for module in args.include:
-            try:
-                globals()[module] = importlib.import_module(module)
-            except ImportError as ime:
-                print(
-                    f"[WARNING] Failed to import '{module}' with error {ime}",
-                    file=sys.stderr,
-                )
+    def handle_arguments(self, args, **kwargs):
+        """ Handle the root, detecting it if necessary """
+        args.root_directory = (Path(args.root_input) if args.root_input else get_artifacts_root()) / platform.system()
+        if not args.root_directory.exists():
+            raise ValueError(f"F prime artifacts root directory '{args.root_input}' does not exist")
         return args
 
-    @staticmethod
-    def run_first():
-        """
-        Runs this parser once first so that other parsers can benefit from the existing imported libraries. If there is
-        a problem, the help message will be minimal, but should work.
-        """
-        args, _ = ImportParser.get_parser().parse_known_args()
-        ImportParser.handle_arguments(args)
+
+class CompositeParser(ParserBase):
+    """ Composite parser handles parsing as a composition of multiple other parsers """
+
+    def __init__(self, constituents, description=None):
+        """ Construct this parser by instantiating the sub-parsers"""
+        self.given = description
+        constructed = [constituent() for constituent in constituents]
+        flattened = [item.constituents if isinstance(item, CompositeParser) else [item] for item in constructed]
+        self.constituent_parsers = {*itertools.chain.from_iterable(flattened)}
+
+    @property
+    def constituents(self):
+        """ Get constituent """
+        return self.constituent_parsers
+
+    @property
+    def description(self):
+        """ Return parser description """
+        return self.given if self.given else ",".join(item.description for item in self.constituents)
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Get the argument from all constituents """
+        arguments = {}
+        for constituent in self.constituents:
+            arguments.update(constituent.get_arguments())
+        return arguments
+
+    def handle_arguments(self, args, **kwargs):
+        """ Process all constituent arguments """
+        for constituent in self.constituents:
+            args = constituent.handle_arguments(args, **kwargs)
+        return args
 
 
-class CommParser(ParserBase):
+# class ImportParser(ParserBase):
+#     """
+#     Parser used to import new modules into the F prime namespace. This is how F prime can handle new modules and plugins
+#     by allowing the user to import new Python modules in, which may define new adapters and other items.
+#     """
+#     DESCRIPTION = "Process import arguments allowing for addition of modules"
+#
+#     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+#         """ Return argument list required to run the import parser
+#
+#         Produce the arguments that can be processed by multiple parsers. i.e. argparse, and pytest parsers are the
+#         intended consumers. Returns dictionary of flag tuples (--flag, -f) to keyword arguments to pass to argparse.
+#
+#         Returns:
+#             dictionary of flag tuple to keyword arguments
+#         """
+#         return {
+#             ("--include", ): {
+#                "action": "append",
+#                "default": [],
+#                "help": "Module name in PYTHONPATH to import. Users may specify multiple --include flags.",
+#             }
+#         }
+#
+#     def handle_arguments(self, args, **kwargs):
+#         """
+#         Handle the import arguments by looping through them and importing each. Errors are printed to the console if an
+#         import failed, but no other effect is realized.
+#
+#         :param args: parsed arguments namespace
+#         :return: args as input, has side effect of new imported modules
+#         """
+#         for module in args.include:
+#             try:
+#                 globals()[module] = importlib.import_module(module)
+#             except ImportError as ime:
+#                 print(
+#                     f"[WARNING] Failed to import '{module}' with error {ime}",
+#                     file=sys.stderr,
+#                 )
+#         return args
+#
+#     @staticmethod
+#     def run_first():
+#         """
+#         Runs this parser once first so that other parsers can benefit from the existing imported libraries. If there is
+#         a problem, the help message will be minimal, but should work.
+#         """
+#         args, _ = ImportParser.get_parser().parse_known_args()
+#         ImportParser.handle_arguments(args)
+
+
+class CommAdapterParser(ParserBase):
     """
     Handles parsing of all of the comm-layer arguments. This means selecting a comm adapter, and passing the arguments
     required to setup that comm adapter. In addition, this parser uses the import parser to import modules such that a
     user may import other adapter implementation files.
     """
+    DESCRIPTION = "Process arguments needed to specify a comm-adapter"
 
-    @staticmethod
-    def get_parser():
-        """
-        Produce a parser that will handle the given arguments. These parsers can be combined for a CLI for a tool by
-        assembling them as parent processors to a parser for the given tool.
-        """
-        ImportParser.run_first()
-        adapters = (
-            fprime_gds.common.communication.adapters.base.BaseAdapter.get_adapters().keys()
-        )
-        adapter_parents = []
-        for adapter_name in adapters:
-            adapter = fprime_gds.common.communication.adapters.base.BaseAdapter.get_adapters()[
-                adapter_name
-            ]
-            # Check adapter real quick before moving on
-            if not hasattr(adapter, "get_arguments") or not callable(
-                getattr(adapter, "get_arguments", None)
-            ):
-                print(
-                    f"[WARNING] '{adapter_name}' does not have 'get_arguments' method, skipping.",
-                    file=sys.stderr,
-                )
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Get arguments for the comm-layer parser """
+        adapter_definition_dictionaries = BaseAdapter.get_adapters()
+        adapter_arguments = {}
+        for name, adapter in adapter_definition_dictionaries.items():
+            adapter_arguments_callable = getattr(adapter, "get_arguments", None)
+            if not callable(adapter_arguments_callable):
+                print(f"[WARNING] '{name}' does not have 'get_arguments' method, skipping.", file=sys.stderr)
                 continue
-            comm_parser = argparse.ArgumentParser(
-                description=f"'{adapter_name}' parser", add_help=False
-            )
-            # Add arguments for the parser
-            for argument in adapter.get_arguments().keys():
-                comm_parser.add_argument(*argument, **adapter.get_arguments()[argument])
-            adapter_parents.append(comm_parser)
-        parser = argparse.ArgumentParser(
-            description="Process arguments needed to specify a comm-adapter",
-            add_help=False,
-            parents=adapter_parents,
-        )
-        parser.add_argument(
-            "--comm-adapter",
-            dest="adapter",
-            action="store",
-            type=str,
-            help="Adapter for communicating to flight deployment. [default: %(default)s]",
-            choices=["none"] + list(adapters),
-            default="ip",
-        )
-        parser.add_argument(
-            "--comm-checksum-type",
-            dest="checksum_type",
-            action="store",
-            type=str,
-            help="Setup the checksum algorithm. [default: %(default)s]",
-            choices=[
-                item
-                for item in fprime_gds.common.communication.checksum.CHECKSUM_MAPPING.keys()
-                if item != "default"
-            ],
-            default=fprime_gds.common.communication.checksum.CHECKSUM_SELECTION,
-        )
-        return parser
+            adapter_arguments.update(adapter.get_arguments())
+        com_arguments = {
+            ("--comm-adapter",): {
+                "dest": "adapter",
+                "action": "store",
+                "type": str,
+                "help": "Adapter for communicating to flight deployment. [default: %(default)s]",
+                "choices": ["none"] + [name for name in adapter_definition_dictionaries.keys()],
+                "default": "ip",
+            },
+            ("--comm-checksum-type",): {
+                "dest": "checksum_type",
+                "action": "store",
+                "type": str,
+                "help": "Setup the checksum algorithm. [default: %(default)s]",
+                "choices": [
+                    item
+                    for item in CHECKSUM_MAPPING.keys()
+                    if item != "default"
+                ],
+                "default": CHECKSUM_SELECTION,
+            }
+        }
+        return {**adapter_arguments, **com_arguments}
 
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
+    def handle_arguments(self, args, **kwargs):
         """
-        Handle the input arguments for the the parser. This will help setup the adapter with its expected arguments.
+        Handle the input arguments for the parser. This will help setup the adapter with its expected arguments.
 
         :param args: parsed arguments in namespace format
         :return: namespace with "comm_adapter" value added
         """
-        args = copy.copy(args)
-        args.comm_adapter = (
-            fprime_gds.common.communication.adapters.base.BaseAdapter.construct_adapter(
-                args.adapter, args
-            )
-        )
+        args.comm_adapter = BaseAdapter.construct_adapter(args.adapter, args)
         fprime_gds.common.communication.checksum.CHECKSUM_SELECTION = args.checksum_type
         return args
 
@@ -268,46 +354,38 @@ class LogDeployParser(ParserBase):
     # a consistent directory, opposed to multiple directories across the system.
     first_log = None
 
-    @staticmethod
-    def get_parser():
-        """
-        Creates a new parser that can process "--deployment" and "--logs" arguments for use with any CLI producing log
-        files. Can be used to construct parent arguments
+    DESCRIPTION = "Process arguments needed to specify a logging"
 
-        :return: parser with logging and deploy arguments
-        """
-        parser = argparse.ArgumentParser(
-            description="Process arguments needed to specify a logging", add_help=False
-        )
-        parser.add_argument(
-            "-l",
-            "--logs",
-            dest="logs",
-            action="store",
-            default=os.path.join(os.getcwd(), "logs"),
-            type=str,
-            help="Logging directory. Created if non-existent. [default: %(default)s]",
-        )
-        parser.add_argument(
-            "--log-directly",
-            dest="log_directly",
-            action="store_true",
-            default=False,
-            help="Logging directory is used directly, no extra dated directories created.",
-        )
-        parser.add_argument("--log-to-stdout", action="store_true", default=False,
-                            help="Log to standard out along with log output files")
-        return parser
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return arguments to parse logging options """
+        return {
+            ("-l", "--logs"): {
+                "dest": "logs",
+                "action": "store",
+                "default": os.path.join(os.getcwd(), "logs"),
+                "type": str,
+                "help": "Logging directory. Created if non-existent. [default: %(default)s]",
+            },
+            ("--log-directly",): {
+                "dest": "log_directly",
+                "action": "store_true",
+                "default": False,
+                "help": "Logging directory is used directly, no extra dated directories created.",
+            },
+            ("--log-to-stdout",): {
+                "action": "store_true",
+                "default": False,
+                "help": "Log to standard out along with log output files"
+            }
+        }
 
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
+    def handle_arguments(self, args, **kwargs):
         """
         Read the arguments specified in this parser and validate the expected inputs.
 
         :param args: parsed arguments as namespace
         :return: args namespace
         """
-        args = copy.copy(args)
         # Get logging dir
         if not args.log_directly:
             args.logs = os.path.abspath(
@@ -318,81 +396,69 @@ class LogDeployParser(ParserBase):
 
         # Make sure directory exists
         try:
-            os.makedirs(args.logs)
+            os.makedirs(args.logs, exist_ok=True)
         except OSError as osexc:
             if osexc.errno != errno.EEXIST:
                 raise
         # Setup the basic python logging
         fprime_gds.common.logger.configure_py_log(args.logs, mirror_to_stdout=args.log_to_stdout)
-
         return args
 
 
 class MiddleWareParser(ParserBase):
     """
-    Middleware (ThreadedTcpServer) interface that looks for an address and a port. The argument handling will attempt to
-    connect to the socket to ensure that it is a valid address/port and report any errors. This is then immediately
-    closes the port after use. There is a minor race-condition between this check and the actual usage, however; it
-    should be close enough.
+    Middleware (ThreadedTcpServer, ZMQ) interface that looks for an address and a port. The argument handling will
+    attempt to connect to the socket to ensure that it is a valid address/port and report any errors. This is then
+    immediately closes the port after use. There is a minor race-condition between this check and the actual usage,
+    however; it should be close enough.
     """
+    DESCRIPTION = "Process arguments needed to specify a tool using the middleware"
 
-    @staticmethod
-    def get_parser():
-        """
-        Sets up and parses the arguments required to run the data middleware layer. At this time, the data middleware is
-        the threaded TCP server and thus the arguments are the ip address and port to listen to. May also be used in
-        clients connecting to the middleware layer.
-
-        :return: parser after arguments added
-        """
-        parser = argparse.ArgumentParser(
-            description="Process arguments needed to specify a tool using the middleware",
-            add_help=False,
-        )
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return arguments necessary to run a and connect to the GDS middleware """
         # May use ZMQ transportation layer if zmq package is available
-        if zmq is not None:
-            parser.add_argument(
-                "--zmq",
-                dest="zmq",
-                action="store_true",
-                help="Switch to using the ZMQ transportation layer",
-                default=False,
-            )
-            parser.add_argument(
-                "--zmq-server",
-                dest="zmq_server",
-                action="store_true",
-                help="Sets the ZMQ connection to be a server. Default: false (client)",
-                default=False,
-            )
-            parser.add_argument(
-                "--zmq-transport",
-                dest="zmq_transport",
-                nargs=2,
-                help="Pair of URls used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
-                default=["ipc:///tmp/fprime-server-in", "ipc:///tmp/fprime-server-out"],
-                metavar=("serverInUrl", "serverOutUrl")
-            )
-        parser.add_argument(
-            "--tts-port",
-            dest="tts_port",
-            action="store",
-            type=int,
-            help="Set the threaded TCP socket server port [default: %(default)s]",
-            default=50050,
-        )
-        parser.add_argument(
-            "--tts-addr",
-            dest="tts_addr",
-            action="store",
-            type=str,
-            help="Set the threaded TCP socket server address [default: %(default)s]",
-            default="0.0.0.0",
-        )
-        return parser
+        zmq_arguments = {}
+        if zmq is not None and ZmqClient is not None:
+            zmq_arguments = {
+                ("--zmq",): {
+                    "dest": "zmq",
+                    "action": "store_true",
+                    "help": "Switch to using the ZMQ transportation layer",
+                    "default": False,
+                },
+                ("--zmq-server",): {
+                    "dest": "zmq_server",
+                    "action": "store_true",
+                    "help": "Sets the ZMQ connection to be a server. Default: false (client)",
+                    "default": False,
+                },
+                ("--zmq-transport",): {
+                    "dest": "zmq_transport",
+                    "nargs": 2,
+                    "help": "Pair of URls used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
+                    "default": ["ipc:///tmp/fprime-server-in", "ipc:///tmp/fprime-server-out"],
+                    "metavar": ("serverInUrl", "serverOutUrl")
+                }
+            }
+        tts_arguments = {
+            ("--tts-port",): {
+                "dest": "tts_port",
+                "action": "store",
+                "type": int,
+                "help": "Set the threaded TCP socket server port [default: %(default)s]",
+                "default": 50050,
+            },
+            ("--tts-addr",): {
+                "dest": "tts_addr",
+                "action": "store",
+                "type": str,
+                "help": "Set the threaded TCP socket server address [default: %(default)s]",
+                "default": "0.0.0.0",
+            }
+        }
+        return {**zmq_arguments, **tts_arguments}
 
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
+    def handle_arguments(self, args, **kwargs):
         """
         Checks to ensure that the specified port and address is available before connecting. This prevents user from
         attempting to run on a port that is unavailable.
@@ -400,17 +466,120 @@ class MiddleWareParser(ParserBase):
         :param args: parsed argument namespace
         :return: args namespace
         """
-        # Check ZMQ settings
-        if args.zmq and zmq is None:
-            print("[ERROR] ZeroMQ is not available. Install pyzmq.", file=sys.stderr)
-            sys.exit(-1)
-        elif args.zmq:
-            pass
-        elif not kwargs.get("client", False):
-            fprime_gds.common.communication.adapters.ip.check_port(
-                args.tts_addr, args.tts_port
-            )
+        is_client = kwargs.get("client", False)
+        args.zmq = getattr(args, "zmq", False)
+        tts_connection_address = args.tts_addr.replace("0.0.0.0", "127.0.0.1") if is_client else args.tts_addr
+
+        args.connection_uri = f"tcp://{tts_connection_address}:{args.tts_port}"
+        args.connection_transport = ThreadedTCPSocketClient
+        if args.zmq:
+            args.connection_uri = args.zmq_transport
+            args.connection_transport = ZmqClient
+        elif not is_client:
+            check_port(args.tts_addr, args.tts_port)
         return args
+
+
+class DictionaryParser(DetectionParser):
+    """ Parser for deployments """
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Arguments to handle deployments """
+        return {
+            **super().get_arguments(),
+            **{
+                ("--dictionary",): {
+                    "dest": "dictionary",
+                    "action": "store",
+                    "default": None,
+                    "required": False,
+                    "type": str,
+                    "help": "Path to dictionary. Overrides automatic dictionary detection.",
+                },
+                ("--packet-spec",): {
+                    "dest": "packet_spec",
+                    "action": "store",
+                    "default": None,
+                    "required": False,
+                    "type": str,
+                    "help": "Path to packet specification.",
+                }
+            }
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        """ Handle arguments as parsed """
+        args = super().handle_arguments(args, **kwargs)
+        # Find dictionary setting via "dictionary" argument or the "deploy" argument
+        if args.dictionary is not None and not os.path.exists(args.dictionary):
+            raise ValueError(f"Dictionary file {args.dictionary} does not exist")
+        elif args.dictionary is None:
+            args = super().handle_arguments(args, **kwargs)
+            args.dictionary = find_dict(args.root_directory)
+        return args
+
+
+class FileHandlingParser(ParserBase):
+    """ Parser for deployments """
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Arguments to handle deployments """
+        return {
+            ("--file-storage-directory",): {
+                "dest": "files_directory",
+                "action": "store",
+                "default": "/tmp/fprime-downlink/",
+                "required": False,
+                "type": str,
+                "help": "File to store uplink and downlink files. Default: %(default)s",
+            }
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        """ Handle arguments as parsed """
+        os.makedirs(args.files_directory, exist_ok=True)
+        return args
+
+
+class StandardPipelineParser(CompositeParser):
+    """ Standard pipeline argument parser: combination of MiddleWare and """
+    CONSTITUENTS = [DictionaryParser, FileHandlingParser, MiddleWareParser, LogDeployParser]
+
+    def __init__(self):
+        """ Initialization """
+        super().__init__(constituents=self.CONSTITUENTS, description="Standard pipeline setup")
+
+    @staticmethod
+    def pipeline_factory(args_ns, pipeline=None) -> StandardPipeline:
+        """ A factory of the standard pipline given the handled arguments """
+        pipeline_arguments = {
+            "config": ConfigManager(),
+            "dictionary": args_ns.dictionary,
+            "down_store": args_ns.files_directory,
+            "packet_spec": args_ns.packet_spec,
+            "logging_prefix": args_ns.logs,
+        }
+        pipeline = pipeline if pipeline else StandardPipeline()
+        pipeline.transport_implementation = args_ns.connection_transport
+        try:
+            pipeline.setup(**pipeline_arguments)
+            pipeline.connect(args_ns.connection_uri)
+        except Exception:
+            # In all error cases, pipeline should be shutdown before continuing with exception handling
+            try:
+                pipeline.disconnect()
+            finally:
+                raise
+        return pipeline
+
+
+class CommParser(CompositeParser):
+    """ Comm Executable Parser """
+    CONSTITUENTS = [CommAdapterParser, MiddleWareParser, LogDeployParser]
+
+    def __init__(self):
+        """ Initialization """
+        super().__init__(constituents=self.CONSTITUENTS, description="Communications bridge application")
 
 
 class GdsParser(ParserBase):
@@ -423,78 +592,37 @@ class GdsParser(ParserBase):
 
     Note: deployment can help in setting both dictionary and logs, but isn't strictly required.
     """
+    DESCRIPTION = "Process arguments needed to specify a tool using the GDS"
 
-    @staticmethod
-    def get_parser():
-        """
-        Creates a parser to handle the arguments required to run the GDS layer. This allows the system to start up the
-        GDS and connect into the middleware layer.
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return arguments necessary to run a binary deployment via the GDS"""
+        return {
+            ("-g", "--gui"): {
+                "choices": GUIS,
+                "dest": "gui",
+                "type": str,
+                "help": "Set the desired GUI system for running the deployment. [default: %(default)s]",
+                "default": "html",
+            },
+            ("--gui-addr",): {
+                "dest": "gui_addr",
+                "action": "store",
+                "default": "127.0.0.1",
+                "required": False,
+                "type": str,
+                "help": "Set the GUI server address [default: %(default)s]",
+            },
+            ("--gui-port",): {
+                "dest": "gui_port",
+                "action": "store",
+                "default": "5000",
+                "required": False,
+                "type": str,
+                "help": "Set the GUI server address [default: %(default)s]",
+            }
+        }
 
-        :return: parser for arguments
-        """
-        parser = argparse.ArgumentParser(
-            description="Process arguments needed to specify a tool using the GDS",
-            add_help=False,
-        )
-        parser.add_argument(
-            "-g",
-            "--gui",
-            choices=GUIS,
-            dest="gui",
-            type=str,
-            help="Set the desired GUI system for running the deployment. [default: %(default)s]",
-            default="html",
-        )
-        parser.add_argument(
-            "--dictionary",
-            dest="dictionary",
-            action="store",
-            default=None,
-            required=False,
-            type=str,
-            help="Path to dictionary. Overrides automatic dictionary detection.",
-        )
-        parser.add_argument(
-            "--packet-spec",
-            dest="packet_spec",
-            action="store",
-            default=None,
-            required=False,
-            type=str,
-            help="Path to packet specification.",
-        )
-        parser.add_argument(
-            "-c",
-            "--config",
-            dest="config",
-            action="store",
-            default=None,
-            type=str,
-            help="Configuration for wx GUI. Ignored if not using wx.",
-        )
-        parser.add_argument(
-            "--gui-addr",
-            dest="gui_addr",
-            action="store",
-            default="127.0.0.1",
-            required=False,
-            type=str,
-            help="Set the GUI server address [default: %(default)s]",
-        )
-        parser.add_argument(
-            "--gui-port",
-            dest="gui_port",
-            action="store",
-            default="5000",
-            required=False,
-            type=str,
-            help="Set the GUI server address [default: %(default)s]",
-        )
-
-        return parser
-
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
+    def handle_arguments(self, args, **kwargs):
         """
         Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
         program. This will throw if there is an error.
@@ -502,69 +630,38 @@ class GdsParser(ParserBase):
         :param args: parsed args into a namespace
         :return: args namespace
         """
-        args = copy.copy(args)
-        # Find dictionary setting via "dictionary" argument or the "deploy" argument
-        if args.dictionary is not None and not os.path.exists(args.dictionary):
-            raise ValueError(f"Dictionary file {args.dictionary} does not exist")
-
-        # Handle configuration arguments
-        config = fprime_gds.common.utils.config_manager.ConfigManager()
-        if args.config is not None:
-            if os.path.isfile(args.config):
-                config.set_configs(args.config)
-            else:
-                raise ValueError(f"Configuration file {args.config} not found")
-        args.config = config
         return args
 
 
-class BinaryDeployment(ParserBase):
+class BinaryDeployment(DetectionParser):
     """
     Parsing subclass used to read the arguments of the binary application. This derives functionality from a comm parser
     and represents the flight-side of the equation.
     """
+    DESCRIPTION = "Process arguments needed for running F prime binary"
 
-    @staticmethod
-    def get_parser():
-        """
-        Creates a parser to handle the arguments required to run the binary application. This allows the system to
-        start up the F prime binary deployment, or ignore it.
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return arguments necessary to run a binary deployment via the GDS"""
+        return {
+            **super().get_arguments(),
+            **{
+                ("-n", "--no-app"): {
+                    "dest": "noapp",
+                    "action": "store_true",
+                    "default": False,
+                    "help": "Do not run deployment binary. Overrides --app.",
+                },
+                ("--app",): {
+                    "dest": "app",
+                    "action": "store",
+                    "required": False,
+                    "type": str,
+                    "help": "Path to app to run. Overrides automatic app detection.",
+                },
+            }
+        }
 
-        :return: parser for arguments
-        """
-        parser = argparse.ArgumentParser(
-            description="Process arguments needed for running F prime binary",
-            add_help=False,
-        )
-        parser.add_argument(
-            "-n",
-            "--no-app",
-            dest="noapp",
-            action="store_true",
-            default=False,
-            help="Do not run deployment binary. Overrides --app.",
-        )
-        parser.add_argument(
-            "--app",
-            dest="app",
-            action="store",
-            required=False,
-            type=str,
-            help="Path to app to run. Overrides automatic app detection.",
-        )
-        parser.add_argument(
-            "-r",
-            "--root",
-            dest="root_dir",
-            action="store",
-            required=False,
-            type=str,
-            help="Root directory of build artifacts, used to automatically find app and dictionary. [default: install_dest field in settings.ini]",
-        )
-        return parser
-
-    @classmethod
-    def handle_arguments(cls, args, **kwargs):
+    def handle_arguments(self, args, **kwargs):
         """
         Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
         program. This will throw if there is an error.
@@ -572,14 +669,11 @@ class BinaryDeployment(ParserBase):
         :param args: parsed arguments in namespace
         :return: args namespaces
         """
+        args = super().handle_arguments(args, **kwargs)
         # No app, stop processing now
         if args.noapp:
             return args
-        args = copy.copy(args)
-        if args.app is not None and not os.path.isfile(args.app):
-            raise ValueError(f"F prime binary '{args.app}' does not exist")
-        if args.root_dir is not None and not os.path.isdir(args.root_dir):
-            raise ValueError(
-                f"F prime artifacts root directory '{args.root_dir}' does not exist"
-            )
+        args.app = Path(args.app) if args.app else Path(find_app(args.root_directory))
+        if not args.app.is_file():
+            raise ValueError(f"F prime binary '{args.app}' does not exist or is not a file")
         return args

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -26,7 +26,6 @@ from typing import Any, Dict, List, Tuple
 
 from fprime_gds.common.communication.adapters.base import BaseAdapter
 from fprime_gds.common.communication.adapters.ip import check_port
-from fprime_gds.common.communication.checksum import CHECKSUM_MAPPING, CHECKSUM_SELECTION
 from fprime_gds.common.pipeline.standard import StandardPipeline
 from fprime_gds.common.transport import ThreadedTCPSocketClient
 from fprime_gds.executables.utils import get_artifacts_root, find_dict, find_app
@@ -199,7 +198,7 @@ class DetectionParser(ParserBase):
         """ Handle the root, detecting it if necessary """
         args.root_directory = (Path(args.root_input) if args.root_input else get_artifacts_root()) / platform.system()
         if not args.root_directory.exists():
-            raise ValueError(f"F prime artifacts root directory '{args.root_input}' does not exist")
+            raise ValueError(f"F prime artifacts root directory '{args.root_directory}' does not exist")
         return args
 
 
@@ -323,10 +322,10 @@ class CommAdapterParser(ParserBase):
                 "help": "Setup the checksum algorithm. [default: %(default)s]",
                 "choices": [
                     item
-                    for item in CHECKSUM_MAPPING.keys()
+                    for item in fprime_gds.common.communication.checksum.CHECKSUM_MAPPING.keys()
                     if item != "default"
                 ],
-                "default": CHECKSUM_SELECTION,
+                "default": fprime_gds.common.communication.checksum.CHECKSUM_SELECTION,
             }
         }
         return {**adapter_arguments, **com_arguments}

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -4,65 +4,27 @@
 # Runs a deployment. Starts a GUI, a TCPServer, and the deployment application.
 ####
 import os
-import platform
 import sys
 import webbrowser
-from pathlib import Path
 
-import fprime_gds.executables.cli
-import fprime_gds.executables.utils
+from fprime_gds.executables.cli import StandardPipelineParser, GdsParser, BinaryDeployment, CommParser, ParserBase
+from fprime_gds.executables.utils import run_wrapped_application, AppWrapperException
 
 
-def get_settings():
-    args = parse_args()
-
-    if args.dictionary is not None and (args.app is not None or args.noapp):
-        return args
-
-    root = None
-    if args.root_dir is not None:
-        root = Path(args.root_dir)
-    else:
-        root = fprime_gds.executables.utils.get_artifacts_root()
-    root = root / platform.system()
-
-    if not args.noapp and args.app is None:
-        args.app = fprime_gds.executables.utils.find_app(root)
-
-    if args.dictionary is None:
-        args.dictionary = fprime_gds.executables.utils.find_dict(root)
-
-    return args
+BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
 
 
 def parse_args():
-    """
+    """ Parse command line arguments
     Gets an argument parsers to read the command line and process the arguments. Return
     the arguments in their namespace.
 
     :return: parsed argument namespace
     """
     # Get custom handlers for all executables we are running
-    arg_handlers = [
-        fprime_gds.executables.cli.LogDeployParser,
-        fprime_gds.executables.cli.GdsParser,
-        fprime_gds.executables.cli.MiddleWareParser,
-        fprime_gds.executables.cli.BinaryDeployment,
-        fprime_gds.executables.cli.CommParser,
-    ]
+    arg_handlers = [StandardPipelineParser, GdsParser, BinaryDeployment, CommParser]
     # Parse the arguments, and refine through all handlers
-    try:
-        args, parser = fprime_gds.executables.cli.ParserBase.parse_args(
-            arg_handlers, "Run F prime deployment and GDS"
-        )
-        # Special checks
-        if args.config.get_file_path() is None and args.gui == "wx":
-            raise ValueError("Must supply --config when using 'wx' GUI.")
-    # On ValueError print error, help and exit
-    except ValueError as vexc:
-        print(f"[ERROR] {str(vexc)}", file=sys.stderr, end="\n\n")
-        parser.print_help(sys.stderr)
-        sys.exit(-1)
+    args, parser = ParserBase.parse_args(arg_handlers, "Run F prime deployment and GDS")
     return args
 
 
@@ -81,10 +43,8 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
         name = str(cmd)
     print(f"[INFO] Ensuring {name} is stable for at least {launch_time} seconds")
     try:
-        return fprime_gds.executables.utils.run_wrapped_application(
-            cmd, logfile, env, launch_time
-        )
-    except fprime_gds.executables.utils.AppWrapperException as awe:
+        return run_wrapped_application(cmd, logfile, env, launch_time)
+    except AppWrapperException as awe:
         print(f"[ERROR] {str(awe)}.", file=sys.stderr)
         try:
             if logfile is not None:
@@ -93,232 +53,127 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
                         print(f"    [LOG] {line.strip()}", file=sys.stderr)
         except Exception:
             pass
-        raise fprime_gds.executables.utils.AppWrapperException(f"Failed to run {name}")
+        raise AppWrapperException(f"Failed to run {name}")
 
 
-def launch_tts(tts_port, tts_addr, logs, **_):
-    """
-    Launch the Threaded TCP Server
+def launch_tts(parsed_args):
+    """ Launch the ThreadedTcpServer middleware application
 
-    :param tts_port: port to attach to
-    :param tts_addr: address to bind to
-    :param logs: logs output directory
-    :return: process
+
+    Args:
+        parsed_args: parsed argument namespace
+    Return:
+        launched process
     """
     # Open log, and prepare to close it cleanly on exit
-    tts_log = os.path.join(logs, "ThreadedTCP.log")
+    tts_log = os.path.join(parsed_args.logs, "ThreadedTCP.log")
     # Launch the tcp server
-    tts_cmd = [
-        sys.executable,
-        "-u",
-        "-m",
+    tts_cmd = BASE_MODULE_ARGUMENTS + [
         "fprime_gds.executables.tcpserver",
         "--port",
-        str(tts_port),
+        str(parsed_args.tts_port),
         "--host",
-        str(tts_addr),
+        str(parsed_args.tts_addr),
     ]
     return launch_process(tts_cmd, logfile=tts_log, name="TCP Server")
 
 
-def launch_wx(port, dictionary, connect_address, log_dir, config, **_):
-    """
-    Launch the GDS gui
+def launch_html(parsed_args):
+    """ Launch the Flask application
 
-    :param port: port to connect to
-    :param dictionary: dictionary to look at
-    :param connect_address: address to connect to
-    :param log_dir: directory to place logs
-    :param config: configuration to use
-    :return: process
+    Args:
+        parsed_args: parsed argument namespace
+    Return:
+        launched process
     """
-    gse_args = [
-        sys.executable,
-        "-u",
-        "-m",
-        "fprime_gds.wxgui.tools.gds",
-        "--port",
-        str(port),
-    ]
-    if os.path.isfile(dictionary):
-        gse_args.extend(["-x", dictionary])
-    elif os.path.isdir(dictionary):
-        gse_args.extend(["--dictionary", dictionary])
-    else:
-        print(
-            f"[ERROR] Dictionary invalid, must be XML or PY dicts: {dictionary}",
-            file=sys.stderr,
-        )
-    # For macOS, add in the wx wrapper
-    if platform.system() == "Darwin":
-        gse_args.insert(
-            0,
-            os.path.join(
-                os.path.dirname(__file__),
-                "..",
-                "..",
-                "..",
-                "bin",
-                "osx",
-                "wx-wrapper.bash",
-            ),
-        )
-    gse_args.extend(
-        ["--addr", connect_address, "-L", log_dir, "--config", config.get_file_path()]
-    )
-    return launch_process(gse_args, name="WX GUI")
-
-
-def launch_html(
-    tts_port, dictionary, packet_spec, connect_address, logs, gui_addr, gui_port, **extras
-):
-    """
-    Launch the flask server and a browser pointed at the HTML page.
-
-    :param tts_port: port to connect to
-    :param dictionary: dictionary to look at
-    :param packet_spec: packet specification
-    :param connect_address: address to connect to
-    :param logs: directory to place logs
-    :param gui_addr: Flask server host IP address
-    :param gui_port: Flask server port number
-    :return: process
-    """
-    gse_env = os.environ.copy()
-    gse_env.update(
+    flask_env = os.environ.copy()
+    flask_env.update(
         {
-            "DICTIONARY": str(dictionary),
-            "PACKET_SPEC": str(packet_spec),
             "FLASK_APP": "fprime_gds.flask.app",
-            "LOG_DIR": logs,
+            "STANDARD_PIPELINE_ARGUMENTS": "|".join(StandardPipelineParser().reproduce_cli_args(parsed_args)),
             "SERVE_LOGS": "YES",
         }
     )
-    if tts_port is not None:
-        gse_env.update(
-            {
-                "TTS_PORT": str(tts_port),
-                "TTS_ADDR": connect_address,
-            }
-        )
-    else:
-        gse_env.update({"ZMQ_TRANSPORT": "|".join(connect_address)})
-
-    gse_args = [
-        sys.executable,
-        "-u",
-        "-m",
+    gse_args = BASE_MODULE_ARGUMENTS + [
         "flask",
         "run",
         "--host",
-        str(gui_addr),
+        str(parsed_args.gui_addr),
         "--port",
-        str(gui_port),
+        str(parsed_args.gui_port),
     ]
-    ret = launch_process(gse_args, name="HTML GUI", env=gse_env, launch_time=2)
-    if extras["gui"] == "html":
+    ret = launch_process(gse_args, name="HTML GUI", env=flask_env, launch_time=2)
+    if parsed_args.gui == "html":
         webbrowser.open(
-            f"http://{str(gui_addr)}:{str(gui_port)}/", new=0, autoraise=True
+            f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/", new=0, autoraise=True
         )
     return ret
 
 
-def launch_app(app, port, address, logs, **_):
-    """
-    Launch the app
+def launch_app(parsed_args):
+    """ Launch the raw application
 
-    :param app: application to launch
-    :param port: port to connect to
-    :param address: address to connect to
-    :param logs: log directory to place files into
-    :return: process
+    Args:
+        parsed_args: parsed argument namespace
+    Return:
+        launched process
     """
-    app_name = os.path.basename(app)
-    logfile = os.path.join(logs, f"{app_name}.log")
-    app_cmd = [os.path.abspath(app), "-p", str(port), "-a", address]
+    app_path = parsed_args.app
+    logfile = os.path.join(parsed_args.logs, f"{app_path.name}.log")
+    app_cmd = [app_path.absolute(), "-p", str(parsed_args.port), "-a", parsed_args.address]
     return launch_process(
-        app_cmd, name=f"{app_name} Application", logfile=logfile, launch_time=1
+        app_cmd, name=f"{app_path.name} Application", logfile=logfile, launch_time=1
     )
 
 
-def launch_comm(comm_adapter, tts_port, connect_address, logs, **all_args):
-    """
+def launch_comm(parsed_args):
+    """ Launch the communication adapter process
 
-    :return:
+    Args:
+        parsed_args: parsed argument namespace
+    Return:
+        launched process
     """
-    transport_args = ["--tts-addr", connect_address, "--tts-port", str(tts_port)]
-    if tts_port is None:
-        transport_args = ["--zmq", "--zmq-transport", connect_address[0], connect_address[1], "--zmq-server"]
-    app_cmd = [
-        sys.executable,
-        "-u",
-        "-m",
-        "fprime_gds.executables.comm",
-        "-l",
-        logs,
-        "--log-directly",
-        "--comm-adapter",
-        all_args["adapter"],
-        "--comm-checksum-type",
-        all_args["checksum_type"],
-    ] + transport_args
-    # Manufacture arguments for the selected adapter
-    for arg in comm_adapter.get_arguments().keys():
-        definition = comm_adapter.get_arguments()[arg]
-        destination = definition["dest"]
-        app_cmd.append(arg[0])
-        app_cmd.append(str(all_args[destination]))
-    return launch_process(
-        app_cmd, name=f'comm[{all_args["adapter"]}] Application', launch_time=1
-    )
+    arguments = CommParser().reproduce_cli_args(parsed_args)
+    arguments = arguments + ["--log-directly"] if "--log-directly" not in arguments else arguments
+    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_gds.executables.comm"] + arguments
+    return launch_process(app_cmd, name=f'comm[{parsed_args.adapter}] Application', launch_time=1)
 
 
 def main():
     """
     Main function used to launch processes.
     """
-    settings = vars(get_settings())
+    parsed_args = parse_args()
     launchers = []
+
     # Launch a gui, if specified
-    if settings["zmq"]:
-        settings["connect_address"] = settings["zmq_transport"]
-        settings["tts_port"] = None
-    else:
+    if not parsed_args.zmq:
         launchers.append(launch_tts)
-        settings["connect_address"] = (
-            settings["tts_addr"] if settings["tts_addr"] != "0.0.0.0" else "127.0.0.1"
-        )
+
     # Check if we are running with communications
-    if settings.get("adapter", "") != "none":
+    if parsed_args.adapter != "none":
         launchers.append(launch_comm)
 
     # Add app, if possible
-    if settings.get("app", None) is not None:
-        if settings.get("adapter", "") == "ip":
+    if parsed_args.app:
+        if parsed_args.adapter == "ip":
             launchers.append(launch_app)
         else:
             print("[WARNING] App cannot be auto-launched without IP adapter")
 
     # Launch the desired GUI package
-    gui = settings.get("gui", "none")
-    if gui == "wx":
-        launchers.append(launch_wx)
-    elif gui in ["html", "none"]:
-        launchers.append(launch_html)
-    else:
-        raise Exception(f'Invalid GUI specified: {settings["gui"]}')
+    launchers.append(launch_html)
+
     # Launch launchers and wait for the last app to finish
     try:
-        procs = [launcher(**settings) for launcher in launchers]
+        procs = [launcher(parsed_args) for launcher in launchers]
         print("[INFO] F prime is now running. CTRL-C to shutdown all components.")
         procs[-1].wait()
     except KeyboardInterrupt:
         print("[INFO] CTRL-C received. Exiting.")
     except Exception as exc:
-        print(
-            f"[INFO] Shutting down F prime due to error. {str(exc)}",
-            file=sys.stderr,
-        )
+        print(f"[INFO] Shutting down F prime due to error. {str(exc)}", file=sys.stderr)
         return 1
     # Processes are killed atexit
     return 0

--- a/src/fprime_gds/flask/components.py
+++ b/src/fprime_gds/flask/components.py
@@ -5,9 +5,6 @@ This sets up the primary data components that allow Flask to connect into the sy
 pipeline and other components are created to interact with Flask.
 """
 import os
-import sys
-from pathlib import Path
-from typing import List
 
 from fprime_gds.common.pipeline.standard import StandardPipeline
 from fprime_gds.common.history.ram import SelfCleaningRamHistory

--- a/src/fprime_gds/flask/default_settings.py
+++ b/src/fprime_gds/flask/default_settings.py
@@ -9,39 +9,21 @@
 #
 ####
 import os
-from pathlib import Path
-import fprime_gds.common.utils.config_manager
 
 # Select uploads directory and create it
 uplink_dir = os.environ.get("UP_FILES_DIR", "/tmp/fprime-uplink/")
 DOWNLINK_DIR = os.environ.get("DOWN_FILES_DIR", "/tmp/fprime-downlink/")
 
-# Configuration is mostly driven from environment variables
-DICTIONARY = os.environ.get("DICTIONARY", None)
-PACKET_SPEC = os.environ.get("PACKET_SPEC", None)
+STANDARD_PIPELINE_ARGUMENTS = os.environ.get("STANDARD_PIPELINE_ARGUMENTS").split("|")
 
-# Making packet spec optional
-if PACKET_SPEC is None or PACKET_SPEC == "None":
-    PACKET_SPEC = None
-else:
-    PACKET_SPEC = Path(PACKET_SPEC)
-
-ZMQ_TRANSPORT = os.environ.get("ZMQ_TRANSPORT", None)
-ZMQ_TRANSPORT = None if ZMQ_TRANSPORT is None else ZMQ_TRANSPORT.split("|")
-PORT = int(os.environ.get("TTS_PORT", "50050"), 0)
-ADDRESS = os.environ.get("TTS_ADDR", "127.0.0.1")
-
-LOG_DIR = os.environ.get("LOG_DIR", "/tmp/fprime-gds-logs")
 SERVE_LOGS = os.environ.get("SERVE_LOGS", "YES") == "YES"
 UPLOADED_UPLINK_DEST = uplink_dir
 UPLOADS_DEFAULT_DEST = uplink_dir
 REMOTE_SEQ_DIRECTORY = "/seq"
 MAX_CONTENT_LENGTH = 32 * 1024 * 1024  # Max length of request is 32MiB
 
-# Gds config setup
-GDS_CONFIG = fprime_gds.common.utils.config_manager.ConfigManager()
 
-for directory in [LOG_DIR, UPLOADED_UPLINK_DEST, UPLOADS_DEFAULT_DEST, DOWNLINK_DIR]:
+for directory in [UPLOADED_UPLINK_DEST, UPLOADS_DEFAULT_DEST, DOWNLINK_DIR]:
     os.makedirs(directory, exist_ok=True)
 
 # TODO: load real config

--- a/test/fprime_gds/executables/test_run_deployment.py
+++ b/test/fprime_gds/executables/test_run_deployment.py
@@ -17,7 +17,7 @@ class TestRunDeployment(unittest.TestCase):
         with tempfile.TemporaryDirectory() as temporary_directory:
             self.create_fake_deployment_structure(temporary_directory)
             with mock.patch("sys.argv", ["main", "-g", "html", "-r", temporary_directory]):
-                run_deployment.get_settings()
+                run_deployment.parse_args()
 
     def create_fake_deployment_structure(self, temporary_directory):
         system_dir = Path(temporary_directory) / platform.system()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**||
|**_Affected Component_**| Integration Test API |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

There are several changes contained here:

1. Test API and pipeline had minor properties added
2. Command line argument processing cleaned-up and made more generic (for use within pytest)
3. Pytest fixtures published as pytest11 plugin allowing easy integration testing

## Rationale

The setup and attaching of the fprime-gds to the integration test runner should be generic and command-line driven.  It should not be on the shoulders of the test writer to figure out how to attach to a running GDS.

https://github.com/LeStarch/fprime/blob/update/streamlined-int-tests/Ref/test/int/ref_integration_test.py

The above re-implementation contains tests, and helpers.  It does not contain connection code.  That is provided by the fprime-gds via a pytest fixture.  



