### PR TITLE
Default to ZMQ with --no-zmq to fallback on TTS

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -184,7 +184,7 @@ class ParserBase(ABC):
             sys.exit(-1)
         except Exception as exc:
             print(f"[ERROR] {exc}", file=sys.stderr)
-            raise
+            sys.exit(-1)
         return args_ns, parser
 
     @staticmethod

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -569,7 +569,7 @@ class MiddleWareParser(ParserBase):
                 "dest": "zmq",
                 "action": "store_false",
                 "help": "Disable ZMQ transportation layer, falling back to TCP socket server.",
-                "default": False,
+                "default": True,
             },
             ("--zmq-transport",): {
                 "dest": "zmq_transport",

--- a/src/fprime_gds/executables/comm.py
+++ b/src/fprime_gds/executables/comm.py
@@ -19,20 +19,16 @@ Note: assuming the module containing the ground adapter has been imported, then 
 import logging
 import signal
 import sys
-
 from pathlib import Path
 
 # Required adapters built on standard tools
-try:
-    from fprime_gds.common.zmq_transport import ZmqGround
-except ImportError:
-    ZmqGround = None
 import fprime_gds.common.communication.adapters.base
 import fprime_gds.common.communication.adapters.ip
 import fprime_gds.common.communication.ground
 import fprime_gds.common.logger
 import fprime_gds.executables.cli
 from fprime_gds.common.communication.updown import Downlinker, Uplinker
+from fprime_gds.common.zmq_transport import ZmqGround
 
 # Uses non-standard PIP package pyserial, so test the waters before getting a hard-import crash
 try:
@@ -68,11 +64,8 @@ def main():
         sys.exit(-1)
 
     # Create the handling components for either side of this script, adapter for hardware, and ground for the GDS side
-    if args.zmq and ZmqGround is None:
-        print("[ERROR] ZeroMQ is not available. Install pyzmq.", file=sys.stderr)
-        sys.exit(-1)
-    elif args.zmq:
-        ground = fprime_gds.common.zmq_transport.ZmqGround(args.zmq_transport)
+    if args.zmq:
+        ground = ZmqGround(args.zmq_transport)
     else:
         ground = fprime_gds.common.communication.ground.TCPGround(
             args.tts_addr, args.tts_port

--- a/test/fprime_gds/test_plugins.py
+++ b/test/fprime_gds/test_plugins.py
@@ -217,7 +217,7 @@ def start_up(request):
     extra_plugins, flags = request.param
 
     command_arguments = ["fprime-gds", "-n", "--dictionary", str( parent_path / "sample" / "dictionary.xml"),
-                         "--zmq", "--zmq-transport", "ipc:///tmp/fprime-test-in",  "ipc:///tmp/fprime-test-out",
+                         "--zmq-transport", "ipc:///tmp/fprime-test-in",  "ipc:///tmp/fprime-test-out",
                          "-g", "none"] + flags
 
     # Update the environment to side-load python


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2520 |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Defaults to using the ZMQ transport layer, falling back to TTS by user request with `--no-zmq`

## Rationale

https://github.com/nasa/fprime/issues/2520

