### PR TITLE
Fix rendering of processor time

### DIFF
--- a/src/fprime_gds/flask/static/js/vue-support/channel.js
+++ b/src/fprime_gds/flask/static/js/vue-support/channel.js
@@ -67,7 +67,7 @@ Vue.component("channel-table", {
             if (item.time == null || item.val == null) {
                 return ["", "0x" + item.id.toString(16), template.full_name, ""];
             }
-            return [timeToString(item.datetime || item.time), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time || item.datetime), "0x" + item.id.toString(16), template.full_name,
                 (typeof(item.display_text) !== "undefined")? item.display_text : item.val]
         },
         /**

--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -80,7 +80,7 @@ Vue.component("event-list", {
                 const msg = '<span title="' + groups[0] + '">' + command_mnemonic + '</span>'
                 display_text = display_text.replace(OPREG, msg);
             }
-            return [timeToString(item.datetime || item.time), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time || item.datetime), "0x" + item.id.toString(16), template.full_name,
                 template.severity.value.replace("EventSeverity.", ""), display_text];
         },
         /**


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/3605 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

`timeToString` provides better rendering for processor timestamps than `timeToDate`. `timeToDate` is used to derive `item.datetime`, so defaulting to the value for `item.datetime` over the value for `item.time` results in processor times getting rendered as unix times. This PR changes the default to prefer the full `timeToString` rendering approach instead.

## Rationale

Processor times should be preferentially rendered as 0-based numbers, such as `210.42764`, not 1970-based dates, such as `1970-01-01T00:03:30.427Z`.

## Testing/Review Recommendations

N/A

## Future Work

This does not solve the problem of rendering charts correctly, because charts are still always based on full calendar dates.
