### PR TITLE
Allow JS config; fix dictionary cli config

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -318,6 +318,7 @@ class ConfigDrivenParser(ParserBase):
 
     DEFAULT_CONFIGURATION_PATH = Path("fprime-gds.yml")
 
+
     @classmethod
     def set_default_configuration(cls, path: Path):
         """Set path for (global) default configuration file
@@ -413,6 +414,14 @@ class ConfigDrivenParser(ParserBase):
             print(f"[INFO] Reading command-line configuration from: {args.config}")
             with open(args.config, "r") as file_handle:
                 try:
+                    relative_base = args.config.parent.absolute()
+
+                    def path_constructor(loader, node):
+                        """ Processes !PATH annotations as relative to current file """
+                        calculated_path = relative_base / loader.construct_scalar(node)
+                        return calculated_path
+
+                    yaml.SafeLoader.add_constructor("!PATH", path_constructor)
                     loaded = yaml.safe_load(file_handle)
                     args.config_values = loaded if loaded is not None else {}
                 except Exception as exc:

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -11,6 +11,7 @@ import webbrowser
 from fprime_gds.executables.cli import (
     BinaryDeployment,
     ConfigDrivenParser,
+    CompositeParser,
     CommParser,
     GdsParser,
     ParserBase,
@@ -104,6 +105,7 @@ def launch_html(parsed_args):
     Return:
         launched process
     """
+    composite_parser = CompositeParser([StandardPipelineParser, ConfigDrivenParser])
     reproduced_arguments = StandardPipelineParser().reproduce_cli_args(parsed_args)
     if "--log-directly" not in reproduced_arguments:
         reproduced_arguments += ["--log-directly"]

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -203,7 +203,7 @@ def handle_unexpected_error(error):
 @app.route("/js/config.js")
 def config_serve():
     """
-    Serve the config.js file specifcally
+    Serve the config.js file
 
     :param path: path to the file (in terms of web browser)
     """

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -29,7 +29,7 @@ import fprime_gds.flask.logs
 import fprime_gds.flask.sequence
 import fprime_gds.flask.stats
 import fprime_gds.flask.updown
-from fprime_gds.executables.cli import ParserBase, StandardPipelineParser
+from fprime_gds.executables.cli import ParserBase, StandardPipelineParser, ConfigDrivenParser
 
 from . import components
 
@@ -59,6 +59,7 @@ def construct_app():
         compress.init_app(app)
 
     app.config.from_object("fprime_gds.flask.default_settings")
+
     # Override defaults from python files specified in 'FP_FLASK_SETTINGS'
     if "FP_FLASK_SETTINGS" in os.environ:
         app.config.from_envvar("FP_FLASK_SETTINGS")
@@ -69,9 +70,14 @@ def construct_app():
     # Standard pipeline creation
     input_arguments = app.config["STANDARD_PIPELINE_ARGUMENTS"]
     args_ns, _ = ParserBase.parse_args(
-        [StandardPipelineParser], "n/a", input_arguments, client=True
+        [StandardPipelineParser, ConfigDrivenParser], "n/a", input_arguments, client=True
     )
+    # Load app configuration from file
+    for key, value in args_ns.config_values.get("flask", {}).items():
+        app.config[key] = value
+
     pipeline = components.setup_pipelined_components(app.debug, args_ns)
+
 
     # Restful API registration
     api = fprime_gds.flask.errors.setup_error_handling(app)
@@ -193,6 +199,15 @@ def handle_unexpected_error(error):
     response = {"errors": [fprime_gds.flask.errors.build_error_object(error)]}
     return flask.jsonify(response), status_code
 
+
+@app.route("/js/config.js")
+def config_serve():
+    """
+    Serve the config.js file specifcally
+
+    :param path: path to the file (in terms of web browser)
+    """
+    return flask.send_file(app.config["JS_CONFIGURATION_FILE"])
 
 @app.route("/js/<path:path>")
 def files_serve(path):

--- a/src/fprime_gds/flask/default_settings.py
+++ b/src/fprime_gds/flask/default_settings.py
@@ -16,5 +16,6 @@ SERVE_LOGS = os.environ.get("SERVE_LOGS", "YES") == "YES"
 
 MAX_CONTENT_LENGTH = 32 * 1024 * 1024  # Max length of request is 32MiB
 
+JS_CONFIGURATION_FILE = os.path.join(os.path.dirname(__file__), "static", "js", "config.js")
 
 # TODO: load real config


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

This allows for better configuration in the GDS:

1. It allows FLASK config (from default_settings.py) to be specified in the `flask` section of fprime-gds.yml
2. It allows JS_CONIFIGURATION_FILE to be specified allowing for configuration of the JS layer
3. It (somehow) fixes nasa/fprime#4021

Fixes nasa/fprime#4021, nasa/fprime#3262