### PR TITLE
Fix logging of timebase in seqgen

### DIFF
--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -137,7 +137,7 @@ class SeqBinaryWriter:
         for cmd in seq_cmds_list:
             sequence += self.__binaryCmdRecord(cmd)
         size = len(sequence)
-        tb_txt = b"ANY" if self.__timebase == 0xFFFF else hex(self.__timebase)
+        tb_txt = "ANY" if self.__timebase == 0xFFFF else hex(self.__timebase)
 
         print(f"Sequence is {size} bytes with timebase {tb_txt}")
 

--- a/src/fprime_gds/common/encoders/seq_writer.py
+++ b/src/fprime_gds/common/encoders/seq_writer.py
@@ -137,9 +137,9 @@ class SeqBinaryWriter:
         for cmd in seq_cmds_list:
             sequence += self.__binaryCmdRecord(cmd)
         size = len(sequence)
-        tb_txt = b"ANY" if self.__timebase == 0xFFFF else bytes(self.__timebase)
+        tb_txt = b"ANY" if self.__timebase == 0xFFFF else hex(self.__timebase)
 
-        print("Sequence is %d bytes with timebase %s" % (size, tb_txt))
+        print(f"Sequence is {size} bytes with timebase {tb_txt}")
 
         header = b""
         header += U32Type(


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/1907 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/1907

`bytes(n)` creates a zero'ed out bytes object of size N, which is not what we want here, and was the cause of the reported bug.
`hex(n)` returns the string representation of N in hex, which is what we're looking for.

## Rationale

Bugfix
