### PR TITLE
Output unframed (garbage) data to file

### DIFF
--- a/src/fprime_gds/common/communication/ground.py
+++ b/src/fprime_gds/common/communication/ground.py
@@ -91,7 +91,7 @@ class TCPGround(GroundHandler):
         :return: list deframed packets
         """
         self.data += self.tcp.read()
-        (frames, self.data) = self.deframer.deframe_all(self.data, no_copy=True)
+        (frames, self.data, _) = self.deframer.deframe_all(self.data, no_copy=True)
         return frames
 
     def send_all(self, frames):

--- a/src/fprime_gds/common/communication/updown.py
+++ b/src/fprime_gds/common/communication/updown.py
@@ -36,16 +36,19 @@ class Downlinker:
     """
 
     def __init__(
-        self, adapter: BaseAdapter, ground: GroundHandler, deframer: FramerDeframer
+        self, adapter: BaseAdapter, ground: GroundHandler, deframer: FramerDeframer, discarded=None
     ):
         """Initialize the downlinker
 
-        Constructs a new downlinker object used to run the downlink and deframing operation.
+        Constructs a new downlinker object used to run the downlink and deframing operation. This downlinker will log
+        discarded (unframed) data when discarded is a writable data object. When discarded is None the discarded data is
+        dropped.
 
         Args:
             adapter: adapter used to read raw data from the hardware connection
             ground: handles the ground side connection
             deframer: deframer used to deframe data from the communication format
+            discarded: file to write discarded data to. None to drop the data.
         """
         self.running = True
         self.th_ground = None
@@ -54,6 +57,7 @@ class Downlinker:
         self.ground = ground
         self.deframer = deframer
         self.outgoing = Queue()
+        self.discarded = discarded
 
     def start(self):
         """Starts the downlink pipeline"""
@@ -74,12 +78,20 @@ class Downlinker:
         while self.running:
             # Blocks until data is available, but may still return b"" if timeout
             pool += self.adapter.read()
-            frames, pool = self.deframer.deframe_all(pool, no_copy=True)
+            frames, pool, discarded_data = self.deframer.deframe_all(pool, no_copy=True)
             try:
                 for frame in frames:
                     self.outgoing.put_nowait(frame)
             except Full:
                 DW_LOGGER.warning("GDS ground queue full, dropping frame")
+            try:
+                if self.discarded is not None:
+                    self.discarded.write(discarded_data)
+                    self.discarded.flush()
+            # Failure to write discarded data should never stop the GDS. Log it and move on.
+            except Exception as exc:
+                DW_LOGGER.warning("Cannot write discarded data %s", exc)
+                self.discarded = None  # Give up on logging further data
 
     def sending(self):
         """Outgoing stage of downlink
@@ -107,6 +119,7 @@ class Downlinker:
         for thread in [self.th_data, self.th_ground]:
             if thread is not None:
                 thread.join()
+        self.discarded = None
 
     def add_loopback_frame(self, frame):
         """Adds a frame to loopback to ground

--- a/src/fprime_gds/common/communication/updown.py
+++ b/src/fprime_gds/common/communication/updown.py
@@ -36,7 +36,11 @@ class Downlinker:
     """
 
     def __init__(
-        self, adapter: BaseAdapter, ground: GroundHandler, deframer: FramerDeframer, discarded=None
+        self,
+        adapter: BaseAdapter,
+        ground: GroundHandler,
+        deframer: FramerDeframer,
+        discarded=None,
     ):
         """Initialize the downlinker
 
@@ -61,10 +65,14 @@ class Downlinker:
 
     def start(self):
         """Starts the downlink pipeline"""
-        self.th_ground = threading.Thread(target=self.sending, name="DownlinkTTSGroundThread")
+        self.th_ground = threading.Thread(
+            target=self.sending, name="DownlinkTTSGroundThread"
+        )
         self.th_ground.daemon = True
         self.th_ground.start()
-        self.th_data = threading.Thread(target=self.deframing, name="DownLinkDeframingThread")
+        self.th_data = threading.Thread(
+            target=self.deframing, name="DownLinkDeframingThread"
+        )
         self.th_data.daemon = True
         self.th_data.start()
 

--- a/src/fprime_gds/common/logger/__init__.py
+++ b/src/fprime_gds/common/logger/__init__.py
@@ -10,6 +10,8 @@ import logging
 import os
 import sys
 
+INITIALIZED = False
+
 
 def configure_py_log(directory=None, filename=sys.argv[0], mirror_to_stdout=False):
     """
@@ -21,6 +23,9 @@ def configure_py_log(directory=None, filename=sys.argv[0], mirror_to_stdout=Fals
     :param mode: of file to write
     :param mirror_to_stdout: mirror the log output to standard our
     """
+    global INITIALIZED
+    if INITIALIZED:
+        return
     handlers = [logging.StreamHandler(sys.stdout)] if directory is None or mirror_to_stdout else []
     if directory is not None:
         log_file = os.path.join(directory, os.path.basename(filename))
