### PR TITLE
Fix scalar input forms

### DIFF
--- a/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
+++ b/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
@@ -68,7 +68,7 @@ export let command_scalar_argument_template = `
         <command-enum-argument v-if="argument.type.ENUM_DICT" :argument="argument"></command-enum-argument>
         <input v-else :type="inputType[0]" v-bind:id="argument.name" class="form-control fprime-input"
                :placeholder="argument.name" :pattern="inputType[1]" :step="inputType[2]" v-on:input="validateTrigger"
-               v-model="argument.value"  :class="argument.error == '' ? '' : 'is-invalid'" required>
+               v-model.number="argument.value"  :class="argument.error == '' ? '' : 'is-invalid'" required>
         <div class="invalid-feedback">{{ argument.error }}</div>
     </div>
 </div>

--- a/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
+++ b/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
@@ -16,6 +16,17 @@ export let command_enum_argument_template = `
 `;
 
 /**
+ * Enum argument uses the v-select dropdown to render the various choices while providing search and match capabilities.
+ */
+export let command_bool_argument_template = `
+<v-select :id="argument.name" style="flex: 1 1 auto; background-color: white;"
+          :clearable="false" :searchable="true" @input="validateTrigger"
+          :filterable="true"  label="full_name" :options="['True', 'False']"
+          v-model="argument.value" class="fprime-input" :class="argument.error == '' ? '' : 'is-invalid'" required>
+</v-select>
+`;
+
+/**
  * Serializable arguments "flatten" the structure into a list of fields.
  */
 export let command_serializable_argument_template = `
@@ -64,8 +75,8 @@ export let command_scalar_argument_template = `
         <label :for="argument.name" class="control-label font-weight-bold">
             {{ argument.name + ((argument.description != null) ? ": " + argument.description : "") }}
         </label>
-        
-        <command-enum-argument v-if="argument.type.ENUM_DICT" :argument="argument"></command-enum-argument>
+        <command-bool-argument v-if="argument.type.name == 'BoolType'" :argument="argument"></command-bool-argument>
+        <command-enum-argument v-else-if="argument.type.ENUM_DICT" :argument="argument"></command-enum-argument>
         <input v-else :type="inputType[0]" v-bind:id="argument.name" class="form-control fprime-input"
                :placeholder="argument.name" :pattern="inputType[1]" :step="inputType[2]" v-on:input="validateTrigger"
                v-model="argument.value"  :class="argument.error == '' ? '' : 'is-invalid'" required>

--- a/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
+++ b/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
@@ -68,7 +68,7 @@ export let command_scalar_argument_template = `
         <command-enum-argument v-if="argument.type.ENUM_DICT" :argument="argument"></command-enum-argument>
         <input v-else :type="inputType[0]" v-bind:id="argument.name" class="form-control fprime-input"
                :placeholder="argument.name" :pattern="inputType[1]" :step="inputType[2]" v-on:input="validateTrigger"
-               v-model.number="argument.value"  :class="argument.error == '' ? '' : 'is-invalid'" required>
+               v-model="argument.value"  :class="argument.error == '' ? '' : 'is-invalid'" required>
         <div class="invalid-feedback">{{ argument.error }}</div>
     </div>
 </div>

