### PR TITLE
Fix Parser Oversight

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -559,7 +559,9 @@ class CompositeParser(ParserBase):
         ]
         # Check to ensure everything passed in became a ParserBase after construction
         for i, construct in enumerate(constructed):
-            assert isinstance(construct, ParserBase), f"{construct.__class__.__name__} ({i}) not a ParserBase child"
+            assert isinstance(
+                construct, ParserBase
+            ), f"{construct.__class__.__name__} ({i}) not a ParserBase child"
         flattened = [
             item.constituents if isinstance(item, CompositeParser) else [item]
             for item in constructed

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -398,11 +398,11 @@ class IndividualPluginParser(BareArgumentParser):
                 for key, value in self.extract_arguments(arguments).items()
                 if key != self.disable_flag_destination
             }
-            plugin_instance = functools.partial(
+            plugin_zero_argument_class = functools.partial(
                 self.plugin_class.get_implementor(), **plugin_arguments
             )
             self.plugin_system.add_bound_class(
-                self.plugin_class.category, plugin_instance
+                self.plugin_class.category, plugin_zero_argument_class
             )
         return arguments
 
@@ -554,11 +554,12 @@ class CompositeParser(ParserBase):
         """Construct this parser by instantiating the sub-parsers"""
         self.given = description
         constructed = [
-            constituent if isinstance(constituent, ParserBase) else constituent()
+            constituent() if callable(constituent) else constituent
             for constituent in constituents
-            if (inspect.isclass(constituent) and issubclass(constituent, ParserBase))
-            or isinstance(constituent, ParserBase)
         ]
+        # Check to ensure everything passed in became a ParserBase after construction
+        for i, construct in enumerate(constructed):
+            assert isinstance(construct, ParserBase), f"{construct.__class__.__name__} ({i}) not a ParserBase child"
         flattened = [
             item.constituents if isinstance(item, CompositeParser) else [item]
             for item in constructed


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

`CompositeParser` had a flaw where it would not properly handle arguments and check they were valid.  In short, it will take something that can be constructed into a parser or a parser object. However, it did not accurately capture curried-constructors and failed on them.

The fix is to call callables, and otherwise pass instances.  Then check that everything is properly a ParserBase once constructed.