### PR TITLE
Fixes nasa/fprime#3086. Default to insertion order for chrono hist

### DIFF
--- a/src/fprime_gds/common/history/chrono.py
+++ b/src/fprime_gds/common/history/chrono.py
@@ -160,7 +160,9 @@ class ChronologicalHistory(History):
             the index that the item was inserted at (int)
         """
         for i, item in reversed(list(enumerate(ordered))):
-            if item.get_time() < data_object.get_time():
+            # Note: for events with the exact same time, this should default to the order received from downlink
+            #       and as such the data item should be treated as older.
+            if item.get_time() <= data_object.get_time():
                 ordered.insert(i + 1, data_object)
                 return i
         # If the data object is the earliest in the list or the list was empty

--- a/src/fprime_gds/common/history/chrono.py
+++ b/src/fprime_gds/common/history/chrono.py
@@ -161,7 +161,7 @@ class ChronologicalHistory(History):
         """
         for i, item in reversed(list(enumerate(ordered))):
             # Note: for events with the exact same time, this should default to the order received from downlink
-            #       and as such the data item should be treated as older.
+            #       and as such the data item should be treated as newer because it was received later.
             if item.get_time() <= data_object.get_time():
                 ordered.insert(i + 1, data_object)
                 return i


### PR DESCRIPTION
Chronological history needs to default to insertion order when the timestamps of the items are identical. This is fixed by changing the < to <= when comparing timestamps for "older" items.

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes nasa/fprime#3086