### PR TITLE
Expose dictionary path for integration API

### DIFF
--- a/src/fprime_gds/common/models/dictionaries.py
+++ b/src/fprime_gds/common/models/dictionaries.py
@@ -49,6 +49,9 @@ class Dictionaries:
         self._fw_type_name_dict = None
         self._versions = None
         self._metadata = None
+        self._dictionary_path = None
+        self._packet_spec_path = None
+        self._packet_set_name = None
 
     def load_dictionaries(self, dictionary, packet_spec, packet_set_name):
         """
@@ -59,6 +62,11 @@ class Dictionaries:
         :param packet_spec: specification for packets, or None, for packetized telemetry
         :param packet_set_name: name of packet set in case multiple are available
         """
+        # Update the "from" values
+        self._dictionary_path = dictionary
+        self._packet_spec_path = packet_spec
+        self._packet_set_name = packet_set_name
+
         if Path(dictionary).is_file() and ".json" in Path(dictionary).suffixes:
             # Events
             json_event_loader = (
@@ -203,6 +211,21 @@ class Dictionaries:
         Note: framework_version and project_version are also available as separate properties
         for legacy reasons. New code should use the metadata property."""
         return self._metadata
+
+    @property
+    def dictionary_path(self):
+        """ Dictionary Path """
+        return self._dictionary_path
+
+    @property
+    def packet_spec_path(self):
+        """ Dictionary Path """
+        return self._packet_spec_path
+    
+    @property
+    def packet_set_name(self):
+        """ Dictionary Path """
+        return self._packet_set_name
 
     @property
     def packet(self):

--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -239,3 +239,8 @@ class StandardPipeline:
         :return: filing compositions
         """
         return self.__filing
+
+    @property
+    def dictionaries(self):
+        """ Dictionaries member """
+        return self.__dictionaries

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -71,7 +71,7 @@ class IntegrationTestAPI(DataHandler):
 
         # Copy dictionaries and binary file to output directory
         if logpath is not None:
-            base_dir = Path(self.pipeline.dictionary_path).parents[1]
+            base_dir = Path(self.dictionaries.dictionary_path).parents[1]
             for subdir in ["bin", "dict"]:
                 dir_path = base_dir / subdir
                 if dir_path.is_dir():
@@ -84,6 +84,13 @@ class IntegrationTestAPI(DataHandler):
 
         # Used by the data_callback method to detect if events have been received out of order.
         self.last_evr = None
+
+    @property
+    def dictionaries(self):
+        """ Return the dictionaries """
+        # Pipeline should not be exposed to the user, but it stores the dictionary
+        # thus delegate to it.
+        return self.pipeline.dictionaries
 
     def setup(self):
         """Set up the API, assumes pipeline is now setup"""


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This exposes the dictionaries object, and adds path, spec, and set name properties.  These were needed, but gotten in a round-about way. This fixes that.