### PR TITLE
Fix build-artifact detection

### DIFF
--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -125,9 +125,8 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
         return child
     except Exception as exc:
         msg = f"Failed to run application: {' '.join(arguments)}. Error: {exc}"
-        raise AppWrapperException(
-            msg
-        )
+        raise AppWrapperException(msg)
+
 
 def find_settings(path: Path) -> Path:
     """
@@ -153,7 +152,9 @@ def get_artifacts_root() -> Path:
     except FprimeSettingsException as e:
         print("[ERROR]", e)
         sys.exit(-1)
-    assert "install_destination" in ini_settings, "install_destination not in settings.ini"
+    assert (
+        "install_destination" in ini_settings
+    ), "install_destination not in settings.ini"
     print(
         f"""[INFO] Autodetected artifacts root '{ini_settings["install_destination"]}' from project settings.ini file."""
     )

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -129,10 +129,22 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
             msg
         )
 
+def find_settings(path: Path) -> Path:
+    """
+    Finds the settings file by recursing parent to parent until a matching file is found.
+    """
+    needle = Path("settings.ini")
+    while path != path.parent:
+        if (path / needle).is_file():
+            return path / needle
+        path = path.parent
+    raise FprimeLocationUnknownException()
+
 
 def get_artifacts_root() -> Path:
     try:
-        ini_settings = IniSettings.load(None)
+        ini_file = find_settings(Path.cwd())
+        ini_settings = IniSettings.load(ini_file)
     except FprimeLocationUnknownException:
         print(
             "[ERROR] Not in fprime project and no deployment path provided, unable to find dictionary and/or app"
@@ -143,7 +155,7 @@ def get_artifacts_root() -> Path:
         sys.exit(-1)
     assert "install_destination" in ini_settings, "install_destination not in settings.ini"
     print(
-        f"""[INFO] Autodetected artifacts root '{ini_settings["install_destination"]}' from deployment settings.ini file."""
+        f"""[INFO] Autodetected artifacts root '{ini_settings["install_destination"]}' from project settings.ini file."""
     )
     return ini_settings["install_destination"]
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes the issue where the `build-artifacts` location is not auto-detected when using the new build structure (nasa/fprime#1994) and running from within a deployment.

This implementation has the advantage that it will also detect the correct location for the old build structure.

