### PR TITLE
Disable the generation of junitxml report by default

### DIFF
--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -60,9 +60,8 @@ def pytest_configure(config):
     hook is called for other conftest files as they are registered.
     """
     # Create a JUnit XML report file to capture the test result in a specified location
-    if not config.getoption("--junit-xml"):
-        if config.getoption("--gen-junitxml"):
-            config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
+    if config.getoption("--gen-junitxml"):
+        config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
 
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -46,6 +46,12 @@ def pytest_addoption(parser):
         default="report.xml",
         help="File to store JUnit XML report. [default: %(default)s]",
     )
+    # Add an option to enable JUnit XML report generation to a specified location
+    parser.addoption(
+        "--gen-junitxml",
+        action="store_true",
+        help="Enable JUnitXML report generation to a specified location"
+    )
 
 def pytest_configure(config):
     """ This is a hook to allow plugins and conftest files to perform initial configuration
@@ -53,9 +59,10 @@ def pytest_configure(config):
     This hook is called for every initial conftest file after command line options have been parsed. After that, the 
     hook is called for other conftest files as they are registered.
     """
-    # Create a JUnit XML report file to capture the test result
-    config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
-    config.option.junitxml = True
+    # Create a JUnit XML report file to capture the test result in a specified location
+    if not config.getoption("--junit-xml"):
+        if config.getoption("--gen-junitxml"):
+            config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
 
 @pytest.fixture(scope='session')
 def fprime_test_api_session(request):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [2646](https://github.com/nasa/fprime/issues/2646) |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This is a hotfix to an existing feature request documented in ticket #197. Previous change updated the default pytest behavior. This hotfix will restore the original pytest behavior.

## Rationale

Running pytest should not generate junitxml report. The generation of this report should only be requested or set by user.

## Testing/Review Recommendations

- Verified the generation of the junitxml report is done only when the `--gen-junitxml` flag is set or when the file location is passed in `--junit-xml` 

## Future Work

N/A