### PR TITLE
Add concurrency groups to CI workflows

### DIFF
--- a/.github/workflows/codeql-security-scan.yml
+++ b/.github/workflows/codeql-security-scan.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ devel ]
+# Cancel in-progress runs if a newer run is started on a given PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
 jobs:
   analyze:

--- a/.github/workflows/fprime-gds-tests.yml
+++ b/.github/workflows/fprime-gds-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ devel ]
+# Cancel in-progress runs if a newer run is started on a given PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
 jobs:
   Unit-tests:

--- a/.github/workflows/gds-cli-tests.yml
+++ b/.github/workflows/gds-cli-tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ devel ]
+# Cancel in-progress runs if a newer run is started on a given PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
 env:
   DICTIONARY: ./.github/resources/RefTopologyAppDictionary.xml

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -11,6 +11,10 @@ on:
     tags-ignore:
       - "**"
     types: ['opened', 'reopened', 'synchronize']
+# Cancel in-progress runs if a newer run is started on a given PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'devel') && !contains(github.ref, 'release/')}}
 
 jobs:
   spelling:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Adds concurrency groups so that we don't queue up too many jobs when pushing new commits to PRs
