### PR TITLE
Fix dp_writer bug: Use underlying type for FwDpIdType alias

### DIFF
--- a/src/fprime_gds/executables/data_product_writer.py
+++ b/src/fprime_gds/executables/data_product_writer.py
@@ -336,12 +336,12 @@ class DPHeader(BaseModel):
     
     @computed_field
     @property
-    def dataId(self) -> Type:
+    def dataId(self) -> AliasType:
         return self.header.get("FwDpIdType")
     
     @computed_field
     @property
-    def dataSize(self) -> Type:
+    def dataSize(self) -> AliasType:
         return self.header.get("FwSizeStoreType")
 
     @model_validator(mode='after')
@@ -731,7 +731,7 @@ class DataProductWriter:
     def get_record_data(self, headerJSON: DPHeader, dictJSON: FprimeDict) -> Dict[str, int]:
         rootDict = {}
         # Go through all the Records and find the one that matches recordId
-        rootDict['dataId'] = self.read_field(headerJSON.dataId.type)
+        rootDict['dataId'] = self.read_field(headerJSON.dataId.underlyingType)
         for record in dictJSON.records:
             if record.id == rootDict['dataId']:    
                 print(f'Processing Record ID {record.id}')

--- a/test/fprime_gds/executables/dp_writer_data/dictionary.json
+++ b/test/fprime_gds/executables/dp_writer_data/dictionary.json
@@ -7,7 +7,247 @@
     ],
     "dictionarySpecVersion" : "1.0.0"
   },
