### PR TITLE
Add option to accept comms with FSW running TCP server

### DIFF
--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -54,17 +54,17 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
     KEEPALIVE_DATA = b"sitting well"
     MAXIMUM_DATA_SIZE = 4096
 
-    def __init__(self, address, port):
+    def __init__(self, address, port, server=True):
         """
         Initialize this adapter by creating a handler for UDP and TCP. A thread for the KEEPALIVE application packets
-        will be created, if the interval is not none.
+        will be created, if the interval is not none. Handlers are created as clients if server is set to false.
         """
         self.address = address
         self.port = port
         self.stop = False
         self.keepalive = None
-        self.tcp = TcpHandler(address, port)
-        self.udp = UdpHandler(address, port)
+        self.tcp = TcpHandler(address, port, server=server)
+        self.udp = UdpHandler(address, port, server=server)
         self.thtcp = None
         self.thudp = None
         self.data_chunks = queue.Queue()
@@ -170,6 +170,12 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
                 "type": int,
                 "default": 50000,
                 "help": "Port of the IP adapter server. Default: %(default)s",
+            },
+            ("--fsw-server",): {
+                "dest": "server",
+                "action": "store_false",
+                "default": True,
+                "help": "Run the IP adapter as the client (meaning FSW is the TCP Server).",
             },
         }
 

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -57,7 +57,7 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
     def __init__(self, address, port, server=True):
         """
         Initialize this adapter by creating a handler for UDP and TCP. A thread for the KEEPALIVE application packets
-        will be created, if the interval is not none. Handlers are created as clients if server is set to false.
+        will be created, if the interval is not none. Handlers are servers unless server=False.
         """
         self.address = address
         self.port = port
@@ -171,11 +171,13 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
                 "default": 50000,
                 "help": "Port of the IP adapter server. Default: %(default)s",
             },
-            ("--fsw-server",): {
+            ("--ip-client",): {
+                # dest is "server" since it is handled in BaseAdapter.construct_adapter and passed with the same
+                # name to the IpAdapter constructor. Default to server=True, meaning IpAdapter is the TCP server
                 "dest": "server",
                 "action": "store_false",
                 "default": True,
-                "help": "Run the IP adapter as the client (meaning FSW is the TCP Server).",
+                "help": "Run the IP adapter as the client (connects to FSW running TcpServer)",
             },
         }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Add a command line option to have the GDS comms adapter act as a client instead of server, thus accepting FSW acting as the TCP server. I wasn't sure what the best --option-name and help_text were... let me know if you have a better idea.

## Testing/Review Recommendations

With the option, `server=False` is fed into the constructor here:

https://github.com/thomas-bc/fprime-gds/blob/96dd25f02f727ada49ce99160f8b198fe78bb271/src/fprime_gds/common/communication/adapters/base.py#L117-L118