@@ -33,4 +38,4 @@ def configure_py_log(directory=None, filename=sys.argv[0], mirror_to_stdout=Fals
         logging.getLogger().addHandler(handler)
     logging.getLogger().setLevel(logging.INFO)
     logging.info("Logging system initialized!")
-
+    INITIALIZED = True

--- a/src/fprime_gds/common/logger/__init__.py
+++ b/src/fprime_gds/common/logger/__init__.py
@@ -26,7 +26,11 @@ def configure_py_log(directory=None, filename=sys.argv[0], mirror_to_stdout=Fals
     global INITIALIZED
     if INITIALIZED:
         return
-    handlers = [logging.StreamHandler(sys.stdout)] if directory is None or mirror_to_stdout else []
+    handlers = (
+        [logging.StreamHandler(sys.stdout)]
+        if directory is None or mirror_to_stdout
+        else []
+    )
     if directory is not None:
         log_file = os.path.join(directory, os.path.basename(filename))
         log_file = log_file if log_file.endswith(".log") else f"{log_file}.log"

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -326,6 +326,15 @@ class CommAdapterParser(ParserBase):
                 ],
                 "default": fprime_gds.common.communication.checksum.CHECKSUM_SELECTION,
             },
+            ("--output-unframed-data",): {
+                "dest": "output_unframed_data",
+                "action": "store",
+                "nargs": "?",
+                "help": "Log unframed data to supplied file relative to log directory. Use '-' for standard out.",
+                "default": None,
+                "const": "unframed.log",
+                "required": False
+            }
         }
         return {**adapter_arguments, **com_arguments}
 

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -226,12 +226,16 @@ class DetectionParser(ParserBase):
         if likely_deployment.exists():
             args.deployment = likely_deployment
             return args
-        child_directories = [child for child in detected_toolchain.iterdir() if child.is_dir()]
+        child_directories = [
+            child for child in detected_toolchain.iterdir() if child.is_dir()
+        ]
         if not child_directories:
             msg = f"No deployments found in {detected_toolchain}. Specify deployment with: --deployment"
             raise Exception(msg)
         # Works for the old structure where the bin, lib, and dict directories live immediately under the platform
-        elif len(child_directories) == 3 and set([path.name for path in child_directories]) == {"bin", "lib", "dict"}:
+        elif len(child_directories) == 3 and set(
+            [path.name for path in child_directories]
+        ) == {"bin", "lib", "dict"}:
             args.deployment = detected_toolchain
             return args
         elif len(child_directories) > 1:
@@ -310,8 +314,7 @@ class CommAdapterParser(ParserBase):
                 "action": "store",
                 "type": str,
                 "help": "Adapter for communicating to flight deployment. [default: %(default)s]",
-                "choices": ["none"]
-                + list(adapter_definition_dictionaries),
+                "choices": ["none"] + list(adapter_definition_dictionaries),
                 "default": "ip",
             },
             ("--comm-checksum-type",): {
@@ -333,8 +336,8 @@ class CommAdapterParser(ParserBase):
                 "help": "Log unframed data to supplied file relative to log directory. Use '-' for standard out.",
                 "default": None,
                 "const": "unframed.log",
-                "required": False
-            }
+                "required": False,
+            },
         }
         return {**adapter_arguments, **com_arguments}
 
@@ -708,9 +711,7 @@ class BinaryDeployment(DetectionParser):
         args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
         if not args.app.is_file():
             msg = f"F prime binary '{args.app}' does not exist or is not a file"
-            raise ValueError(
-                msg
-            )
+            raise ValueError(msg)
         return args
 
 
@@ -737,7 +738,7 @@ class SearchArgumentsParser(ParserBase):
                 "action": "store",
                 "required": False,
                 "type": int,
-                "nargs":'+',
+                "nargs": "+",
                 "help": f"only show {self.command_name} matching the given type ID(s) 'ID'; can provide multiple IDs to show all given types",
                 "metavar": "ID",
             },

--- a/src/fprime_gds/executables/comm.py
+++ b/src/fprime_gds/executables/comm.py
@@ -86,19 +86,30 @@ def main():
     # Set the framing class used and pass it to the uplink and downlink component constructions giving each a separate
     # instantiation
     framer_class = FpFramerDeframer
-    LOGGER.info("Starting uplinker/downlinker connecting to FSW using %s with %s", adapter, framer_class.__name__)
+    LOGGER.info(
+        "Starting uplinker/downlinker connecting to FSW using %s with %s",
+        adapter,
+        framer_class.__name__,
+    )
     discarded_file_handle = None
     try:
         if args.output_unframed_data == "-":
             discarded_file_handle = sys.stdout.buffer
         elif args.output_unframed_data is not None:
-            discarded_file_handle_path = (Path(args.logs) / Path(args.output_unframed_data)).resolve()
+            discarded_file_handle_path = (
+                Path(args.logs) / Path(args.output_unframed_data)
+            ).resolve()
             try:
                 discarded_file_handle = open(discarded_file_handle_path, "wb")
                 LOGGER.info("Logging unframed data to %s", discarded_file_handle_path)
             except OSError:
