### PR TITLE
Added incremental id in history items

### DIFF
--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -28,6 +28,7 @@ class HistoryHelper {
         this.active_key = active_key;
         this.consumers = [];
         this.active_timeout = null;
+        this.counter = 0;
     }
 
     /**
@@ -57,9 +58,9 @@ class HistoryHelper {
         let _self = this;
         // Break our when no new items returned
         if (new_items.length === 0) { return; }
-        new_items.filter((item) => item.time).forEach((item, index) => {
+        new_items.filter((item) => item.time).forEach((item) => {
             item.datetime = timeToDate(item.time);
-            item.incremental_id = index + this.store.length;
+            item.incremental_id = this.counter++;
         });
         this.consumers.forEach((consumer) => {
             try {

--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -57,8 +57,9 @@ class HistoryHelper {
         let _self = this;
         // Break our when no new items returned
         if (new_items.length === 0) { return; }
-        new_items.filter((item) => item.time).forEach((item) => {
-            item.datetime = timeToDate(item.time)
+        new_items.filter((item) => item.time).forEach((item, index) => {
+            item.datetime = timeToDate(item.time);
+            item.incremental_id = index + this.store.length;
         });
         this.consumers.forEach((consumer) => {
             try {

--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -109,7 +109,7 @@ Vue.component("event-list", {
          * @return {string} unique key
          */
         keyify(item) {
-            return "evt-" + item.id + "-" + item.time.seconds + "-"+ item.time.microseconds;
+            return "evt-" + item.id + "-" + item.time.seconds + "-"+ item.time.microseconds + "-" + item.incremental_id;
         },
         /**
          * A function to clear events out of the data store. This is to reset the events entirely.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**| Event table  |

---
## Change Description

Added an incremental ID to the objects stored in the `HistoryHelper`.

## Rationale

The current implementation works only if there are no events with the same ID sent in the same timestamp. By adding the incremental-id is possible to have a  unique ID for the events. This enables the support of events with the same ID sent in the same instant. 

I know that sending an event with the same id at the same time is very improbable but it happened in my project. We were sending an ERROR in sequence and GDS crashed.  