### PR TITLE
fixing missing logs by flattening out log folder structure

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -297,10 +297,6 @@ class LogDeployParser(ParserBase):
     to end up in the proper place.
     """
 
-    # Class variable to store logs on first encounter of the logging call. This helps ensure that the logs all end up in
-    # a consistent directory, opposed to multiple directories across the system.
-    first_log = None
-
     DESCRIPTION = "Process arguments needed to specify a logging"
 
     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -340,6 +340,8 @@ class LogDeployParser(ParserBase):
                     args.logs, datetime.datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
                 )
             )
+            # A dated directory has been set, all log handling must now be direct
+            args.log_directly = True
 
         # Make sure directory exists
         try:

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -86,11 +86,14 @@ def launch_html(parsed_args):
     Return:
         launched process
     """
+    reproduced_arguments = StandardPipelineParser().reproduce_cli_args(parsed_args)
+    if "--log-directly" not in reproduced_arguments:
+        reproduced_arguments += ["--log-directly"]
     flask_env = os.environ.copy()
     flask_env.update(
         {
             "FLASK_APP": "fprime_gds.flask.app",
-            "STANDARD_PIPELINE_ARGUMENTS": "|".join(StandardPipelineParser().reproduce_cli_args(parsed_args)),
+            "STANDARD_PIPELINE_ARGUMENTS": "|".join(reproduced_arguments),
             "SERVE_LOGS": "YES",
         }
     )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes nasa/fprime#1885.

The "calculate a dated folder" code for logging only needs be run once.  All other logging (including over in the flask process) should be direct to that folder.
