### PR TITLE
Restrict flask version to <=2.2.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,7 @@ integrated configuration with ground in-the-loop.
     python_requires=">=3.7",
     setup_requires=["setuptools_scm"],
     install_requires=[
-        "flask>=1.1.2",
+        "flask>=1.1.2,<=2.2.3",
         "flask_compress>=1.11",
         "pyzmq>=24.0.1",
         "pexpect>=4.8.0",


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Restrict flask version to >=1.1.2 and <=2.2.3. Tested in python 3.9.6 virtual environment and was able to successfully install and start F´ GDS.

## Rationale

From flask [release notes](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-0):

> Setting custom json_encoder and json_decoder classes on the app or a blueprint, and the corresponding json.JSONEncoder and JSONDecoder classes, are deprecated. JSON behavior can now be overridden using the app.json provider interface. https://github.com/pallets/flask/pull/4692
