### PR TITLE
Add `flake8-error-message` convention

### DIFF
--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -34,7 +34,8 @@ def check_port(address, port):
         socket_trial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         socket_trial.bind((address, port))
     except OSError as err:
-        raise OSError(f"Error with address/port of '{address}:{port}' : {err}")
+        msg = f"Error with address/port of '{address}:{port}' : {err}"
+        raise OSError(msg)
     finally:
         if socket_trial is not None:
             socket_trial.close()

--- a/src/fprime_gds/common/communication/adapters/uart.py
+++ b/src/fprime_gds/common/communication/adapters/uart.py
@@ -172,17 +172,20 @@ class SerialAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         """
         ports = map(lambda info: info.device, list_ports.comports(include_links=True))
         if args["device"] not in ports:
+            msg = f"Serial port '{args['device']}' not valid. Available ports: {ports}"
             raise ValueError(
-                f"Serial port '{args['device']}' not valid. Available ports: {ports}"
+                msg
             )
         # Note: baud rate may not *always* work. These are a superset
         try:
             baud = int(args["baud"])
         except ValueError:
+            msg = f"Serial baud rate '{args['baud']}' not integer. Use one of: {SerialAdapter.BAUDS}"
             raise ValueError(
-                f"""Serial baud rate '{args["baud"]}' not integer. Use one of: {SerialAdapter.BAUDS}"""
+                msg
             )
         if baud not in SerialAdapter.BAUDS:
+            msg = f"Serial baud rate '{baud}' not supported. Use one of: {SerialAdapter.BAUDS}"
             raise ValueError(
-                f"Serial baud rate '{baud}' not supported. Use one of: {SerialAdapter.BAUDS}"
+                msg
             )

--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -115,7 +115,8 @@ class FpFramerDeframer(FramerDeframer):
             FpFramerDeframer.TOKEN_TYPE = "B"
             FpFramerDeframer.START_TOKEN = 0xEF
         else:
-            raise ValueError(f"Invalid TOKEN_SIZE of {FpFramerDeframer.TOKEN_SIZE}")
+            msg = f"Invalid TOKEN_SIZE of {FpFramerDeframer.TOKEN_SIZE}"
+            raise ValueError(msg)
         FpFramerDeframer.HEADER_FORMAT = ">" + (FpFramerDeframer.TOKEN_TYPE * 2)
 
     def frame(self, data):

--- a/src/fprime_gds/common/decoders/ch_decoder.py
+++ b/src/fprime_gds/common/decoders/ch_decoder.py
@@ -77,14 +77,16 @@ class ChDecoder(Decoder):
             ptr += ch_time.getSize()
 
             if ch_id not in self.__dict:
-                raise DecodingException(f"Channel {ch_id} not found in dictionary")
+                msg = f"Channel {ch_id} not found in dictionary"
+                raise DecodingException(msg)
             # Retrieve the template instance for this channel
             ch_temp = self.__dict[ch_id]
 
             try:
                 val_obj = self.decode_ch_val(data, ptr, ch_temp)
             except Exception as exc:
-                raise DecodingException(f"Channel {ch_temp.name} failed to decode: {exc}")
+                msg = f"Channel {ch_temp.name} failed to decode: {exc}"
+                raise DecodingException(msg)
             ch_list.append(ChData(val_obj, ch_time, ch_temp))
             ptr += val_obj.getSize()
         return ch_list

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -75,7 +75,8 @@ class EventDecoder(decoder.Decoder):
             ptr += event_time.getSize()
 
             if event_id not in self.__dict:
-                raise DecodingException(f"Event {event_id} not found in dictionary")
+                msg = f"Event {event_id} not found in dictionary"
+                raise DecodingException(msg)
 
             event_temp = self.__dict[event_id]
 
@@ -119,7 +120,8 @@ class EventDecoder(decoder.Decoder):
                 arg_obj.deserialize(arg_data, offset)
                 arg_results.append(arg_obj)
             except TypeException as e:
-                raise DecodingException(f"Event argument decoding failed {e.getMsg()}")
+                msg = f"Event argument decoding failed {e.getMsg()}"
+                raise DecodingException(msg)
 
             offset = offset + arg_obj.getSize()
 

--- a/src/fprime_gds/common/encoders/file_encoder.py
+++ b/src/fprime_gds/common/encoders/file_encoder.py
@@ -90,7 +90,8 @@ class FileEncoder(encoder.Encoder):
         elif data.packetType == FilePacketType.END:
             out_data += struct.pack(">I", data.hashValue)
         elif data.packetType != FilePacketType.CANCEL:
-            raise Exception(f"Invalid packet type found while encoding: {data.packetType}")
+            msg = f"Invalid packet type found while encoding: {data.packetType}"
+            raise Exception(msg)
         descriptor = U32Type(DataDescType["FW_PACKET_FILE"].value).serialize()
         length_obj = self.config.get_type("msg_len")
         length_obj.val = len(descriptor) + len(out_data)

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -227,8 +227,9 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
         """
         # Prevent multiple uplinks at once
         if self.state != FileStates.IDLE:
