### PR TITLE
Add consistency to imports based on `isort` settings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ from pathlib import Path
 
 import sphinx_rtd_theme  # pylint: disable=unused-import
 
-
 # importlib.metadata is implemented in Python 3.8
 # Previous versions require the backport, https://pypi.org/project/importlib-metadata/
 try:

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@
 
 from setuptools import find_packages, setup
 
-
 ####
 # GDS Packages:
 #

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -7,16 +7,16 @@ across a Tcp and/or UDP network interface.
 
 @author lestarch
 """
-import atexit
 import abc
+import atexit
 import logging
 import queue
 import socket
 import threading
 import time
 
-import fprime_gds.common.logger
 import fprime_gds.common.communication.adapters.base
+import fprime_gds.common.logger
 
 LOGGER = logging.getLogger("ip_adapter")
 

--- a/src/fprime_gds/common/communication/adapters/uart.py
+++ b/src/fprime_gds/common/communication/adapters/uart.py
@@ -10,11 +10,10 @@ drivers.
 
 import logging
 
-import fprime_gds.common.communication.adapters.base
-
 import serial
 from serial.tools import list_ports
 
+import fprime_gds.common.communication.adapters.base
 
 LOGGER = logging.getLogger("serial_adapter")
 

--- a/src/fprime_gds/common/communication/framing.py
+++ b/src/fprime_gds/common/communication/framing.py
@@ -12,9 +12,10 @@ that implement this pattern. The current list of implementation classes are:
 @author lestarch
 """
 import abc
-import sys
 import copy
 import struct
+import sys
+
 from .checksum import calculate_checksum
 
 

--- a/src/fprime_gds/common/communication/ground.py
+++ b/src/fprime_gds/common/communication/ground.py
@@ -11,8 +11,9 @@ available to the comm layer, and currently a single implementation used to attac
 import abc
 import logging
 
-from .framing import TcpServerFramerDeframer
 from fprime_gds.common.communication.adapters.ip import TcpHandler
+
+from .framing import TcpServerFramerDeframer
 
 LOGGER = logging.getLogger("gds_sender")
 

--- a/src/fprime_gds/common/communication/updown.py
+++ b/src/fprime_gds/common/communication/updown.py
@@ -9,16 +9,16 @@ Uplink is the reverse, it pulls data in from the ground handler, frames it, and 
 is represented by a single thread, as it is not dealing with multiple streams of data that need to be multiplexed.
 
 """
-import threading
-from queue import Queue, Full, Empty
 import logging
+import threading
+from queue import Empty, Full, Queue
 
 from fprime.common.models.serialize.numerical_types import U32Type
-from fprime_gds.common.utils.data_desc_type import DataDescType
-from fprime_gds.common.communication.adapters.base import BaseAdapter
-from fprime_gds.common.communication.ground import GroundHandler
-from fprime_gds.common.communication.framing import FramerDeframer
 
+from fprime_gds.common.communication.adapters.base import BaseAdapter
+from fprime_gds.common.communication.framing import FramerDeframer
+from fprime_gds.common.communication.ground import GroundHandler
+from fprime_gds.common.utils.data_desc_type import DataDescType
 
 DW_LOGGER = logging.getLogger("downlink")
 UP_LOGGER = logging.getLogger("uplink")

--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -8,10 +8,11 @@
 """
 
 from fprime.common.models.serialize import time_type
+from fprime.common.models.serialize.array_type import ArrayType
+from fprime.common.models.serialize.serializable_type import SerializableType
+
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
-from fprime.common.models.serialize.serializable_type import SerializableType
-from fprime.common.models.serialize.array_type import ArrayType
 
 
 class ChData(sys_data.SysData):

--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -10,10 +10,13 @@ argument values.
 @bug No known bugs
 """
 import json
+
 from fprime.common.models.serialize.array_type import ArrayType
 from fprime.common.models.serialize.bool_type import BoolType
 from fprime.common.models.serialize.enum_type import EnumType
 from fprime.common.models.serialize.numerical_types import (
+    F32Type,
+    F64Type,
     I8Type,
     I16Type,
     I32Type,
@@ -22,12 +25,11 @@ from fprime.common.models.serialize.numerical_types import (
     U16Type,
     U32Type,
     U64Type,
-    F32Type,
-    F64Type,
 )
 from fprime.common.models.serialize.serializable_type import SerializableType
 from fprime.common.models.serialize.string_type import StringType
 from fprime.common.models.serialize.time_type import TimeBase, TimeType
+
 from fprime_gds.common.data_types import sys_data
 
 

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -8,6 +8,7 @@
 """
 
 from fprime.common.models.serialize import time_type
