### PR TITLE
Add await_connection to Integration Test API

### DIFF
--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -234,6 +234,31 @@ class IntegrationTestAPI(DataHandler):
         """
         return Path(self.pipeline.dictionary_path).parent.parent.name
 
+    def wait_for_dataflow(self, count=1, start=None, timeout=120):
+        """
+        Wait for data flow by checking for any telemetry updates within a specified timeout.
+
+        Args:
+            count: either an exact amount (int) or a predicate to specify how many objects to find
+            start: an optional index or predicate to specify the earliest item to search
+            timeout: the number of seconds to wait before terminating the search (int)
+        """
+        if start is None:
+            start = self.get_latest_time()
+
+        chan_dict = self.pipeline.dictionaries.channel_name
+        chans = list(chan_dict.keys())
+
+        chan_hist = self.get_telemetry_subhistory()
+        result = self.await_telemetry_count(
+            count, channels=chans, history=chan_hist, start=start, timeout=timeout
+        )
+        if not result:
+            msg = f'Failed to detect any data flow for {timeout} s.'
+            self.__log(msg, TestLogger.RED)
+            assert False, msg
+        self.remove_telemetry_subhistory(chan_hist)
+
     ######################################################################################
     #   History Functions
     ######################################################################################

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -234,20 +234,18 @@ class IntegrationTestAPI(DataHandler):
         """
         return Path(self.pipeline.dictionary_path).parent.parent.name
 
-    def wait_for_dataflow(self, count=1, start=None, timeout=120):
+    def wait_for_dataflow(self, count=1, channels=None, start=None, timeout=120):
         """
         Wait for data flow by checking for any telemetry updates within a specified timeout.
 
         Args:
             count: either an exact amount (int) or a predicate to specify how many objects to find
+            channels: a channel specifier or list of channel specifiers (mnemonic, ID, or predicate). All will count if None
             start: an optional index or predicate to specify the earliest item to search
             timeout: the number of seconds to wait before terminating the search (int)
         """
         if start is None:
             start = self.get_latest_time()
-
-        ch_dict = self.pipeline.dictionaries.channel_name
-        channels = list(ch_dict.keys())
 
         history = self.get_telemetry_subhistory()
         result = self.await_telemetry_count(

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -246,18 +246,18 @@ class IntegrationTestAPI(DataHandler):
         if start is None:
             start = self.get_latest_time()
 
-        chan_dict = self.pipeline.dictionaries.channel_name
-        chans = list(chan_dict.keys())
+        ch_dict = self.pipeline.dictionaries.channel_name
+        channels = list(ch_dict.keys())
 
-        chan_hist = self.get_telemetry_subhistory()
+        history = self.get_telemetry_subhistory()
         result = self.await_telemetry_count(
-            count, channels=chans, history=chan_hist, start=start, timeout=timeout
+            count, channels=channels, history=history, start=start, timeout=timeout
         )
         if not result:
             msg = f'Failed to detect any data flow for {timeout} s.'
             self.__log(msg, TestLogger.RED)
             assert False, msg
-        self.remove_telemetry_subhistory(chan_hist)
+        self.remove_telemetry_subhistory(history)
 
     ######################################################################################
     #   History Functions


### PR DESCRIPTION
Added wait_for_dataflow()

| | |
|:---|:---|
|**_Related Issue(s)_**|  [2642](https://github.com/nasa/fprime/issues/2642) |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

There is a need to add a function in the fprime_test_api that allows tests to block or wait on data flow.

## Rationale

This function allows user to launch fit test calling fprime_test_api.wait_for_dataflow() and be able to bring up the flight software within a specified time duration.

## Testing/Review Recommendations

- Launch fprime-gds without the binary being loaded via one terminal
- Load the binary via a separate terminal and verify GSE is up and running
- Execute fit test
- While fit test is executing, kill the process that's running the binary
- Verify wait_for_dataflow() asserts when detecting no data flow for specified time duration
- Load the binary via a separate terminal and verify GSE is up and running
- Verify wait_for_dataflow() continues after detecting data flow

## Future Work

N/A
