### PR TITLE
Preventing a launch of Flask when -g none is specified. Fixes #2337

### DIFF
--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -112,10 +112,9 @@ def launch_html(parsed_args):
         str(parsed_args.gui_port),
     ]
     ret = launch_process(gse_args, name="HTML GUI", env=flask_env, launch_time=2)
-    if parsed_args.gui == "html":
-        webbrowser.open(
-            f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/", new=0, autoraise=True
-        )
+    webbrowser.open(
+        f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/", new=0, autoraise=True
+    )
     return ret
 
 
@@ -172,7 +171,8 @@ def main():
             print("[WARNING] App cannot be auto-launched without IP adapter")
 
     # Launch the desired GUI package
-    launchers.append(launch_html)
+    if parsed_args.gui == "html":
+        launchers.append(launch_html)
 
     # Launch launchers and wait for the last app to finish
     try:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This fixes an issue where `-g none` would launch Flask and just not open the browser. This had the negative effect that RAM usage would spiral as no clients attached allowing histories to clear.

Now flask will not launch at all.  Here is what was tested:
- [x] Flask does not launch
- [x] Test API scripts can still run w/o flask
- [x] `fprime-cli` telemetry and events still run w/o flask
- [x] `fprime-cli` send commands works w/o flask   