+  "constants" : [
+  {
+    "kind" : "constant",
+    "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
+    "type" : {
+      "name" : "U64",
+      "kind" : "integer",
+      "size" : 64,
+      "signed" : false
+    },
+    "value" : 32,
+    "annotation" : "The container user data size"
+  }
+  ],
   "typeDefinitions" : [
+      {
+        "kind" : "alias",
+        "qualifiedName" : "FwIdType",
+        "type" : {
+          "name" : "U32",
+          "kind" : "integer",
+          "size" : 32,
+          "signed" : false
+        },
+        "underlyingType" : {
+          "name" : "U32",
+          "kind" : "integer",
+          "size" : 32,
+          "signed" : false
+        },
+        "annotation" : "The id type."
+      },
+      {
+          "kind" : "alias",
+          "qualifiedName" : "FwTlmPacketizeIdType",
+          "type" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          },
+          "underlyingType" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "enum",
+          "qualifiedName" : "Fw.DpState",
+          "representationType" : {
+            "name" : "U8",
+            "kind" : "integer",
+            "size" : 8,
+            "signed" : false
+          },
+          "enumeratedConstants" : [
+            {
+              "name" : "UNTRANSMITTED",
+              "value" : 0,
+              "annotation" : "The untransmitted state"
+            },
+            {
+              "name" : "PARTIAL",
+              "value" : 1,
+              "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
+            },
+            {
+              "name" : "TRANSMITTED",
+              "value" : 2,
+              "annotation" : "The transmitted state"
+            }
+          ],
+          "default" : "Fw.DpState.UNTRANSMITTED"
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwEventIdType",
+          "type" : {
+            "name" : "FwIdType",
+            "kind" : "qualifiedIdentifier"
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwSizeStoreType",
+          "type" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          },
+          "underlyingType" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwTimeContextStoreType",
+          "type" : {
+            "name" : "U8",
+            "kind" : "integer",
+            "size" : 8,
+            "signed" : false
+          },
+          "underlyingType" : {
+            "name" : "U8",
+            "kind" : "integer",
+            "size" : 8,
+            "signed" : false
+          },
+          "annotation" : "The type used to serialize a time context value"
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwDpIdType",
+          "type" : {
+            "name" : "FwIdType",
+            "kind" : "qualifiedIdentifier"
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "enum",
+          "qualifiedName" : "Fw.DpCfg.ProcType",
+          "representationType" : {
+            "name" : "U8",
+            "kind" : "integer",
+            "size" : 8,
+            "signed" : false
+          },
+          "enumeratedConstants" : [
+            {
+              "name" : "PROC_TYPE_ZERO",
+              "value" : 1,
+              "annotation" : "Processing type 0"
+            },
+            {
+              "name" : "PROC_TYPE_ONE",
+              "value" : 2,
+              "annotation" : "Processing type 1"
+            },
+            {
+              "name" : "PROC_TYPE_TWO",
+              "value" : 4,
+              "annotation" : "Processing type 2"
+            }
+          ],
+          "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
+          "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwPacketDescriptorType",
+          "type" : {
+            "name" : "FwIdType",
+            "kind" : "qualifiedIdentifier"
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwDpPriorityType",
+          "type" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwTimeBaseStoreType",
+          "type" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          },
+          "underlyingType" : {
+            "name" : "U16",
+            "kind" : "integer",
+            "size" : 16,
+            "signed" : false
+          },
+          "annotation" : "The type used to serialize a time base value"
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwOpcodeType",
+          "type" : {
+            "name" : "FwIdType",
+            "kind" : "qualifiedIdentifier"
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+        },
+        {
+          "kind" : "alias",
+          "qualifiedName" : "FwChanIdType",
+          "type" : {
+            "name" : "FwIdType",
+            "kind" : "qualifiedIdentifier"
+          },
+          "underlyingType" : {
+            "name" : "U32",
+            "kind" : "integer",
+            "size" : 32,
+            "signed" : false
+          }
+    },
     {
       "kind" : "struct",
       "qualifiedName" : "Ref.PacketStat",
@@ -841,34 +1081,6 @@
     },
     {
       "kind" : "enum",
-      "qualifiedName" : "Fw.DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "Fw.DpState.UNTRANSMITTED"
-    },
-    {
-      "kind" : "enum",
       "qualifiedName" : "Ref.SignalType",
       "representationType" : {
         "name" : "I32",
@@ -1211,239 +1423,6 @@
         "tSub" : 0
       },
       "annotation" : "Data structure representing a data product."
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwTlmPacketizeIdType",
-      "type" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Fw.DpState",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "UNTRANSMITTED",
-          "value" : 0,
-          "annotation" : "The untransmitted state"
-        },
-        {
-          "name" : "PARTIAL",
-          "value" : 1,
-          "annotation" : "The partially transmitted state\nA data product is in this state from the start of transmission\nuntil transmission is complete."
-        },
-        {
-          "name" : "TRANSMITTED",
-          "value" : 2,
-          "annotation" : "The transmitted state"
-        }
-      ],
-      "default" : "Fw.DpState.UNTRANSMITTED"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwEventIdType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwSizeStoreType",
-      "type" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwTimeContextStoreType",
-      "type" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "annotation" : "The type used to serialize a time context value"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwDpIdType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "enum",
-      "qualifiedName" : "Fw.DpCfg.ProcType",
-      "representationType" : {
-        "name" : "U8",
-        "kind" : "integer",
-        "size" : 8,
-        "signed" : false
-      },
-      "enumeratedConstants" : [
-        {
-          "name" : "PROC_TYPE_ZERO",
-          "value" : 1,
-          "annotation" : "Processing type 0"
-        },
-        {
-          "name" : "PROC_TYPE_ONE",
-          "value" : 2,
-          "annotation" : "Processing type 1"
-        },
-        {
-          "name" : "PROC_TYPE_TWO",
-          "value" : 4,
-          "annotation" : "Processing type 2"
-        }
-      ],
-      "default" : "Fw.DpCfg.ProcType.PROC_TYPE_ZERO",
-      "annotation" : "A bit mask for selecting the type of processing to perform on\na container before writing it to disk."
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwPacketDescriptorType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwDpPriorityType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwTimeBaseStoreType",
-      "type" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U16",
-        "kind" : "integer",
-        "size" : 16,
-        "signed" : false
-      },
-      "annotation" : "The type used to serialize a time base value"
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwOpcodeType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    },
-    {
-      "kind" : "alias",
-      "qualifiedName" : "FwChanIdType",
-      "type" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      },
-      "underlyingType" : {
-        "name" : "U32",
-        "kind" : "integer",
-        "size" : 32,
-        "signed" : false
-      }
-    }
-  ],
-  "constants": [
-    {
-      "kind" : "constant",
-      "qualifiedName" : "Fw.DpCfg.CONTAINER_USER_DATA_SIZE",
-      "type" : {
-        "name" : "U64",
-        "kind" : "integer",
-        "size" : 64,
-        "signed" : false
-      },
-      "value" : 32,
-      "annotation" : "The container user data size"
     }
   ],
   "commands" : [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixed bug where the underlying type of the FwDpIdType alias type was not used when decoding DPs.
