### PR TITLE
Fixing an issue where falsey values where masked by the GDS UI

### DIFF
--- a/src/fprime_gds/flask/static/addons/channel-render/channel-render.js
+++ b/src/fprime_gds/flask/static/addons/channel-render/channel-render.js
@@ -107,7 +107,13 @@ Vue.component("channel-render", {
          * @returns: display text of item/child item
          */
         displayText() {
-            return this.item?.display_text || this.item?.val || this.val || "";
+            let possibles = [this.item?.display_text, this.item?.val, this.val];
+            for (let i = 0; i < possibles.length; i++) {
+                if (typeof(possibles[i]) !== "undefined" && possibles[i] !== null) {
+                    return possibles[i];
+                }
+            }
+            return "";
         }
 
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes an issue where any telemetry value that had false-y equivalence was not displayed in the channel tab but rather displayed an empty box.

