### PR TITLE
Turn off Dashboard by default

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -416,6 +416,7 @@ viewcode
 vle
 vname
 VRuntime
+vuejs
 vw
 Watney
 webified

--- a/src/fprime_gds/flask/static/index.html
+++ b/src/fprime_gds/flask/static/index.html
@@ -77,7 +77,9 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                                     <li v-for="tab in tabs"
                                         :class="['nav-item', 'nav-link', 'click-able-item', { active: currentTab == tab[0] }]"
                                         :key="tab[0]"
-                                        v-on:click="route(tab[0])">
+                                        v-on:click="route(tab[0])"
+                                        v-if="config.enableDashboards || tab[0] != 'Dashboard'"
+                                    >
                                         <span class="d-none d-sm-none d-md-none d-lg-block" v-bind:id="tab[0]">{{ tab[0] }}</span>
                                         <span class="d-none d-sm-block d-md-block d-lg-none">{{ tab[1] }}</span>
                                     </li>
@@ -111,7 +113,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                         <dictionary    v-show="currentTab == 'Dictionaries'"></dictionary>
                         <logging       v-show="currentTab == 'Logs'"></logging>
                         <sequencer     v-show="currentTab == 'Sequences'"></sequencer>
-                        <dashboard     v-show="currentTab == 'Dashboard'"></dashboard>
+                        <dashboard v-if="config.enableDashboards"    v-show="currentTab == 'Dashboard'"></dashboard>
                         <advanced-settings v-show="currentTab == 'Advanced'"></advanced-settings>
                         <dictionary-version></dictionary-version>
                     </div>

--- a/src/fprime_gds/flask/static/js/config.js
+++ b/src/fprime_gds/flask/static/js/config.js
@@ -22,5 +22,13 @@ export let config = {
         default: 1000
     },
     // Summary counter fields containing object of field: bootstrap class
-    summaryFields: {"WARNING_HI": "warning", "FATAL": "danger", "GDS_Errors": "danger"}
+    summaryFields: {"WARNING_HI": "warning", "FATAL": "danger", "GDS_Errors": "danger"},
+
+    // Dashboards are a security vulnerability in that users are uploading artifacts that trigger
+    // arbitrary rendering and code execution. This is explained in more detail here:
+    //     https://v2.vuejs.org/v2/guide/security#Rule-No-1-Never-Use-Non-trusted-Templates
+    //
+    // Thus dashboards are disabled by default and projects must opt-in thus taking the responsibility
+    // to validate and review the safety of the dashboards they use.
+    enableDashboards: false
 };


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Dashboards allow rendering of user-provided content.  They should be an opt-in feature.  @bitwarrior