+
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
 

--- a/src/fprime_gds/common/data_types/sys_data.py
+++ b/src/fprime_gds/common/data_types/sys_data.py
@@ -11,6 +11,7 @@ of the data as well as data such as channel value or argument value.
 @bug No known bugs
 """
 from fprime.common.models.serialize import time_type
+
 from fprime_gds.common.templates import data_template
 
 

--- a/src/fprime_gds/common/decoders/ch_decoder.py
+++ b/src/fprime_gds/common/decoders/ch_decoder.py
@@ -17,6 +17,7 @@ Example data that would be sent to a decoder that parses channels:
 @bug No known bugs
 """
 from fprime.common.models.serialize.time_type import TimeType
+
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.decoders.decoder import Decoder, DecodingException
 from fprime_gds.common.utils import config_manager

--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -16,6 +16,7 @@ Example data structure:
 """
 from fprime.common.models.serialize import time_type
 from fprime.common.models.serialize.type_exceptions import TypeException
+
 from fprime_gds.common.data_types import event_data
 from fprime_gds.common.decoders import decoder
 from fprime_gds.common.utils import config_manager

--- a/src/fprime_gds/common/decoders/pkt_decoder.py
+++ b/src/fprime_gds/common/decoders/pkt_decoder.py
@@ -18,6 +18,7 @@ Example data that would be sent to a decoder that parses events or channels:
 """
 
 from fprime.common.models.serialize.time_type import TimeType
+
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.decoders.ch_decoder import ChDecoder
 from fprime_gds.common.utils import config_manager

--- a/src/fprime_gds/common/distributor/distributor.py
+++ b/src/fprime_gds/common/distributor/distributor.py
@@ -14,10 +14,10 @@ descriptor header will be passed on to the registered objects.
 @bug No known bugs
 """
 import logging
-from fprime_gds.common.utils import config_manager, data_desc_type
-from fprime_gds.common.handlers import DataHandler
-from fprime_gds.common.decoders.decoder import DecodingException
 
+from fprime_gds.common.decoders.decoder import DecodingException
+from fprime_gds.common.handlers import DataHandler
+from fprime_gds.common.utils import config_manager, data_desc_type
 
 LOGGER = logging.getLogger("distributor")
 

--- a/src/fprime_gds/common/encoders/ch_encoder.py
+++ b/src/fprime_gds/common/encoders/ch_encoder.py
@@ -32,9 +32,10 @@ Serialized Ch format:
 @bug No known bugs
 """
 
-from .encoder import Encoder
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.utils.data_desc_type import DataDescType
+
+from .encoder import Encoder
 
 
 class ChEncoder(Encoder):

--- a/src/fprime_gds/common/encoders/cmd_encoder.py
+++ b/src/fprime_gds/common/encoders/cmd_encoder.py
@@ -42,11 +42,13 @@ Serialized command format:
 """
 
 
-from . import encoder
 from fprime.common.models.serialize.numerical_types import U32Type
+
 from fprime_gds.common.data_types.cmd_data import CmdData
-from fprime_gds.common.utils.data_desc_type import DataDescType
 from fprime_gds.common.utils import config_manager
+from fprime_gds.common.utils.data_desc_type import DataDescType
+
+from . import encoder
 
 
 class CmdEncoder(encoder.Encoder):

--- a/src/fprime_gds/common/encoders/event_encoder.py
+++ b/src/fprime_gds/common/encoders/event_encoder.py
@@ -37,9 +37,10 @@ Serialized Event format:
 @bug No known bugs
 """
 
-from .encoder import Encoder
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.utils.data_desc_type import DataDescType
+
+from .encoder import Encoder
 
 
 class EventEncoder(Encoder):

--- a/src/fprime_gds/common/encoders/file_encoder.py
+++ b/src/fprime_gds/common/encoders/file_encoder.py
@@ -45,6 +45,7 @@ import struct
 
 from fprime.common.models.serialize.numerical_types import U32Type
 from fprime.constants import DATA_ENCODING
