### PR TITLE
Fixing check_arguments for consistency; added UT

### DIFF
--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -195,14 +195,14 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         return cls
 
     @classmethod
-    def check_arguments(cls, args):
+    def check_arguments(cls, address, port, server=True):
         """
         Code that should check arguments of this adapter. If there is a problem with this code, then a "ValueError"
         should be raised describing the problem with these arguments.
 
         :param args: arguments as dictionary
         """
-        check_port(args["address"], args["port"])
+        check_port(address, port)
 
 
 class IpHandler(abc.ABC):

--- a/src/fprime_gds/common/communication/adapters/uart.py
+++ b/src/fprime_gds/common/communication/adapters/uart.py
@@ -175,7 +175,7 @@ class SerialAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         return cls
 
     @classmethod
-    def check_arguments(cls, args):
+    def check_arguments(cls, device, baud):
         """
         Code that should check arguments of this adapter. If there is a problem with this code, then a "ValueError"
         should be raised describing the problem with these arguments.
@@ -183,16 +183,16 @@ class SerialAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         :param args: arguments as dictionary
         """
         ports = map(lambda info: info.device, list_ports.comports(include_links=True))
-        if args["device"] not in ports:
-            msg = f"Serial port '{args['device']}' not valid. Available ports: {ports}"
+        if device not in ports:
+            msg = f"Serial port '{device}' not valid. Available ports: {ports}"
             raise ValueError(
                 msg
             )
         # Note: baud rate may not *always* work. These are a superset
         try:
-            baud = int(args["baud"])
+            baud = int(baud)
         except ValueError:
-            msg = f"Serial baud rate '{args['baud']}' not integer. Use one of: {SerialAdapter.BAUDS}"
+            msg = f"Serial baud rate '{baud}' not integer. Use one of: {SerialAdapter.BAUDS}"
             raise ValueError(
                 msg
             )

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -419,7 +419,7 @@ class PluginArgumentParser(ParserBase):
         }
         # Check arguments or yield a Value error
         if hasattr(plugin, "check_arguments"):
-            plugin.check_arguments(filled_arguments)
+            plugin.check_arguments(**filled_arguments)
         return filled_arguments
 
 

--- a/test/fprime_gds/test_plugins.py
+++ b/test/fprime_gds/test_plugins.py
@@ -111,6 +111,12 @@ class GoodWithArgs(Good):
             },
         }
 
+    @classmethod
+    def check_arguments(cls, my_fancy_arg, fancy_2):
+        """ Check arguments to raise ValueError """
+        if fancy_2 < 0:
+            raise ValueError("Must be positive")
+
 
 class StartFunction(GdsFunction):
     """ A plugin implementation that starts a function
@@ -273,6 +279,15 @@ def test_plugin_arguments(plugins):
     assert isinstance(args.framing_selection_instance, GoodWithArgs), "Invalid instance created"
     assert args.framing_selection_instance.my_fancy_arg == a_string, "String argument did not process"
     assert args.framing_selection_instance.fancy_2 == int(a_number), "Integer argument did not process"
+
+
+def test_plugin_check_arguments(plugins):
+    """ Tests that arguments are validated in plugins """
+    a_string = "a_string"
+    a_number = "-20"
+    to_parse = ["--framing", "good-with-args", "--my-fancy-arg", a_string, "--my-fancy-arg-with-dest", a_number]
+    with pytest.raises(SystemExit):
+        args, _ = ParserBase.parse_args([PluginArgumentParser,], arguments=to_parse)
 
 
 @pytest.mark.parametrize("start_up", [(f"{__name__}:StartFunction", [])], indirect=True)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Added a UT for check_args. Made `check_arguments` consistent with `__init__`.