### PR TITLE
Add support to GDS for struct member array

### DIFF
--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -261,7 +261,11 @@ class XmlLoader(dict_loader.DictLoader):
                     type_obj = self.parse_type(memb_type_name, memb, xml_obj)
                     # memb_size is not None for member array
                     if(memb_size is not None):
-                        type_obj = ArrayType.construct_type("Array_"+type_name, type_obj, int(memb_size), fmt_str)
+                        type_obj = ArrayType.construct_type(
+                            f"Array_{type_obj.__name__}_{memb_size}",
+                            type_obj,
+                            int(memb_size),
+                            fmt_str)
 
                     members.append((name, type_obj, fmt_str, desc))
 

--- a/src/fprime_gds/common/loaders/xml_loader.py
+++ b/src/fprime_gds/common/loaders/xml_loader.py
@@ -61,6 +61,7 @@ class XmlLoader(dict_loader.DictLoader):
     SER_MEMB_FMT_STR_TAG = "format_specifier"
     SER_MEMB_DESC_TAG = "description"
     SER_MEMB_TYPE_TAG = "type"
+    SER_MEMB_SIZE_TAG = "size"
 
     # Xml section names and tags for array types
     ARR_SECT = "arrays"
@@ -256,7 +257,11 @@ class XmlLoader(dict_loader.DictLoader):
                     fmt_str = memb.get(self.SER_MEMB_FMT_STR_TAG)
                     desc = memb.get(self.SER_MEMB_DESC_TAG)
                     memb_type_name = memb.get(self.SER_MEMB_TYPE_TAG)
+                    memb_size = memb.get(self.SER_MEMB_SIZE_TAG)
                     type_obj = self.parse_type(memb_type_name, memb, xml_obj)
+                    # memb_size is not None for member array
+                    if(memb_size is not None):
+                        type_obj = ArrayType.construct_type("Array_"+type_name, type_obj, int(memb_size), fmt_str)
 
                     members.append((name, type_obj, fmt_str, desc))
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added support for struct member array on fprime-gds.

## Rationale

Before this merge request `gds` was supporting only structs containing members of type array. With this change gds will also support arrays declared directly in the struct. 

More info from the discussion: https://github.com/nasa/fprime/discussions/2082#discussioncomment-6167558

## Testing/Review Recommendations

Here https://github.com/SMorettini/fprime/tree/UpdateDemoToShowArrMemberaySupportGds I update the Ref application to test this pull request. Should I make a pull request in Fprime?
