### PR TITLE
Fixes nasa/fprime#2654

### DIFF
--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -202,7 +202,12 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
 
         :param args: arguments as dictionary
         """
-        check_port(address, port)
+        try:
+            if server:
+                check_port(address, port)
+        except OSError as os_error:
+            raise ValueError(f"{os_error}")
+
 
 
 class IpHandler(abc.ABC):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes nasa/fprime#2654:

1. Only check port availability if "server"
2. Trap OSError and recast as ValueError per expected `check_arguments` API


## Future Work

This type of error isn't so much an "argument error" as it is a "runtime error".  We should allow `check_arguments` to produce two types of exceptions one that is an argument error and prints help, the other that just prints the error.