-                LOGGER.warning("Failed to open %s. Unframed data will be discarded.", discarded_file_handle_path)
-        downlinker = Downlinker(adapter, ground, framer_class(), discarded=discarded_file_handle)
+                LOGGER.warning(
+                    "Failed to open %s. Unframed data will be discarded.",
+                    discarded_file_handle_path,
+                )
+        downlinker = Downlinker(
+            adapter, ground, framer_class(), discarded=discarded_file_handle
+        )
         uplinker = Uplinker(adapter, ground, framer_class(), downlinker)
 
         # Open resources for the handlers on either side, this prepares the resources needed for reading/writing data

--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -121,7 +121,18 @@ class FullListHistory extends ListHistory {
      * @param new_items: new items being to be process
      */
     send(new_items) {
-        this.store.splice(0, this.store.length, ...new_items);
+        // When the lists are not the same, update the stored list otherwise keep the list to prevent unnecessary bound
+        // data re-rendering.
+        if (this.store.length !== new_items.length) {
+            this.store.splice(0, this.store.length, ...new_items);
+            return;
+        }
+        for (let i = 0; i < Math.min(this.store.length, new_items.length); i++) {
+            if (this.store[i] !== new_items[i]) {
+                this.store.splice(0, this.store.length, ...new_items);
+                return;
+            }
+        }
     }
 }
 

--- a/src/fprime_gds/flask/static/js/vue-support/log.js
+++ b/src/fprime_gds/flask/static/js/vue-support/log.js
@@ -21,9 +21,11 @@ let template = `
         <div class="my-3">
             <v-select id="logselect"
                     :clearable="true" :searchable="true"
-                    :filterable="true"  :options="options"
+                    :filterable="true"  :options="logs"
                     v-model="selected">
             </v-select>
+            <input name="scroll" type="checkbox" v-model="scroll" />
+            <label for="scroll">Scroll Log Output</label>
         </div>
     </div>
     <div class="fp-scroll-container">
@@ -31,6 +33,7 @@ let template = `
             <pre><code>{{ text }}</code></pre>
         </div>
     </div>
+    <span>{{ error }}</span>
 </div>
 `;
 
@@ -40,18 +43,9 @@ Vue.component('v-select', VueSelect.VueSelect);
 
 Vue.component("logging", {
     template: template,
-    data() {return {"selected": "", "logs": _datastore.logs, text: ""}},
+    data() {return {"selected": "", "logs": _datastore.logs, text: "", "scroll": true, "error": ""}},
     mounted() {
         setInterval(this.update, 1000); // Grab log updates once a second
-    },
-    computed:{
-        /**
-         * Computes the appropriate log files available.
-         * @return {string[]}
-         */
-        options: function () {
-            return this.logs;
-        }
     },
     methods: {
         /**
@@ -65,8 +59,22 @@ Vue.component("logging", {
             _loader.load("/logdata/" + this.selected, "GET").then(
                 (result) => {
                     _self.text = result[_self.selected];
-                    this.$el.scrollTop = this.$el.scrollHeight
-                }).catch((result) => {_self.text = "[ERROR] "+ result});
+                    // Update on next-tick so that the updated content has been drawn already
+                    _self.$nextTick(() => {
+                        let panes = _self.$el.getElementsByClassName("fp-scrollable");
+                        if (panes && _self.scroll)
+                        {
+                            panes[0].scrollTop = panes[0].scrollHeight;
+                        }
+                    });
+                    _self.error = "";
+                }).catch((result) => {
+                    if (result === "") {
+                        _self.error = "[ERROR] Failed to update log content.";
+                    } else {
+                        _self.error = "[ERROR] " + result + ".";
+                    }
+                });
         }
     }
 });

--- a/src/fprime_gds/flask/static/js/vue-support/log.js
+++ b/src/fprime_gds/flask/static/js/vue-support/log.js
@@ -33,7 +33,7 @@ let template = `
             <pre><code>{{ text }}</code></pre>
         </div>
     </div>
-    <span>{{ error }}</span>
+    <div class="alert alert-danger" role="alert" v-if="error">{{ error }}</div>
 </div>
 `;
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| Infra |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This introduces a new argument `--output-unframed-data` to the `fprime-gds` that allows capture and output of the unframed (junk) data that is discarded by the deframing process.  This is needed for several reasons:

1. Sometimes data is multi-plexed, that is, frames come down mixed with something else (like console data)
2. Sometimes this data is necessary to understand bugs and other issues
3. Sometimes no data loss is acceptable even-if corrupted

This option allows users to output it when the flag is supplied.  When not supplied, the data is discarded as it was previously.

Fixed some other issues:
1. Logs drop-down jumping about: https://github.com/nasa/fprime/issues/2381
2. Logs pane clearing current data when erred preventing user from seeing what *was* there: https://github.com/nasa/fprime/issues/2380
3. Better scrolling of log pane data. Fixes: https://github.com/nasa/fprime/issues/2379
4. Python log output in GDS is no-longer in triplicate. Fixes: https://github.com/nasa/fprime/issues/2378

Primarily fixes: https://github.com/nasa/fprime/issues/2382

## Rationale

See above.

## Testing/Review Recommendations

Tested by putting out-of-frame data into `Ref`'s downlink.

## Future Work

None