--- a/src/fprime_gds/flask/static/addons/commanding/arguments.js
+++ b/src/fprime_gds/flask/static/addons/commanding/arguments.js
@@ -8,6 +8,7 @@
  */
 import "../../third-party/js/vue-select.js"
 import {
+    command_bool_argument_template,
     command_enum_argument_template,
     command_array_argument_template,
     command_serializable_argument_template,
@@ -139,6 +140,15 @@ export function squashify_argument(argument) {
     else if (["F64Type", "F32Type"].indexOf(argument.type.name) != -1) {
         value = parseFloat(argument.value);
     }
+    else if (argument.type.name == "BoolType") {
+        if ((typeof(value) === "string") && (["true", "yes"].indexOf(value.toLowerCase()) !== -1)) {
+            value = true;
+        } else if ((typeof(value) === "string") && (["false", "no"].indexOf(value.toLowerCase()) !== -1)) {
+            value = false;
+        } else {
+            console.assert(typeof(value) !== "boolean", "Cannot process boolean, invalid input type")
+        }
+    }
     return value;
 }
 
@@ -246,6 +256,14 @@ Vue.component("command-enum-argument", {
 });
 
 /**
+ * Special boolean processing component to render as a drop-down.
+ */
+Vue.component("command-bool-argument", {
+    ...base_argument_component_properties,
+    template: command_bool_argument_template,
+});
+
+/**
  * Scalar argument processing. Sets up the input type such that numbers can be input with the correct formatting.
  */
 Vue.component("command-scalar-argument", {
@@ -259,14 +277,14 @@ Vue.component("command-scalar-argument", {
          */
         inputType() {
             // Unsigned integer
-            if (this.argument.type.name[0] == 'U') {
+            if (["U64Type", "U32Type", "U16Type", "U8Type"].indexOf(this.argument.type.name) != -1) {
                 // Supports binary, hex, octal, and digital
                 return ["text", "0[bB][01]+|0[oO][0-7]+|0[xX][0-9a-fA-F]+|[1-9]\\d*|0", ""];
             }
-            else if (this.argument.type.name[0] == 'I') {
+            else if (["I64Type", "I32Type", "I16Type", "I8Type"].indexOf(this.argument.type.name) != -1) {
                 return ["number", null, "1"];
             }
-            else if (this.argument.type.name[0] == 'F') {
+            else if (["F64Type", "F32Type"].indexOf(this.argument.type.name) != -1) {
                 return ["number", null, "any"];
             }
             return ["text", ".*", null];

--- a/src/fprime_gds/flask/static/addons/commanding/arguments.js
+++ b/src/fprime_gds/flask/static/addons/commanding/arguments.js
@@ -118,7 +118,7 @@ export function squashify_argument(argument) {
             let field = argument.type.MEMBER_LIST[i][0];
             value[field] = squashify_argument(argument.value[field]);
         }
-    } else if (argument.type.name[0] == 'U') {
+    } else if (["U64Type", "U32Type", "U16Type", "U8Type"].indexOf(argument.type.name) != -1) {
         if (argument.value.startsWith("0x")) {
             // Hexadecimal
             value = parseInt(argument.value, 16);
@@ -133,10 +133,10 @@ export function squashify_argument(argument) {
             value = parseInt(argument.value, 10);
         }
     }
-    else if (argument.type.name[0] == 'I') {
+    else if (["I64Type", "I32Type", "I16Type", "I8Type"].indexOf(argument.type.name) != -1) {
         value = parseInt(argument.value, 10);
     }
-    else if (argument.type.name[0] == 'F') {
+    else if (["F64Type", "F32Type"].indexOf(argument.type.name) != -1) {
         value = parseFloat(argument.value);
     }
     return value;

--- a/src/fprime_gds/flask/static/addons/commanding/arguments.js
+++ b/src/fprime_gds/flask/static/addons/commanding/arguments.js
@@ -118,6 +118,26 @@ export function squashify_argument(argument) {
             let field = argument.type.MEMBER_LIST[i][0];
             value[field] = squashify_argument(argument.value[field]);
         }
+    } else if (argument.type.name[0] == 'U') {
+        if (argument.value.startsWith("0x")) {
+            // Hexadecimal
+            value = parseInt(argument.value, 16);
+        } else if (argument.value.startsWith("0b")) {
+            // Binary
+            value = parseInt(argument.value.slice(2), 2);
+        } else if (argument.value.startsWith("0o")) {
+            // Octal
+            value = parseInt(argument.value.slice(2), 8);
+        } else {
+            // Decimal
+            value = parseInt(argument.value, 10);
+        }
+    }
+    else if (argument.type.name[0] == 'I') {
+        value = parseInt(argument.value, 10);
+    }
+    else if (argument.type.name[0] == 'F') {
+        value = parseFloat(argument.value);
     }
     return value;
 }

--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -274,6 +274,10 @@ class DataStore {
         if (argument.type.ENUM_DICT) {
             argument.value = Object.keys(argument.type.ENUM_DICT)[0];
         }
+        // Booleans are initialized to True
+        else if (argument.type.name === "BoolType") {
+            argument.value = "True";
+        }
         // Arrays expand to a set length of N pseudo-arguments
         else if (argument.type.LENGTH) {
             let array_length = argument.type.LENGTH;

--- a/src/fprime_gds/flask/static/js/validate.js
+++ b/src/fprime_gds/flask/static/js/validate.js
@@ -116,6 +116,11 @@ export function validate_scalar_input(argument) {
         argument.error = "";
         return true;
     }
+    // Boolean type handling
+    else if (argument.type.name === "BoolType") {
+        return (argument.value == null) ? null :
+            ["yes", "no", "true", "false"].indexOf(argument.value.toString().toLowerCase()) >= 0;
+    }
     console.assert(false, "Unknown scalar type: " + argument.type.name);
     argument.error = "";
     return true;


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| fprime_gds/flask |

---

## Change Description

Original change:  _Added the modifier `number` to the scalar argument. This will cast the value to a number and not return a string.((https://v2.vuejs.org/v2/guide/forms.html#number))_  --> This change was breaking the usage of hex, bin and octal because there is not such representation in Javascript.

The new change consists of updating the squash function so any number is actually converted to a number.

## Rationale

This fix is required to have commands containing argument arrays of numbers. Without the Fix, Vue will send to the GDS server an array like `'["1", "2",...]'`. The parsing of the array will fail in Python with the error "Failed to validate all arguments". 

After the fix, the array will be sent to the GDS backend as '[1, 2,...]' and the parsing of the array will work fine.