+
 from fprime_gds.common.data_types.file_data import FilePacketType
 from fprime_gds.common.utils.data_desc_type import DataDescType
 

--- a/src/fprime_gds/common/encoders/pkt_encoder.py
+++ b/src/fprime_gds/common/encoders/pkt_encoder.py
@@ -37,9 +37,10 @@ Serialized Packet format:
 @bug No known bugs
 """
 
-from .encoder import Encoder
 from fprime_gds.common.data_types.pkt_data import PktData
 from fprime_gds.common.utils.data_desc_type import DataDescType
+
+from .encoder import Encoder
 
 
 class PktEncoder(Encoder):

--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -7,8 +7,9 @@ Created on August 16, 2019
 import struct
 import zlib
 
-from fprime.common.models.serialize.type_exceptions import TypeMismatchException
 from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
+from fprime.common.models.serialize.type_exceptions import TypeMismatchException
+
 from fprime_gds.common.utils import config_manager
 from fprime_gds.common.utils.data_desc_type import DataDescType
 

--- a/src/fprime_gds/common/files/downlinker.py
+++ b/src/fprime_gds/common/files/downlinker.py
@@ -14,6 +14,7 @@ import logging
 import os
 
 import fprime.constants
+
 import fprime_gds.common.handlers
 from fprime_gds.common.data_types.file_data import FilePacketType
 from fprime_gds.common.files.helpers import (

--- a/src/fprime_gds/common/gds_cli/base_commands.py
+++ b/src/fprime_gds/common/gds_cli/base_commands.py
@@ -4,8 +4,8 @@ CLI commands
 """
 
 import abc
-import sys
 import json
+import sys
 from typing import Iterable
 
 import fprime_gds.common.gds_cli.filtering_utils as filtering_utils

--- a/src/fprime_gds/common/gds_cli/command_send.py
+++ b/src/fprime_gds/common/gds_cli/command_send.py
@@ -5,8 +5,9 @@ Handles executing the "command-send" CLI command for the GDS
 import difflib
 from typing import Iterable, List
 
-import fprime_gds.common.gds_cli.test_api_utils as test_api_utils
 from fprime.common.models.serialize.type_exceptions import NotInitializedException
+
+import fprime_gds.common.gds_cli.test_api_utils as test_api_utils
 from fprime_gds.common.gds_cli.base_commands import BaseCommand
 from fprime_gds.common.pipeline.dictionaries import Dictionaries
 from fprime_gds.common.templates.cmd_template import CmdTemplate

--- a/src/fprime_gds/common/gds_cli/test_api_utils.py
+++ b/src/fprime_gds/common/gds_cli/test_api_utils.py
@@ -3,7 +3,7 @@ A file containing utilities for interacting with the Integration Test API
 """
 
 import types
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.data_types.event_data import EventData
@@ -11,7 +11,6 @@ from fprime_gds.common.data_types.sys_data import SysData
 from fprime_gds.common.templates.data_template import DataTemplate
 from fprime_gds.common.testing_fw import predicates
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
-from typing import Callable
 
 
 def get_upcoming_event(

--- a/src/fprime_gds/common/history/chrono.py
+++ b/src/fprime_gds/common/history/chrono.py
@@ -7,6 +7,7 @@ retrieval operations. This history will re-order itself based on FSW time.
 :author: koran
 """
 from fprime.common.models.serialize.time_type import TimeType
+
 from fprime_gds.common.history.history import History
 from fprime_gds.common.testing_fw import predicates
 

--- a/src/fprime_gds/common/history/ram.py
+++ b/src/fprime_gds/common/history/ram.py
@@ -9,8 +9,8 @@ Note: this RAM history treats "start times" as session tokens to remember where 
 
 :author: lestarch
 """
-import time
 import threading
+import time
 
 from fprime_gds.common.history.history import History
 

--- a/src/fprime_gds/common/loaders/event_py_loader.py
+++ b/src/fprime_gds/common/loaders/event_py_loader.py
@@ -8,6 +8,7 @@
 """
 
 from fprime.common.models.serialize.type_exceptions import TypeMismatchException
