### PR TITLE
Initial setup of fprime-gds to work with OpenMCT

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -782,3 +782,41 @@ class RetrievalArgumentsParser(ParserBase):
 
     def handle_arguments(self, args, **kwargs):
         return args
+    
+class OpenMCTTelemetryPollerParser(ParserBase):
+    """ Parser for OpenMCT Server arguments  """
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """ Return arguments on whether to use OpenMCT, post to a specific URI, and publish telemetry at a specific frequency"""
+        return {
+            ("--openmct",): {
+                "dest": "openmct",
+                "action": 'store_true',
+                "help": "Determines whethers OpenMCT will be used for Telemetry Visualization",
+                "required": False
+            },
+            ("--openmct-uri",): {
+                "dest": "openmct_uri",
+                "type": str,
+                "default": "http://127.0.0.1:4052/fprime_telem",
+                "help": "URI of the OpenMCT Server. The URI at which the F-Prime telemetry will be broadcasted.",
+                "required": False
+            },
+            ("--openmct-telem-rate",): {
+                "dest": "openmct_telem_rate",
+                "type": float,
+                "default": 1,
+                "help": "Rate(in Hz) at which we want to poll the F-Prime Telemetry Pipeline for new telemetry",
+                "required": False
+            },
+            ("--openmct-dir",): {
+                "dest": "openmct_dir",
+                "type": str, 
+                "default": "",
+                "help": "Directory where the OpenMCT Installation is located",
+                "required": False
+            }
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        return args

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -19,10 +19,14 @@ from fprime_gds.executables.utils import AppWrapperException, run_wrapped_applic
 
 # Try to Import FPrime-OpenMCT Python Packages
 try: 
+    import fprime_openmct
+except ImportError:
+    fprime_openmct = None
+
+if fprime_openmct is not None: 
     from fprime_openmct.config_server import ServerConfig
     from fprime_openmct.fprime_to_openmct import TopologyAppDictionaryJSONifier
-except:
-    pass
+
 
 
 BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
@@ -211,6 +215,9 @@ def main():
 
     # Check if OpenMCT is set to be used. If true, generate OpenMCT States and Launch the OpenMCT Server
     if parsed_args.openmct:
+
+        if fprime_openmct is None:
+            raise ImportError('FPrime-OpenMCT Bridge not installed. Please install fprime_openmct with pip.')
 
         # Try Generating the OpenMCT JSON and Initial States
         top_dict = TopologyAppDictionaryJSONifier(str(parsed_args.dictionary))

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -19,7 +19,6 @@ from fprime_gds.executables.utils import AppWrapperException, run_wrapped_applic
 
 # Try to Import FPrime-OpenMCT Python Packages
 try: 
-    import fprime_openmct 
     from fprime_openmct.config_server import ServerConfig
     from fprime_openmct.fprime_to_openmct import TopologyAppDictionaryJSONifier
 except:
@@ -166,10 +165,9 @@ def launch_openmct(parsed_args):
     Return:
         launched process
     """
-    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'javascript')
     openmct_server = ServerConfig()
 
-    app_cmd = openmct_server.launch_openmct_server(openmct_dir)
+    app_cmd = openmct_server.launch_openmct_server()
 
     return app_cmd 
 
@@ -215,10 +213,9 @@ def main():
     if parsed_args.openmct:
 
         # Try Generating the OpenMCT JSON and Initial States
-        openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'javascript')
         top_dict = TopologyAppDictionaryJSONifier(str(parsed_args.dictionary))
-        top_dict.writeOpenMCTJSON('FPrimeDeploymentTopologyAppDictionary', openmct_dir)
-        top_dict.writeInitialStatesJSON('initial_states', openmct_dir)
+        top_dict.writeOpenMCTJSON('FPrimeDeploymentTopologyAppDictionary')
+        top_dict.writeInitialStatesJSON('initial_states')
 
         # Try Launching OpenMCT Server
         launchers.append(launch_openmct)

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -19,7 +19,7 @@ from fprime_gds.executables.utils import AppWrapperException, run_wrapped_applic
 
 import fprime_openmct 
 from fprime_openmct.config_server import register_npm_package, install_npm_package, start_npm_package
-from fprime_openmct.telem_definition_generator.TopAppDictXMLtoOpenMCTJSON import TopologyAppDictionaryJSONifier
+from fprime_openmct.src.fprime_openmct.TopAppDictXMLtoOpenMCTJSON import TopologyAppDictionaryJSONifier
 
 
 BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
@@ -33,7 +33,7 @@ def parse_args():
     :return: parsed argument namespace
     """
     # Get custom handlers for all executables we are running
-    arg_handlers = [StandardPipelineParser, GdsParser, BinaryDeployment, CommParser]
+    arg_handlers = [StandardPipelineParser, GdsParser, BinaryDeployment, CommParser, OpenMCTTelemetryPollerParser]
     # Parse the arguments, and refine through all handlers
     args, parser = ParserBase.parse_args(arg_handlers, "Run F prime deployment and GDS")
     return args
@@ -164,7 +164,7 @@ def get_openmct_json(parsed_args):
         Initial States JSON for OpenMCT 
     """
 
-    openmct_dir = fprime_openmct.__file__.replace('/__init__.py', '')
+    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'src/fprime_openmct/javascript')
 
     top_dict = TopologyAppDictionaryJSONifier(str(parsed_args.dictionary))
     top_dict.writeOpenMCTJSON('FPrimeDeploymentTopologyAppDictionary', openmct_dir)
@@ -178,10 +178,10 @@ def launch_openmct(parsed_args):
     Return:
         launched process
     """
-    openmct_dir = fprime_openmct.__file__.replace('/__init__.py', '/')
+    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'src/fprime_openmct/javascript')
 
 
-    pkg = register_npm_package(openmct_dir + "package.json")
+    pkg = register_npm_package(openmct_dir + "/package.json")
 
     # Check and install node server if needed
     install_npm_package(pkg, openmct_dir)
