### PR TITLE
Add display text if there is no format string

### DIFF
--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -43,7 +43,8 @@ class EventData(sys_data.SysData):
         if event_args is None:
             self.display_text = event_temp.description
         elif event_temp.format_str == "":
-            self.display_text = str([arg.val for arg in event_args])
+            args_template = self.template.get_args()
+            self.display_text = str([{args_template[index][0]:arg.val} for index, arg in enumerate(event_args)])
         else:
             self.display_text = format_string_template(
                 event_temp.format_str, tuple([arg.val for arg in event_args])

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -40,9 +40,14 @@ class EventData(sys_data.SysData):
         self.args = event_args
         self.time = event_time
         self.template = event_temp
-        self.display_text = event_temp.description if event_args is None else format_string_template(
-            event_temp.format_str, tuple([arg.val for arg in event_args])
-        )
+        if event_args is None:
+            self.display_text = event_temp.description
+        elif event_temp.format_str == "":
+            self.display_text = str([arg.val for arg in event_args])
+        else:
+            self.display_text = format_string_template(
+                event_temp.format_str, tuple([arg.val for arg in event_args])
+            )
 
     def get_args(self):
         return self.args


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| data_types  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This merge request add a `display_text` for events having arguments but not a `format_string`. 

## Rationale

Before the arguments of an event without a `format_string` were not logged or printed everywhere. This pull request will enable the visualization of the argument also if the `format_string` is not set.

An event with no `format_string` but three arguments(an integer, an enum and a float) will contain in the column Event Description of gds: `[{'My_integer_arg': 123}, {'My_enum_arg': 'VALUE_OF_ENUM'}, {'My_float_arg': 12.34}]`.
