### PR TITLE
Remove spaces from CmdData::get_str(). Fixes #2925

### DIFF
--- a/src/fprime_gds/common/data_types/cmd_data.py
+++ b/src/fprime_gds/common/data_types/cmd_data.py
@@ -131,9 +131,8 @@ class CmdData(sys_data.SysData):
         else:
             # The arguments are currently serializable objects which cannot be
             # used to fill in a format string. Convert them to values that can be
-            arg_val_list = [arg_obj.val for arg_obj in self.args]
-
-            arg_str = " ".join(str(arg_val_list))
+            arg_val_list = self.get_arg_vals()
+            arg_str = str(arg_val_list)
 
         if verbose and csv:
             return f"{time_str},{raw_time_str},{name},{self.id},{arg_str}"

--- a/test/fprime_gds/common/data_types/test_cmd_data.py
+++ b/test/fprime_gds/common/data_types/test_cmd_data.py
@@ -34,7 +34,7 @@ class CmdDataTest(unittest.TestCase):
         Tests CmdData::get_str() for a command with several numerical arguments
         """
         opcode = 43
-        mnemonic = "TEST_CMD_NUMS"
+        mnemonic = "TEST_CMD_NUMERICS"
         component = "PythonTests"
         arguments = [("just_int", None, numerical_types.U32Type),
                      ("just_float", None, numerical_types.F64Type),
@@ -51,7 +51,7 @@ class CmdDataTest(unittest.TestCase):
         Tests CmdData::get_str() for a command with one string argument
         """
         opcode = 44
-        mnemonic = "TEST_CMD_NUMS"
+        mnemonic = "TEST_CMD_STR"
         component = "PythonTests"
         arguments = [("just_string", None, StringType.construct_type(f"String_{128}", 128))]
         command_template = CmdTemplate(opcode, mnemonic, component, arguments)

--- a/test/fprime_gds/common/data_types/test_cmd_data.py
+++ b/test/fprime_gds/common/data_types/test_cmd_data.py
@@ -1,0 +1,66 @@
+"""
+Tests Command Data
+
+Created on Jan 11, 2025
+@author: AlesKus
+"""
+
+import unittest
+from fprime.common.models.serialize.bool_type import BoolType
+import fprime.common.models.serialize.numerical_types as numerical_types
+from fprime.common.models.serialize.string_type import StringType
+from fprime_gds.common.templates.cmd_template import CmdTemplate
+from fprime_gds.common.data_types.cmd_data import CmdData
+
+
+class CmdDataTest(unittest.TestCase):
+    def test_str_bool_command_arg(self):
+        """
+        Tests CmdData::get_str() for a command with one bool argument
+        """
+        opcode = 42
+        mnemonic = "TEST_CMD_BOOL"
+        component = "PythonTests"
+        arguments = [("status", None, BoolType)]
+        command_template = CmdTemplate(opcode, mnemonic, component, arguments)
+        cmd_data = CmdData((True, ), command_template)
+
+        data_str = cmd_data.get_str()
+
+        self.assertIn("[True]", data_str)
+
+    def test_str_numerical_command_args(self):
+        """
+        Tests CmdData::get_str() for a command with several numerical arguments
+        """
+        opcode = 43
+        mnemonic = "TEST_CMD_NUMS"
+        component = "PythonTests"
+        arguments = [("just_int", None, numerical_types.U32Type),
+                     ("just_float", None, numerical_types.F64Type),
+                     ("just_byte", None, numerical_types.I8Type)]
+        command_template = CmdTemplate(opcode, mnemonic, component, arguments)
+        cmd_data = CmdData((12345, 98.765, 127), command_template)
+
+        data_str = cmd_data.get_str()
+
+        self.assertIn("[12345, 98.765, 127]", data_str)
+
+    def test_str_string_command_args(self):
+        """
+        Tests CmdData::get_str() for a command with one string argument
+        """
+        opcode = 44
+        mnemonic = "TEST_CMD_NUMS"
+        component = "PythonTests"
+        arguments = [("just_string", None, StringType.construct_type(f"String_{128}", 128))]
+        command_template = CmdTemplate(opcode, mnemonic, component, arguments)
+        cmd_data = CmdData(("Everything is good", ), command_template)
+
+        data_str = cmd_data.get_str()
+
+        self.assertIn("['Everything is good']", data_str)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#2925 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Removed `" ".join` from CmdData::get_str().
Added some simple unit tests to ensure it works.

## Rationale

Fix nasa/fprime#2925.

## Testing/Review Recommendations

Same as in the issue description:

1. Run the Ref example
2. Execute a command with a string argument
3. Look at command.log

There should be no spaces in the args section.

## Future Work

N/A