@@ -199,7 +199,7 @@ def poll_telem(parsed_args):
         launched process
     """
     
-    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.telem_poller.fprime_telem_poller"] + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
+    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.src.fprime_openmct.fprime_telem_poller"] + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
 
     return launch_process(app_cmd, name='OpenMCT Poller', launch_time=1) 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -19,7 +19,7 @@ from fprime_gds.executables.utils import AppWrapperException, run_wrapped_applic
 
 import fprime_openmct 
 from fprime_openmct.config_server import register_npm_package, install_npm_package, start_npm_package
-from fprime_openmct.src.fprime_openmct.TopAppDictXMLtoOpenMCTJSON import TopologyAppDictionaryJSONifier
+from fprime_openmct.fprime_to_openmct import TopologyAppDictionaryJSONifier
 
 
 BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
@@ -164,7 +164,7 @@ def get_openmct_json(parsed_args):
         Initial States JSON for OpenMCT 
     """
 
-    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'src/fprime_openmct/javascript')
+    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'javascript')
 
     top_dict = TopologyAppDictionaryJSONifier(str(parsed_args.dictionary))
     top_dict.writeOpenMCTJSON('FPrimeDeploymentTopologyAppDictionary', openmct_dir)
@@ -178,7 +178,7 @@ def launch_openmct(parsed_args):
     Return:
         launched process
     """
-    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'src/fprime_openmct/javascript')
+    openmct_dir = fprime_openmct.__file__.replace('__init__.py', 'javascript')
 
 
     pkg = register_npm_package(openmct_dir + "/package.json")
@@ -199,7 +199,7 @@ def poll_telem(parsed_args):
         launched process
     """
     
-    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.src.fprime_openmct.fprime_telem_poller"] + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
+    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.fprime_telem_poller"] + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
 
     return launch_process(app_cmd, name='OpenMCT Poller', launch_time=1) 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -184,7 +184,7 @@ def poll_telem(parsed_args):
         launched process
     """
     
-    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.fprime_telem_poller"] + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
+    app_cmd = BASE_MODULE_ARGUMENTS + ["fprime_openmct.fprime_telem_poller"] + StandardPipelineParser().reproduce_cli_args(parsed_args) + OpenMCTTelemetryPollerParser().reproduce_cli_args(parsed_args)
 
     return launch_process(app_cmd, name='OpenMCT Poller', launch_time=1) 
 
@@ -217,7 +217,7 @@ def main():
     if parsed_args.openmct:
 
         if fprime_openmct is None:
-            raise ImportError('FPrime-OpenMCT Bridge not installed. Please install fprime_openmct with pip.')
+            raise ImportError('FPrime-OpenMCT Bridge not installed. Please install fprime_openmct with pip')
 
         # Try Generating the OpenMCT JSON and Initial States
         top_dict = TopologyAppDictionaryJSONifier(str(parsed_args.dictionary))


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Mohit Singh |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**| F-Prime GDS  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Add functionality to run OpenMCT from the F-Prime GDS. A user can specify the openmct argument at command line by running `fprime-gds --openmct` , and they will get two tabs; one that launches the standard GDS, and one that launches an OpenMCT server with all the telemetry channels registered and showing Real Time Telemetry. 

## Rationale
The current F-Prime GDS has two ways of visualizing telemetry. `Channels` and `Charts`. These telemetry visualizations can be expanded upon by integrating OpenMCT with F-Prime. OpenMCT allows for users to create dashboards, utilize gauges, stacked/overlay plots, and tables. It also incorporates conditional coloring based on user defined limits.  

## Testing/Review Recommendations
Currently this functionality has been fully tested with the base `Ref` deployment. It should be tested with additional deployments to ensure no critical values are hardcoded, since that would hinder general usability.

**NOTE**: This pull request is breaking. Users will need to install the `fprime_openmct` python package repo since that is imported at the start of `run_deployment.py`. That package is available at https://github.com/mohitsingh999/fprime-openmct currently and can be registered as a python package by running `pip install .` at the root of `fprime-openmct`. A pull request has been created to merge this repo into https://github.com/fprime-community/fprime-openmct, and is currently being reviewed. 

## Future Work

Work needs to be done to ensure the OpenMCT integration with `fprime-gds` happens in parallel with integration of `fprime-openmct` in `fprime-community`. General installation instructions will need to be updated to inform users to install `fprime_openmct` with pip, in addition to `fprime_tools` and `fprime_gds`. `fprime-openmct` needs to be registered on PyPI as well, just like `fprime-gds` and `fprime-tools`. 

@jwest115 will be taking over managing OpenMCT integration related tasks after August 10th