+
 from fprime_gds.common.templates import event_template
 from fprime_gds.common.utils.event_severity import EventSeverity
 

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -14,12 +14,13 @@ helper functions
 @bug No known bugs
 """
 import os
-from lxml import etree
 
 from fprime.common.models.serialize.array_type import ArrayType
 from fprime.common.models.serialize.bool_type import BoolType
 from fprime.common.models.serialize.enum_type import EnumType
 from fprime.common.models.serialize.numerical_types import (
+    F32Type,
+    F64Type,
     I8Type,
     I16Type,
     I32Type,
@@ -28,15 +29,15 @@ from fprime.common.models.serialize.numerical_types import (
     U16Type,
     U32Type,
     U64Type,
-    F32Type,
-    F64Type,
 )
 from fprime.common.models.serialize.serializable_type import SerializableType
 from fprime.common.models.serialize.string_type import StringType
+from lxml import etree
+
 from fprime_gds.common.data_types import exceptions
 from fprime_gds.version import (
-    MINIMUM_SUPPORTED_FRAMEWORK_VERSION,
     MAXIMUM_SUPPORTED_FRAMEWORK_VERSION,
+    MINIMUM_SUPPORTED_FRAMEWORK_VERSION,
 )
 
 # Custom Python Modules

--- a/src/fprime_gds/common/logger/test_logger.py
+++ b/src/fprime_gds/common/logger/test_logger.py
@@ -22,8 +22,8 @@ import time
 # If openpyxl isn't installed, ignore all functionality in this module
 try:
     from openpyxl import Workbook
-    from openpyxl.styles import PatternFill, Font, Alignment
     from openpyxl.cell import WriteOnlyCell
+    from openpyxl.styles import Alignment, Font, PatternFill
     from openpyxl.utils.exceptions import WorkbookAlreadySaved
 
     MODULE_INSTALLED = True

--- a/src/fprime_gds/common/models/common/command.py
+++ b/src/fprime_gds/common/models/common/command.py
@@ -7,6 +7,7 @@ Created on Jan 5, 2015
 import copy
 from enum import Enum
 
+from fprime.common.models.serialize.numerical_types import U32Type
 from fprime.common.models.serialize.type_base import BaseType
 
 # Import the types this way so they do not need prefixing for execution.
@@ -15,7 +16,6 @@ from fprime.common.models.serialize.type_exceptions import (
     ArgNotFoundException,
     TypeMismatchException,
 )
-from fprime.common.models.serialize.numerical_types import U32Type
 
 Descriptor = Enum(value="Descriptor", names="ABSOLUTE RELATIVE")
 

--- a/src/fprime_gds/common/pipeline/histories.py
+++ b/src/fprime_gds/common/pipeline/histories.py
@@ -7,6 +7,7 @@ to compose in this code.
 @author mstarch
 """
 from typing import Type
+
 from fprime_gds.common.history.history import History
 from fprime_gds.common.history.ram import RamHistory
 

--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -12,15 +12,16 @@ import datetime
 import os.path
 from pathlib import Path
 from typing import Type
+
 import fprime.common.models.serialize.time_type
+
 import fprime_gds.common.data_types.cmd_data
 import fprime_gds.common.distributor.distributor
 import fprime_gds.common.logger.data_logger
+from fprime_gds.common.transport import RoutingTag, ThreadedTCPSocketClient
 
 # Local imports for the sake of composition
 from . import dictionaries, encoding, files, histories
-
-from fprime_gds.common.transport import RoutingTag, ThreadedTCPSocketClient
 
 
 class StandardPipeline:

--- a/src/fprime_gds/common/templates/event_template.py
+++ b/src/fprime_gds/common/templates/event_template.py
@@ -12,6 +12,7 @@ or cmdSeq_CS_CmdStarted
 
 from fprime.common.models.serialize import type_base
 from fprime.common.models.serialize.type_exceptions import TypeMismatchException
+
 from fprime_gds.common.utils.event_severity import EventSeverity
 
 from . import data_template

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -11,6 +11,7 @@ import signal
 import time
 
 from fprime.common.models.serialize.time_type import TimeType
