### PR TITLE
Fixes nasa/fprime#2312 by correcting scalar validation

### DIFF
--- a/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
+++ b/src/fprime_gds/flask/static/addons/commanding/argument-templates.js
@@ -59,7 +59,7 @@ export let command_array_argument_template = `
  * enumerations are handled here as they represent a single scalar input.
  */
 export let command_scalar_argument_template = `
-<div style="display: contents;">
+<div style="display: contents;" class="fprime-scalar-argument">
     <div class="form-group col-md-6">
         <label :for="argument.name" class="control-label font-weight-bold">
             {{ argument.name + ((argument.description != null) ? ": " + argument.description : "") }}

--- a/src/fprime_gds/flask/static/addons/commanding/arguments.js
+++ b/src/fprime_gds/flask/static/addons/commanding/arguments.js
@@ -174,13 +174,22 @@ let base_argument_component_properties = {
             validateArgument(recurse_down) {
                 recurse_down = !!(recurse_down); // Force recurse_down to be defined as a boolean
                 let valid = validate_input(this.argument);
-                // HTML element validation
+                // Each scalar argument needs to set custom validity on the HTML input that it owns. However, non-scalar
+                // inputs skip this step less the first scalar child's input box be poisoned with incorrect validity due
+                // to the unbounded recursive nature of getElementsByClassName used to find a fprime-input children.
+                let is_scalar = [...document.getElementsByClassName("fprime-scalar-argument")]
+                    .filter((scalar) => scalar === this.$el || scalar.contains(this.$el)).length > 0;
+
+                // Now grab the singular the nearest input and report validity if and only if this is a scalar. Non-
+                // scalar values are compositions of scalar children and thus validity will be set when the scalar
+                // itself is validated.
                 let input_element = this.$el.getElementsByClassName("fprime-input")[0] || this.$el;
-                if (input_element.setCustomValidity && input_element.reportValidity) {
+                if (is_scalar && input_element.setCustomValidity && input_element.reportValidity) {
                     input_element.setCustomValidity(this.argument.error);
                     input_element.reportValidity();
                 }
-                // Downward recursion uses children
+                // Validation can happen recursively down through the children, or up through the parent in order to
+                // laterally validate complex arguments when a single input scalar filed is adjusted.
                 let recursive_listing = (recurse_down) ? this.$children.slice().reverse() : [this.$parent];
                 let valid_recursion = (recursive_listing || []).reduce(
                     (accumulator, next_element) => {


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

When validating complex (multi-field) command inputs, validity was set using `getElementsByClassName()[0].setValidity`.  This meant for cases when the element being validated was a composition of smaller inputs, it would grab the first one and mark it invalid.

Now this is only performed on scalars such that the focus is not yanked to another element.

Fixes nasa/fprime#2312

## Rationale

Annoying UI bugs get stomped 🥾🥾🥾.

## Testing/Review Recommendations

Try working with multi-filed commands (SEND_SCALAR) and notice the difference!

## Future Work

None known.
