### PR TITLE
Update channels to last received with option for latest time

### DIFF
--- a/src/fprime_gds/flask/static/addons/advanced-settings/addon-templates.js
+++ b/src/fprime_gds/flask/static/addons/advanced-settings/addon-templates.js
@@ -9,6 +9,10 @@ export let advanced_template = `
                 <h3>{{ setting_category.replace("_", " ") }}</h3>
                 <div v-html="settings[setting_category].description"></div>
                 <div class="input-group mb-3" v-for="setting_key in Object.keys(settings[setting_category].settings)">
+                    <small v-if="(settings[setting_category].descriptions || {})[setting_key]">
+                        <strong>{{ setting_key }}</strong>
+                        {{ settings[setting_category].descriptions[setting_key]}}
+                    </small>
                     <div class="input-group-prepend col-6">
                         <span class="input-group-text col-12">{{ setting_key }}</span>
                     </div>

--- a/src/fprime_gds/flask/static/addons/advanced-settings/addon.js
+++ b/src/fprime_gds/flask/static/addons/advanced-settings/addon.js
@@ -28,7 +28,7 @@ Vue.component("advanced-settings", {
                         response_object_limit: "Limit to the number of objects returned by one POLL request to the backend. " +
                                                 "Lower this value if polling times are longer than polling intervals. Default: 6000.",
                         compact_commanding: "Use the compact form for command arguments. In this form, Array and Serializable type " +
-                                            "inputs are flattened into a sequential set of input boxes without extranious structure.",
+                                            "inputs are flattened into a sequential set of input boxes without extraneous structure.",
                         channels_display_last_received: "When set, any channel received will update the displayed value. Otherwise " +
                                                         "only channels with newer timestamps update the displayed value."
                     },

--- a/src/fprime_gds/flask/static/addons/advanced-settings/addon.js
+++ b/src/fprime_gds/flask/static/addons/advanced-settings/addon.js
@@ -19,13 +19,19 @@ Vue.component("advanced-settings", {
                     settings: _settings.polling_intervals
                 },
                 "Miscellaneous": {
-                    description: "Miscellaneous settings for GDS UI operations." +
-                        "<small><ul>" +
-                        "<li>event_buffer_size: maximum event records. Default: -1, infinite.</li>" +
-                        "<li>command_buffer_size: maximum command history records. Default: -1, infinite.</li>" +
-                        "<li>response_object_limit: maximum results to load per polling request. Default: 6000</li>" +
-                        '<li>compact_commanding: use compact "flattened" style for commanding complex arguments.</li>' +
-                        "</ul></small>",
+                    description: "Miscellaneous settings for GDS UI operations.",
+                    descriptions: {
+                        event_buffer_size: "Maximum number of events stored by the GDS. When exceeded, oldest events are dropped " +
+                                            "Lower this value if performance drops on the Events tab. Default: -1, no limit.",
+                        command_buffer_size: "Maximum number of commands stored by the GDS. When exceeded, oldest commands are dropped " +
+                                                "Lower this value if performance drops on the Commanding tab. Default: -1, no limit.",
+                        response_object_limit: "Limit to the number of objects returned by one POLL request to the backend. " +
+                                                "Lower this value if polling times are longer than polling intervals. Default: 6000.",
+                        compact_commanding: "Use the compact form for command arguments. In this form, Array and Serializable type " +
+                                            "inputs are flattened into a sequential set of input boxes without extranious structure.",
+                        channels_display_last_received: "When set, any channel received will update the displayed value. Otherwise " +
+                                                        "only channels with newer timestamps update the displayed value."
+                    },
                     settings: _settings.miscellaneous
                 }
             },

--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -148,8 +148,12 @@ class MappedHistory extends HistoryHelper {
         let updated = {};
         for (let i = 0; i < new_items.length; i++) {
             let item = new_items[i];
-            // Check for miss-ordered updates
-            if ((this.store[item.id] || null) === null || item.datetime >= this.store[item.id].datetime) {
+            // When displaying last received, update the value always
+            if (_settings.miscellaneous.channels_display_last_received) {
+                updated[item.id] = item;
+            }
+            // Otherwise check for a newer timestamp
+            else if ((this.store[item.id] || null) === null || item.datetime >= this.store[item.id].datetime) {
                 updated[item.id] = item;
             }
         }

--- a/src/fprime_gds/flask/static/js/settings.js
+++ b/src/fprime_gds/flask/static/js/settings.js
@@ -12,7 +12,8 @@ class Settings {
             event_buffer_size: -1,
             command_buffer_size: -1,
             response_object_limit: 6000,
-            compact_commanding: false
+            compact_commanding: false,
+            channels_display_last_received: true
          };
          this.polling_intervals = {};
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This adds a setting to control if the latest channel received (by order, or by timestamp) should be displayed.

Defaults to packet order, but users expecting out-of-order packets can adjust in the settings tab.