+
 from fprime_gds.common.handlers import DataHandler
 from fprime_gds.common.history.chrono import ChronologicalHistory
 from fprime_gds.common.history.test import TestHistory

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -15,11 +15,11 @@ Here a test (defined by starting the name with test_) uses the fprime_test_api f
 @author lestarch
 """
 import sys
+
 import pytest
 
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 from fprime_gds.executables.cli import StandardPipelineParser
-
 
 SEQUENCE_COUNTER = -1
 

--- a/src/fprime_gds/common/tools/seqgen.py
+++ b/src/fprime_gds/common/tools/seqgen.py
@@ -17,13 +17,13 @@ import argparse
 import os
 import sys
 
+from fprime.common.models.serialize.time_type import TimeBase, TimeType
+
 from fprime_gds.common.data_types import exceptions as gseExceptions
+from fprime_gds.common.data_types.cmd_data import CmdData, CommandArgumentsException
 from fprime_gds.common.encoders.seq_writer import SeqBinaryWriter
 from fprime_gds.common.loaders.cmd_xml_loader import CmdXmlLoader
 from fprime_gds.common.parsers.seq_file_parser import SeqFileParser
-from fprime_gds.common.data_types.cmd_data import CmdData, CommandArgumentsException
-from fprime.common.models.serialize.time_type import TimeBase, TimeType
-
 
 __author__ = "Tim Canham"
 __version__ = "1.0"

--- a/src/fprime_gds/common/transport.py
+++ b/src/fprime_gds/common/transport.py
@@ -7,11 +7,11 @@ ThreadedTCPSocketClient used to send data through the threaded tcp server.
 
 @author lestarch
 """
-from abc import abstractmethod, ABC
-from enum import Enum
 import select
 import socket
 import threading
+from abc import ABC, abstractmethod
+from enum import Enum
 
 from fprime_gds.common.handlers import DataHandler, HandlerRegistrar
 

