### PR TITLE
chore: migrate markers to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,3 +85,7 @@ fprime_test_api = "fprime_gds.common.testing_fw.pytest_integration"
 # - https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html
 # - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout
 ####
+[tool.pytest.ini_options]
+markers =[
+  "gds_cli"
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,0 @@
-[pytest]
-markers = 
-    gds_cli


### PR DESCRIPTION
## Change Description

This PR aims to migrate the pytest markers from the `pytest.ini` file to `pyproject.toml`

## Rationale

This allows for a more minimal project structure.

## Testing/Review Recommendations

A simple way to verify if `pytest` recognises the markers from the `pyproject.toml` file is to run `pytest --markers`.