### PR TITLE
Update Space Packet package dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "pyserial>=3.5",
     "pydantic>=2.6",
     "PyYAML>=6.0.2",
-    "spacepackets>=0.28.0",
+    "spacepackets>=0.30.0",
     "crc>=7.0.0"
 ]
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3777

Needed to get rid of old `crc` package