### PR TITLE
Fixing ids argument

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -725,6 +725,7 @@ class SearchArgumentsParser(ParserBase):
                 "action": "store",
                 "required": False,
                 "type": int,
+                "nargs":'+',
                 "help": f"only show {self.command_name} matching the given type ID(s) 'ID'; can provide multiple IDs to show all given types",
                 "metavar": "ID",
             },


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The `--ids` parameter was converted to an int but an iterable was requested for the filter. I changed the type of the param to fix the error and support multiple ids.

The `nargs` is documented [here](https://docs.python.org/3/library/argparse.html?highlight=argparse#nargs).