### PR TITLE
Bump pyserial to full dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,6 @@ integrated configuration with ground in-the-loop.
         "argcomplete>=1.12.3",
         "Jinja2>=2.11.3",
         "openpyxl>=3.0.10",
+        "pyserial>=3.5"
     ],
-    extras_require={
-        # I and T API
-        "uart-adapter": "pyserial",
-    },
 )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Shipping pyserial (and therefore --comm-adapter uart) by default.

## Rationale

Shipping a UART deployment with fprime-util, and this is a rather small package