### PR TITLE
Fix a small bug in codegen for StackCmd

### DIFF
--- a/src/fprime_gds/common/fpy/test_helpers.py
+++ b/src/fprime_gds/common/fpy/test_helpers.py
@@ -76,11 +76,15 @@ def run_seq(
 
     deserialized_dirs = deserialize_directives(Path(file.name).read_bytes())
 
-    model = FpySequencerModel()
     ch_json_dict_loader = ChJsonLoader(dictionary)
     (ch_id_dict, ch_name_dict, versions) = ch_json_dict_loader.construct_dicts(
         dictionary
     )
+    cmd_json_dict_loader = CmdJsonLoader(dictionary)
+    (cmd_id_dict, cmd_name_dict, versions) = cmd_json_dict_loader.construct_dicts(
+        dictionary
+    )
+    model = FpySequencerModel(cmd_dict=cmd_id_dict)
     tlm_db = {}
     for chan_name, val in tlm.items():
         ch_template = ch_name_dict[chan_name]

--- a/test/fprime_gds/common/fpy/test_seqs.py
+++ b/test/fprime_gds/common/fpy/test_seqs.py
@@ -1319,3 +1319,13 @@ var: U32 = 1
 exit(-var == -1)
 """
     assert_run_success(fprime_test_api, seq)
+
+
+def test_multi_arg_vararg_cmd(fprime_test_api):
+    seq = """
+var1: I32 = 1
+var2: F32 = 1.0
+var3: U8 = 8
+CdhCore.cmdDisp.CMD_TEST_CMD_1(var1, var2, var3)
+"""
+    assert_run_success(fprime_test_api, seq)

--- a/test/fprime_gds/common/fpy/test_seqs.py
+++ b/test/fprime_gds/common/fpy/test_seqs.py
@@ -1321,7 +1321,7 @@ exit(-var == -1)
     assert_run_success(fprime_test_api, seq)
 
 
-def test_multi_arg_vararg_cmd(fprime_test_api):
+def test_multi_arg_variable_arg_cmd(fprime_test_api):
     seq = """
 var1: I32 = 1
 var2: F32 = 1.0


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4130 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description
This change fixes a bug in the codegen for the StackCmd directive. Previously, the wrong size for arguments was calculated when there was more than one arg, leading to a format error for such cmds when called with variable args. This is now fixed and a test was added to catch this and similar errors.