### PR TITLE
Downlink files are placed in /tmp/<username>/fprime-downlink

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -250,6 +250,7 @@ getmembers
 getpid
 getroot
 getsize
+getuser
 github
 globals
 gmail

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -15,6 +15,7 @@ import os
 import re
 import platform
 import sys
+import getpass
 
 import fprime_gds.common.logger
 
@@ -527,11 +528,14 @@ class FileHandlingParser(ParserBase):
 
     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
         """Arguments to handle deployments"""
+
+        username = getpass.getuser()
+
         return {
             ("--file-storage-directory",): {
                 "dest": "files_directory",
                 "action": "store",
-                "default": "/tmp/fprime-downlink/",
+                "default": "/tmp/" + username + "/fprime-downlink/",
                 "required": False,
                 "type": str,
                 "help": "File to store uplink and downlink files. Default: %(default)s",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Downlinked files are placed in /tmp/<username>/fprime-downlink

## Rationale

This fixes the problem described in https://github.com/nasa/fprime/issues/1970


## Testing/Review Recommendations

Let different users try and download files.  The GDS should not throw a Permission Error

## Future Work

Note any additional work that will be done relating to this issue.