+            msg = f"Currently uplinking file '{self.active.source}' cannot start uplinking '{file_obj.source}'"
             raise FileUplinkerBusyException(
-                f"Currently uplinking file '{self.active.source}' cannot start uplinking '{file_obj.source}'"
+                msg
             )
         self.state = FileStates.RUNNING
         self.active = file_obj

--- a/src/fprime_gds/common/loaders/ch_xml_loader.py
+++ b/src/fprime_gds/common/loaders/ch_xml_loader.py
@@ -54,8 +54,9 @@ class ChXmlLoader(XmlLoader):
         # Check if xml dict has channels section
         ch_section = self.get_xml_section(self.CH_SECT, xml_tree)
         if ch_section is None:
+            msg = f"Xml dict did not have a {self.CH_SECT} section"
             raise exceptions.GseControllerParsingException(
-                f"Xml dict did not have a {self.CH_SECT} section"
+                msg
             )
 
         id_dict = {}

--- a/src/fprime_gds/common/loaders/cmd_xml_loader.py
+++ b/src/fprime_gds/common/loaders/cmd_xml_loader.py
@@ -46,8 +46,9 @@ class CmdXmlLoader(XmlLoader):
         # Check if xml dict has commands section
         cmd_section = self.get_xml_section(self.CMD_SECT, xml_tree)
         if cmd_section is None:
+            msg = f"Xml dict did not have a {self.EVENT_SECT} section"
             raise exceptions.GseControllerParsingException(
-                f"Xml dict did not have a {self.EVENT_SECT} section"
+                msg
             )
 
         id_dict = {}

--- a/src/fprime_gds/common/loaders/event_xml_loader.py
+++ b/src/fprime_gds/common/loaders/event_xml_loader.py
@@ -48,8 +48,9 @@ class EventXmlLoader(XmlLoader):
         # Check if xml dict has events section
         event_section = self.get_xml_section(self.EVENT_SECT, xml_tree)
         if event_section is None:
+            msg = f"Xml dict did not have a {self.EVENT_SECT} section"
             raise exceptions.GseControllerParsingException(
-                f"Xml dict did not have a {self.EVENT_SECT} section"
+                msg
             )
 
         id_dict = {}