--- a/src/fprime_gds/common/utils/config_manager.py
+++ b/src/fprime_gds/common/utils/config_manager.py
@@ -18,6 +18,8 @@ import configparser
 
 # Custom type modules
 from fprime.common.models.serialize.numerical_types import (
+    F32Type,
+    F64Type,
     I8Type,
     I16Type,
     I32Type,
@@ -26,8 +28,6 @@ from fprime.common.models.serialize.numerical_types import (
     U16Type,
     U32Type,
     U64Type,
-    F32Type,
-    F64Type,
 )
 
 

--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -7,8 +7,8 @@ Utility functions to process strings to be used in FPrime GDS
 Note: This function has an identical copy in fprime-gds
 """
 
-import re
 import logging
+import re
 
 LOGGER = logging.getLogger("string_util_logger")
 

--- a/src/fprime_gds/common/zmq_transport.py
+++ b/src/fprime_gds/common/zmq_transport.py
@@ -11,9 +11,9 @@ replace the ThreadedTcpServer for several reasons as described below.
 """
 import logging
 import struct
-import zmq
-
 from typing import Tuple
+
+import zmq
 
 from fprime_gds.common.communication.ground import GroundHandler
 from fprime_gds.common.transport import (
@@ -21,6 +21,7 @@ from fprime_gds.common.transport import (
     ThreadedTransportClient,
     TransportationException,
 )
+
 LOGGER = logging.getLogger("transport")
 
 class ZmqWrapper(object):

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -10,32 +10,30 @@ code that they are importing.
 import argparse
 import datetime
 import errno
+import getpass
 import itertools
 import os
-import re
 import platform
+import re
 import sys
-import getpass
-
-import fprime_gds.common.logger
-
-# Required to set the checksum as a module variable
-import fprime_gds.common.communication.checksum
-
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
+# Required to set the checksum as a module variable
+import fprime_gds.common.communication.checksum
+import fprime_gds.common.logger
 from fprime_gds.common.communication.adapters.base import BaseAdapter
 from fprime_gds.common.communication.adapters.ip import check_port
 from fprime_gds.common.pipeline.standard import StandardPipeline
 from fprime_gds.common.transport import ThreadedTCPSocketClient
-from fprime_gds.executables.utils import get_artifacts_root, find_dict, find_app
 from fprime_gds.common.utils.config_manager import ConfigManager
+from fprime_gds.executables.utils import find_app, find_dict, get_artifacts_root
 
 # Optional import: ZeroMQ. Requires package: pyzmq
 try:
     import zmq
+
     from fprime_gds.common.zmq_transport import ZmqClient
 except ImportError:
     zmq = None

--- a/src/fprime_gds/executables/comm.py
+++ b/src/fprime_gds/executables/comm.py
@@ -18,9 +18,8 @@ Note: assuming the module containing the ground adapter has been imported, then 
 
 
 import logging
-import sys
 import signal
-
+import sys
 
 # Required adapters built on standard tools
 try:
@@ -28,12 +27,11 @@ try:
 except ImportError:
     ZmqGround = None
 import fprime_gds.common.communication.adapters.base
+import fprime_gds.common.communication.adapters.ip
 import fprime_gds.common.communication.checksum
 import fprime_gds.common.communication.ground
-import fprime_gds.common.communication.adapters.ip
 import fprime_gds.common.logger
 import fprime_gds.executables.cli
-
 from fprime_gds.common.communication.framing import FpFramerDeframer
 from fprime_gds.common.communication.updown import Downlinker, Uplinker
 

--- a/src/fprime_gds/executables/fprime_cli.py
+++ b/src/fprime_gds/executables/fprime_cli.py
@@ -8,13 +8,13 @@ command with the user-provided arguments on the GDS
 
 import abc
 import argparse
-from copy import deepcopy
 import os
 import sys
-import pkg_resources
+from copy import deepcopy
 from typing import Callable, List, Union
 
 import argcomplete
+import pkg_resources
 
 # NOTE: These modules are now only lazily loaded below as needed, due to slow
 # performance when importing them
@@ -23,9 +23,9 @@ import argcomplete
 # import fprime_gds.common.gds_cli.events as events
 # from fprime_gds.common.pipeline.dictionaries import Dictionaries
 from fprime_gds.executables.cli import (
-    StandardPipelineParser,
-    SearchArgumentsParser,
     RetrievalArgumentsParser,
+    SearchArgumentsParser,
+    StandardPipelineParser,
 )
 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -7,9 +7,14 @@ import os
 import sys
 import webbrowser
 
-from fprime_gds.executables.cli import StandardPipelineParser, GdsParser, BinaryDeployment, CommParser, ParserBase
-from fprime_gds.executables.utils import run_wrapped_application, AppWrapperException
-
+from fprime_gds.executables.cli import (
+    BinaryDeployment,
+    CommParser,
+    GdsParser,
+    ParserBase,
+    StandardPipelineParser,
+)
+from fprime_gds.executables.utils import AppWrapperException, run_wrapped_application
 
 BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
 

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -9,10 +9,11 @@ import subprocess
 import sys
 import time
 from pathlib import Path
+
 from fprime.fbuild.settings import (
-    IniSettings,
     FprimeLocationUnknownException,
     FprimeSettingsException,
+    IniSettings,
 )
 
 # Python 2.7 compatibility, adding in missing error type

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sys
 import uuid
+
 import flask
 
 # Try to import Compress, but disable compression if not installed
@@ -17,24 +18,21 @@ try:
 except ImportError:
     Compress = None
 
-from fprime_gds.flask import flask_uploads
-
 import fprime_gds.flask.channels
 
 # Import the Flask API implementations
 import fprime_gds.flask.commands
+import fprime_gds.flask.errors
 import fprime_gds.flask.events
 import fprime_gds.flask.json
 import fprime_gds.flask.logs
-import fprime_gds.flask.updown
 import fprime_gds.flask.sequence
 import fprime_gds.flask.stats
-import fprime_gds.flask.errors
-
+import fprime_gds.flask.updown
 from fprime_gds.executables.cli import ParserBase, StandardPipelineParser
+from fprime_gds.flask import flask_uploads
 
 from . import components
-
 
 # Update logging to avoid redundant messages
 logger = logging.getLogger("werkzeug")

--- a/src/fprime_gds/flask/commands.py
+++ b/src/fprime_gds/flask/commands.py
@@ -21,11 +21,11 @@
 #       a restful interface here. It is done this way to be in-tandem with the events and telemetry
 #       APIs for maintainability.
 ####
-import werkzeug.exceptions
 import flask_restful
 import flask_restful.reqparse
-
 import fprime.common.models.serialize.type_exceptions
+import werkzeug.exceptions
+
 import fprime_gds.common.data_types.cmd_data
 from fprime_gds.flask.resource import DictionaryResource, HistoryResourceBase
 

--- a/src/fprime_gds/flask/components.py
+++ b/src/fprime_gds/flask/components.py
@@ -6,9 +6,8 @@ pipeline and other components are created to interact with Flask.
 """
 import os
 
-from fprime_gds.common.pipeline.standard import StandardPipeline
 from fprime_gds.common.history.ram import SelfCleaningRamHistory
-
+from fprime_gds.common.pipeline.standard import StandardPipeline
 from fprime_gds.executables.cli import StandardPipelineParser
 
 # Module variables, should remain hidden. These are singleton top-level objects used by Flask, and its various

--- a/src/fprime_gds/flask/errors.py
+++ b/src/fprime_gds/flask/errors.py
@@ -6,7 +6,7 @@ more stable and less likely to fail on errors that occur.
 @author lestarch
 """
 
-from flask import jsonify, Flask
+from flask import Flask, jsonify
 from flask_restful import Api
 
 

--- a/src/fprime_gds/flask/flask_uploads.py
+++ b/src/fprime_gds/flask/flask_uploads.py
@@ -22,13 +22,11 @@ else:
 
 import os.path
 import posixpath
-
-from flask import current_app, send_from_directory, abort, url_for
 from itertools import chain  # lgtm [py/unused-import]
+
+from flask import Blueprint, abort, current_app, send_from_directory, url_for
 from werkzeug.datastructures import FileStorage
 from werkzeug.utils import secure_filename
-
-from flask import Blueprint
 
 # Extension presets
 

--- a/src/fprime_gds/flask/json.py
+++ b/src/fprime_gds/flask/json.py
@@ -9,14 +9,14 @@ from inspect import getmembers, isroutine
 from typing import Type
 from uuid import UUID
 
-from fprime.common.models.serialize.type_base import BaseType, ValueType
+import flask.json
 from fprime.common.models.serialize.time_type import TimeType
-from fprime_gds.common.data_types.cmd_data import CmdData
+from fprime.common.models.serialize.type_base import BaseType, ValueType
+
 from fprime_gds.common.data_types.ch_data import ChData
+from fprime_gds.common.data_types.cmd_data import CmdData
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.templates.data_template import DataTemplate
-
-import flask.json
 
 
 def jsonify_base_type(input_type: Type[BaseType]) -> dict:

--- a/src/fprime_gds/flask/logs.py
+++ b/src/fprime_gds/flask/logs.py
@@ -2,6 +2,7 @@
 # Handles GDS logs in a lazy-loading way
 ####
 import os
+
 import flask_restful
 import flask_restful.reqparse
 

--- a/src/fprime_gds/flask/resource.py
+++ b/src/fprime_gds/flask/resource.py
@@ -7,6 +7,7 @@ establish standard patterns, and prevent replicated errors.
 """
 from flask_restful import Resource
 from flask_restful.reqparse import RequestParser
+
 from fprime_gds.flask.errors import build_error_object
 
 

--- a/src/fprime_gds/flask/sequence.py
+++ b/src/fprime_gds/flask/sequence.py
@@ -1,14 +1,15 @@
 ####
 #
 ####
-from pathlib import Path
 import re
 import sys
 from io import StringIO
+from pathlib import Path
+
 import flask_restful
 import flask_restful.reqparse
 
-from fprime_gds.common.tools.seqgen import generateSequence, SeqGenException
+from fprime_gds.common.tools.seqgen import SeqGenException, generateSequence
 
 
 class StdioTheif(object):

--- a/src/fprime_gds/flask/stats.py
+++ b/src/fprime_gds/flask/stats.py
@@ -2,9 +2,10 @@
 
 Statistics package for the GDS to help diagnose performance issues and give greater visibility into the running GDS.
 """
+from typing import Dict
+
 import flask_restful
 
-from typing import Dict
 from fprime_gds.common.history.history import History
 from fprime_gds.common.history.ram import RamHistory
 

--- a/test/fprime_gds/common/encoders/test_ch_encoder.py
+++ b/test/fprime_gds/common/encoders/test_ch_encoder.py
@@ -6,12 +6,12 @@ Created on Jul 10, 2020
 """
 
 
+from fprime.common.models.serialize.numerical_types import U16Type, U32Type
+from fprime.common.models.serialize.time_type import TimeType
+from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.encoders.ch_encoder import ChEncoder
 from fprime_gds.common.templates.ch_template import ChTemplate
 from fprime_gds.common.utils.config_manager import ConfigManager
-from fprime.common.models.serialize.time_type import TimeType
-from fprime.common.models.serialize.numerical_types import U16Type, U32Type
-from fprime_gds.common.data_types.ch_data import ChData
 
 
 def test_ch_encoder():

--- a/test/fprime_gds/common/encoders/test_event_encoder.py
+++ b/test/fprime_gds/common/encoders/test_event_encoder.py
@@ -6,12 +6,12 @@ Created on Jul 10, 2020
 """
 
 
-from fprime_gds.common.encoders.event_encoder import EventEncoder
-from fprime_gds.common.data_types.event_data import EventData
-from fprime_gds.common.utils.config_manager import ConfigManager
-from fprime_gds.common.templates.event_template import EventTemplate
-from fprime.common.models.serialize.time_type import TimeType
 from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
+from fprime.common.models.serialize.time_type import TimeType
+from fprime_gds.common.data_types.event_data import EventData
+from fprime_gds.common.encoders.event_encoder import EventEncoder
+from fprime_gds.common.templates.event_template import EventTemplate
+from fprime_gds.common.utils.config_manager import ConfigManager
 from fprime_gds.common.utils.event_severity import EventSeverity
 
 

--- a/test/fprime_gds/common/encoders/test_pkt_encoder.py
+++ b/test/fprime_gds/common/encoders/test_pkt_encoder.py
@@ -6,14 +6,14 @@ Created on Jul 10, 2020
 """
 
 
-from fprime_gds.common.encoders.pkt_encoder import PktEncoder
+from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
+from fprime.common.models.serialize.time_type import TimeType
+from fprime_gds.common.data_types.ch_data import ChData
 from fprime_gds.common.data_types.pkt_data import PktData
-from fprime_gds.common.utils.config_manager import ConfigManager
+from fprime_gds.common.encoders.pkt_encoder import PktEncoder
 from fprime_gds.common.templates.ch_template import ChTemplate
 from fprime_gds.common.templates.pkt_template import PktTemplate
-from fprime_gds.common.data_types.ch_data import ChData
-from fprime.common.models.serialize.time_type import TimeType
-from fprime.common.models.serialize.numerical_types import U8Type, U16Type, U32Type
+from fprime_gds.common.utils.config_manager import ConfigManager
 
 
 def test_pkt_encoder():

--- a/test/fprime_gds/common/gds_cli/filtering_utils_test.py
+++ b/test/fprime_gds/common/gds_cli/filtering_utils_test.py
@@ -3,14 +3,14 @@ A suite of unit tests for testing the predicates and filtering utilities the
 GDS CLI uses
 """
 
-import pytest
-
 import fprime_gds.common.gds_cli.filtering_utils as filtering_utils
+import pytest
 from fprime.common.models.serialize import time_type
 from fprime_gds.common.data_types.event_data import EventData
 from fprime_gds.common.templates.event_template import EventTemplate
 from fprime_gds.common.testing_fw import predicates
 from fprime_gds.common.utils.event_severity import EventSeverity
+
 
 # Pytest fixtures work by reusing outer names, so disable this warning
 # pylint: disable=redefined-outer-name

--- a/test/fprime_gds/common/gds_cli/utils_test.py
+++ b/test/fprime_gds/common/gds_cli/utils_test.py
@@ -4,10 +4,9 @@ A suite of unit tests for testing utilities the GDS CLI uses
 
 from copy import deepcopy
 
-import pytest
-
 import fprime_gds.common.gds_cli.filtering_utils as filtering_utils
 import fprime_gds.common.gds_cli.test_api_utils as test_api_utils
+import pytest
 from fprime_gds.common.data_types.pkt_data import PktData
 from fprime_gds.common.data_types.sys_data import SysData
 from fprime_gds.common.templates.data_template import DataTemplate

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -6,6 +6,7 @@ Tests format_string util
 """
 
 import unittest
+
 from fprime_gds.common.utils.string_util import format_string_template
 
 

--- a/test/fprime_gds/executables/test_run_deployment.py
+++ b/test/fprime_gds/executables/test_run_deployment.py
@@ -2,7 +2,6 @@ import platform
 import tempfile
 import unittest
 from pathlib import Path
-
 from unittest import mock
 
 from fprime_gds.executables import run_deployment


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This PR consists of de-duplicating, grouping and sorting imports according to isort parameters.

## Rationale

This is to make the code base more consistent, as using a common convention for imports makes the code more readable and idiomatic.

[Ref - Ruff linter](https://beta.ruff.rs/docs/rules/unsorted-imports/)

## Testing/Review Recommendations

Visual inspection

## Future Work

Add Ruff linter into repo's CI (WIP).