### PR TITLE
Fix command argument types when importing from history

### DIFF
--- a/src/fprime_gds/flask/static/addons/commanding/command-history.js
+++ b/src/fprime_gds/flask/static/addons/commanding/command-history.js
@@ -102,7 +102,8 @@ Vue.component("command-history", {
             cmd.full_name = template.full_name;
             // Can only set command if it is a child of a command input
             if (this.$parent.selectCmd) {
-                this.$parent.selectCmd(cmd.full_name, cmd.args);
+                // command-input expects an array of strings as arguments
+                this.$parent.selectCmd(cmd.full_name, cmd.args.map(el => el.toString ? el.toString() : el));
             }
         }
     }

--- a/src/fprime_gds/flask/static/addons/commanding/command-history.js
+++ b/src/fprime_gds/flask/static/addons/commanding/command-history.js
@@ -103,7 +103,27 @@ Vue.component("command-history", {
             // Can only set command if it is a child of a command input
             if (this.$parent.selectCmd) {
                 // command-input expects an array of strings as arguments
-                this.$parent.selectCmd(cmd.full_name, cmd.args.map(el => el.toString ? el.toString() : el));
+                this.$parent.selectCmd(cmd.full_name, this.preprocess_args(cmd.args));
+            }
+        },
+        /**
+         * Process the arguments for a command. If the argument is (or contains) a number, it
+         * is converted to a string. Other types that should be pre-processed can be added here.
+         * 
+         * @param {*} args 
+         * @returns args processed for command input (numbers converted to strings)
+         */
+        preprocess_args(args) {
+            if (Array.isArray(args)) {
+                return args.map(el => this.preprocess_args(el));
+            } else if (typeof args === 'object' && args !== null) {
+                return Object.fromEntries(
+                    Object.entries(args).map(([key, value]) => [key, this.preprocess_args(value)])
+                );
+            } else if (typeof args === 'number') {
+                return args.toString();
+            } else {
+                return args;
             }
         }
     }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Originating Project/Creator_**| |
|**_Affected Component_**|  |
|**_Affected Architectures(s)_**|  |
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Builds Without Errors (y/n)_**|  |
|**_Unit Tests Pass (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/2473

Converting command arguments to string if available (e.g. on int's) as the command input fields expects them to be strings.
