### PR TITLE
Fix apps logging by logging directly to subdirectory

### DIFF
--- a/src/fprime_gds/executables/apps.py
+++ b/src/fprime_gds/executables/apps.py
@@ -40,7 +40,7 @@ class GdsBaseFunction(ABC):
     """
 
     @abstractmethod
-    def run(self):
+    def run(self, parsed_args):
         """Run the start-up function
 
         Run the start-up function unconstrained by the limitations of running in a dedicated subprocess.

--- a/src/fprime_gds/executables/apps.py
+++ b/src/fprime_gds/executables/apps.py
@@ -14,8 +14,8 @@ command line that will be spun into its own process.
 import subprocess
 import sys
 from abc import ABC, abstractmethod
-from argparse import Namespace
-from typing import final, List, Dict, Tuple, Type
+import argparse
+from typing import final, List, Dict, Tuple, Type, Optional
 
 from fprime_gds.plugin.definitions import gds_plugin_specification, gds_plugin
 from fprime_gds.plugin.system import Plugins
@@ -110,13 +110,13 @@ class GdsApp(GdsBaseFunction):
         self.process = None
         self.arguments = arguments
 
-    def run(self):
+    def run(self, parsed_args):
         """Run the application as an isolated process
 
         GdsFunction objects require an implementation of the `run` command. This implementation will take the arguments
         provided from `get_process_invocation` function and supplies them as an invocation of the isolated subprocess.
         """
-        invocation_arguments = self.get_process_invocation()
+        invocation_arguments = self.get_process_invocation(parsed_args)
         self.process = subprocess.Popen(invocation_arguments)
 
     def wait(self, timeout=None):
@@ -137,7 +137,9 @@ class GdsApp(GdsBaseFunction):
         return self.process.returncode
 
     @abstractmethod
-    def get_process_invocation(self) -> List[str]:
+    def get_process_invocation(
+        self, namespace: Optional[argparse.Namespace] = None
+    ) -> List[str]:
         """Run the start-up function
 
         Run the start-up function unconstrained by the limitations of running in a dedicated subprocess.
@@ -216,6 +218,14 @@ class GdsStandardApp(GdsApp):
         return {
             **cls.get_additional_arguments(),
             **StandardPipelineParser().get_arguments(),
+            **{
+                ("--log-directly",): {
+                    "dest": "log_directly",
+                    "action": "store_true",
+                    "default": True,
+                    "help": "Logging directory is used directly, no extra dated directories created.",
+                }
+            },
         }
 
     @classmethod
@@ -230,7 +240,7 @@ class GdsStandardApp(GdsApp):
         """Start function to contain behavior based in standard pipeline"""
         raise NotImplementedError()
 
-    def get_process_invocation(self):
+    def get_process_invocation(self, namespace=None):
         """Return the process invocation for this class' main
 
         The process invocation of this application is to run cls.main and supply it a reproduced version of the
@@ -247,7 +257,8 @@ class GdsStandardApp(GdsApp):
         composite_parser = CompositeParser(
             [self.get_cli_parser(), StandardPipelineParser]
         )
-        namespace, _, _ = ParserBase.parse_known_args([composite_parser])
+        if namespace is None:
+            namespace, _, _ = ParserBase.parse_known_args([composite_parser])
         args = composite_parser.reproduce_cli_args(namespace)
         return [sys.executable, "-c", f"import {module}\n{module}.{cls}.main()"] + args
 
@@ -261,7 +272,7 @@ class GdsStandardApp(GdsApp):
                     []
                 )  # Disable plugin system unless specified through init
             # In the case where `init` sets up the plugin system, we want to pass the assertion
-            # triggered by the code above that turns it off in the not-setup case. 
+            # triggered by the code above that turns it off in the not-setup case.
             except AssertionError:
                 pass
             plugin_name = getattr(cls, "get_name", lambda: cls.__name__)()

--- a/src/fprime_gds/executables/apps.py
+++ b/src/fprime_gds/executables/apps.py
@@ -218,14 +218,6 @@ class GdsStandardApp(GdsApp):
         return {
             **cls.get_additional_arguments(),
             **StandardPipelineParser().get_arguments(),
-            **{
-                ("--log-directly",): {
-                    "dest": "log_directly",
-                    "action": "store_true",
-                    "default": True,
-                    "help": "Logging directory is used directly, no extra dated directories created.",
-                }
-            },
         }
 
     @classmethod

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -5,6 +5,7 @@
 ####
 import os
 import sys
+import copy
 import webbrowser
 
 from fprime_gds.executables.cli import (
@@ -184,13 +185,14 @@ def launch_plugin(parsed_args, plugin_class_instance):
         "get_name",
         lambda: plugin_class_instance.__class__.__name__,
     )()
+    plugin_args = copy.deepcopy(parsed_args)
     # Set logging to use a subdirectory within the root logs directory
-    plugin_logs = os.path.join(parsed_args.logs, plugin_name)
+    plugin_logs = os.path.join(plugin_args.logs, plugin_name)
     os.mkdir(plugin_logs)
-    parsed_args.logs = plugin_logs
-    parsed_args.log_directly = True
+    plugin_args.logs = plugin_logs
+    plugin_args.log_directly = True
     return launch_process(
-        plugin_class_instance.get_process_invocation(parsed_args),
+        plugin_class_instance.get_process_invocation(plugin_args),
         name=f"{ plugin_name } Plugin App",
         launch_time=1,
     )

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -38,7 +38,9 @@ def parse_args():
         PluginArgumentParser,
     ]
     # Parse the arguments, and refine through all handlers
-    args, parser = ConfigDrivenParser.parse_args(arg_handlers, "Run F prime deployment and GDS")
+    args, parser = ConfigDrivenParser.parse_args(
+        arg_handlers, "Run F prime deployment and GDS"
+    )
     return args
 
 
@@ -175,11 +177,20 @@ def launch_comm(parsed_args):
     )
 
 
-def launch_plugin(plugin_class_instance):
+def launch_plugin(parsed_args, plugin_class_instance):
     """Launch a plugin instance"""
-    plugin_name = getattr(plugin_class_instance, "get_name", lambda: plugin_class_instance.__class__.__name__)()
+    plugin_name = getattr(
+        plugin_class_instance,
+        "get_name",
+        lambda: plugin_class_instance.__class__.__name__,
+    )()
+    # Set logging to use a subdirectory within the root logs directory
+    plugin_logs = os.path.join(parsed_args.logs, plugin_name)
+    os.mkdir(plugin_logs)
+    parsed_args.logs = plugin_logs
+    parsed_args.log_directly = True
     return launch_process(
-        plugin_class_instance.get_process_invocation(),
+        plugin_class_instance.get_process_invocation(parsed_args),
         name=f"{ plugin_name } Plugin App",
         launch_time=1,
     )
@@ -218,11 +229,11 @@ def main():
     try:
         procs = [launcher(parsed_args) for launcher in launchers]
         _ = [
-            launch_plugin(cls())
+            launch_plugin(parsed_args, cls())
             for cls in Plugins.system().get_feature_classes("gds_app")
         ]
         _ = [
-            instance().run()
+            instance().run(parsed_args)
             for instance in Plugins.system().get_feature_classes("gds_function")
         ]
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fixes double-logging when plugin apps are running
Adds a subdirectory per plugin, within the root logging directory.