--- a/src/fprime_gds/common/loaders/pkt_xml_loader.py
+++ b/src/fprime_gds/common/loaders/pkt_xml_loader.py
@@ -93,8 +93,9 @@ class PktXmlLoader(XmlLoader):
         """
         packet_list = self.get_xml_tree(path)
         if packet_list.tag != self.PKT_LIST_TAG:
+            msg = f"expected packet list to have tag {self.PKT_LIST_TAG}, but found {packet_list.tag}"
             raise exceptions.GseControllerParsingException(
-                f"expected packet list to have tag {self.PKT_LIST_TAG}, but found {packet_list.tag}"
+                msg
             )
 
         id_dict = {}
@@ -113,8 +114,9 @@ class PktXmlLoader(XmlLoader):
                 ch_name = ch.attrib[self.CH_NAME_FIELD]
 
                 if ch_name not in ch_name_dict:
+                    msg = f"Channel {ch_name} in pkt {pkt_name}, but cannot be found in channel dictionary"
                     raise exceptions.GseControllerParsingException(
-                        f"Channel {ch_name} in pkt {pkt_name}, but cannot be found in channel dictionary"
+                        msg
                     )
 
                 ch_list.append(ch_name_dict[ch_name])

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -396,8 +396,9 @@ class XmlLoader(dict_loader.DictLoader):
             return result
 
         # Abandon all hope
+        msg = f"Could not find type {type_name}"
         raise exceptions.GseControllerParsingException(
-            f"Could not find type {type_name}"
+            msg
         )
 
 

--- a/src/fprime_gds/common/parsers/seq_file_parser.py
+++ b/src/fprime_gds/common/parsers/seq_file_parser.py
@@ -171,8 +171,9 @@ class SeqFileParser:
                     epoch = datetime.utcfromtimestamp(0)
                 delta = (dt - epoch).total_seconds()
             else:
+                msg = f"Line {lineNumber + 1}: Invalid time descriptor {d} found. Descriptor should either be 'A' for absolute times or 'R' for relative times"
                 raise gseExceptions.GseControllerParsingException(
-                    f"Line {lineNumber + 1}: Invalid time descriptor {d} found. Descriptor should either be 'A' for absolute times or 'R' for relative times"
+                    msg
                 )
             seconds = int(delta)
             useconds = int((delta - seconds) * 1000000)
@@ -190,14 +191,16 @@ class SeqFileParser:
                         line = splitString(line)
                         length = len(line)
                         if length < 2:
+                            msg = f'Line {i + 1}: Each line must contain a minimum of two fields, time and command mnemonic\n'
                             raise gseExceptions.GseControllerParsingException(
-                                f"Line {i + 1}: Each line must contain a minimum of two fields, time and command mnemonic\n"
+                                msg
                             )
                         try:
                             descriptor, seconds, useconds = parseTime(i, line[0])
                         except Exception:
+                            msg = f'Line {i + 1}: Encountered syntax error parsing timestamp'
                             raise gseExceptions.GseControllerParsingException(
-                                f"Line {i + 1}: Encountered syntax error parsing timestamp"
+                                msg
                             )
                         mnemonic = line[1]
                         args = []
@@ -206,8 +209,9 @@ class SeqFileParser:
                             try:
                                 args = parseArgs(args)
                             except Exception:
+                                msg = f'Line {i + 1}: Encountered syntax error parsing arguments'
                                 raise gseExceptions.GseControllerParsingException(
-                                    f"Line {i + 1}: Encountered syntax error parsing arguments"
+                                    msg
                                 )
                         yield i, descriptor, seconds, useconds, mnemonic, args
                 except gseExceptions.GseControllerParsingException as exc:

--- a/src/fprime_gds/common/pipeline/dictionaries.py
+++ b/src/fprime_gds/common/pipeline/dictionaries.py
@@ -98,7 +98,8 @@ class Dictionaries:
             self._channel_name_dict = channel_loader.get_name_dict(dictionary)
             assert self._versions == channel_loader.get_versions(), "Version mismatch while loading"
         else:
-            raise Exception(f"[ERROR] Dictionary '{dictionary}' does not exist.")
+            msg = f"[ERROR] Dictionary '{dictionary}' does not exist."
+            raise Exception(msg)
         # Check for packet specification
         if packet_spec is not None:
             packet_loader = fprime_gds.common.loaders.pkt_xml_loader.PktXmlLoader()

--- a/src/fprime_gds/common/tools/seqgen.py
+++ b/src/fprime_gds/common/tools/seqgen.py
@@ -48,10 +48,12 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
 
     # Check for files
     if not os.path.isfile(inputFile):
-        raise SeqGenException(f"Can't open file '{inputFile}'. ")
+        msg = f"Can't open file '{inputFile}'. "
+        raise SeqGenException(msg)
 
     if not os.path.isfile(dictionary):
-        raise SeqGenException(f"Can't open file '{dictionary}'. ")
+        msg = f"Can't open file '{dictionary}'. "
+        raise SeqGenException(msg)
 
     # Check the user environment:
     cmd_xml_dict = CmdXmlLoader()
@@ -60,7 +62,8 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
             dictionary
         )
     except gseExceptions.GseControllerUndefinedFileException:
-        raise SeqGenException(f"Can't open file '{dictionary}'. ")
+        msg = f"Can't open file '{dictionary}'. "
+        raise SeqGenException(msg)
 
     # Parse the input file:
     command_list = []
@@ -73,8 +76,9 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
         for i, descriptor, seconds, useconds, mnemonic, args in parsed_seq:
             try:
                 if mnemonic not in cmd_name_dict:
+                    msg = f"Line {i + 1}: '{mnemonic}' does not match any command in the command dictionary."
                     raise SeqGenException(
-                        f"Line {i+1}: '{mnemonic}' does not match any command in the command dictionary."
+                        msg
                     )
                 # Set the command arguments:
                 try:
@@ -90,8 +94,9 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
                         cmd_time=cmd_time,
                     )
                 except CommandArgumentsException as e:
+                    msg = f"Line {i + 1}: {mnemonic} errored: {','.join(e.errors)}"
                     raise SeqGenException(
-                        f"Line { i + 1 }: { mnemonic } errored: { ','.join(e.errors) }"
+                        msg
                     )
                 command_list.append(cmd_data)
             except SeqGenException as exc:
@@ -110,8 +115,9 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
     try:
         writer.open(outputFile)
     except:
+        msg = f"Encountered problem opening output file '{outputFile}'."
         raise SeqGenException(
-            f"Encountered problem opening output file '{outputFile}'."
+            msg
         )
 
     writer.write(command_list)

--- a/src/fprime_gds/common/transport.py
+++ b/src/fprime_gds/common/transport.py
@@ -214,12 +214,14 @@ class ThreadedTCPSocketClient(ThreadedTransportClient):
             self.sock.send(b"Register %s\n" % incoming_routing.value)
             super().connect(connection_uri, incoming_routing, outgoing_routing)
         except ValueError as vle:
+            msg = f"Failed to parse connection uri: {connection_uri}. {vle}"
             raise TransportationException(
-                f"Failed to parse connection uri: {connection_uri}. {vle}"
+                msg
             )
         except Exception as exc:
+            msg = f"Failed to connect to transportation layer at: {connection_uri}. {exc}"
             raise TransportationException(
-                f"Failed to connect to transportation layer at: {connection_uri}. {exc}"
+                msg
             )
 
     def disconnect(self):

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -221,7 +221,8 @@ class DetectionParser(ParserBase):
             return args
         detected_toolchain = get_artifacts_root() / platform.system()
         if not detected_toolchain.exists():
-            raise Exception(f"{detected_toolchain} does not exist. Make sure to build.")
+            msg = f"{detected_toolchain} does not exist. Make sure to build."
+            raise Exception(msg)
         likely_deployment = detected_toolchain / Path.cwd().name
         # Check if the deployment exists
         if likely_deployment.exists():
@@ -229,13 +230,15 @@ class DetectionParser(ParserBase):
             return args
         child_directories = [child for child in detected_toolchain.iterdir() if child.is_dir()]
         if not child_directories:
-            raise Exception(f"No deployments found in {detected_toolchain}. Specify deployment with: --deployment")
+            msg = f"No deployments found in {detected_toolchain}. Specify deployment with: --deployment"
+            raise Exception(msg)
         # Works for the old structure where the bin, lib, and dict directories live immediately under the platform
         elif len(child_directories) == 3 and set([path.name for path in child_directories]) == {"bin", "lib", "dict"}:
             args.deployment = detected_toolchain
             return args
         elif len(child_directories) > 1:
-            raise Exception(f"Multiple deployments found in {detected_toolchain}. Choose using: --deployment")
+            msg = f"Multiple deployments found in {detected_toolchain}. Choose using: --deployment"
+            raise Exception(msg)
         args.deployment = child_directories[0]
         return args
 
@@ -516,7 +519,8 @@ class DictionaryParser(DetectionParser):
         """Handle arguments as parsed"""
         # Find dictionary setting via "dictionary" argument or the "deploy" argument
         if args.dictionary is not None and not os.path.exists(args.dictionary):
-            raise ValueError(f"Dictionary file {args.dictionary} does not exist")
+            msg = f"Dictionary file {args.dictionary} does not exist"
+            raise ValueError(msg)
         elif args.dictionary is None:
             args = super().handle_arguments(args, **kwargs)
             args.dictionary = find_dict(args.deployment)
@@ -696,8 +700,9 @@ class BinaryDeployment(DetectionParser):
         args = super().handle_arguments(args, **kwargs)
         args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
         if not args.app.is_file():
+            msg = f"F prime binary '{args.app}' does not exist or is not a file"
             raise ValueError(
-                f"F prime binary '{args.app}' does not exist or is not a file"
+                msg
             )
         return args
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -53,7 +53,8 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
                         print(f"    [LOG] {line.strip()}", file=sys.stderr)
         except Exception:
             pass
-        raise AppWrapperException(f"Failed to run {name}")
+        msg = f"Failed to run {name}"
+        raise AppWrapperException(msg)
 
 
 def launch_tts(parsed_args):

--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -266,7 +266,8 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             data = tlm_packet_size + self.recv(size)
 
         else:
-            raise RuntimeError(f"unrecognized client {dst.decode(DATA_ENCODING)}")
+            msg = f"unrecognized client {dst.decode(DATA_ENCODING)}"
+            raise RuntimeError(msg)
         return data
 
     def processNewPkt(self, header, data):

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -104,7 +104,8 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
             print(f"[INFO] Log File: {logfile}")
             file_handler = open(logfile, "wb", 0)
     except OSError as exc:
-        raise AppWrapperException(f"Failed to open: {logfile} with error {str(exc)}.")
+        msg = f"Failed to open: {logfile} with error {str(exc)}."
+        raise AppWrapperException(msg)
     # Spawn the process. Uses pexpect, as this will force the process to output data immediately, rather than buffering
     # the output. That way the log file is fully up-to-date.
     try:
@@ -122,8 +123,9 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
                 )
         return child
     except Exception as exc:
+        msg = f"Failed to run application: {' '.join(arguments)}. Error: {exc}"
         raise AppWrapperException(
-            f'Failed to run application: {" ".join(arguments)}. Error: {exc}'
+            msg
         )
 
 

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -207,7 +207,8 @@ def config_for_set(uset, app, defaults=None):
                 using_defaults = True
                 destination = os.path.join(defaults["dest"], uset.name)
             else:
-                raise RuntimeError(f"no destination for set {uset.name}")
+                msg = f"no destination for set {uset.name}"
+                raise RuntimeError(msg)
 
     if base_url is None and using_defaults and defaults["url"]:
         base_url = addslash(defaults["url"]) + uset.name + "/"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This feature implements the [flake8-err-msg](https://pypi.org/project/flake8-errmsg/) which allows the formatting of nice error messages.

## Rationale

The problem is that Python includes the line with the lift in the default traceback. This means that a user receives a message like this:

```py
sub = "Some value"
raise RuntimeError(f"{sub!r} is incorrect")
```

```sh
Traceback (most recent call last):
  File "tmp.py", line 2, in <module>
    raise RuntimeError(f"{sub!r} is incorrect")
RuntimeError: 'Some value' is incorrect
```

If it is longer or more complex, the duplication can be confusing for a user not used to reading tracebacks.

On the other hand, if you always assign to something like msg, you get :

```py
sub = "Some value"
msg = f"{sub!r} is incorrect"
raise RunetimeError(msg)
```

```sh
Traceback (most recent call last):
  File "tmp.py", line 3, in <module>
    raise RuntimeError(msg)
RuntimeError: 'Some value' is incorrect
```

There is now a more straightforward trace, less code and no double messages.

[Ref - Ruff linter](https://beta.ruff.rs/docs/rules/f-string-in-exception/)

## Testing/Review Recommendations

Inspection is enough

## Future Work

None
