### PR TITLE
Add event args to the dictionary returned by `EventData.get_dict()`

### DIFF
--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -147,6 +147,7 @@ class EventData(sys_data.SysData):
             "name": self.template.get_full_name(),
             "id": self.id,
             "severity": str(self.template.get_severity()),
+            "args": self.args,
             "display_text": self.display_text,
         }
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| None |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| y |

---
## Add event args to the dictionary returned by `EventData.get_dict()`

Hey team,

This PR adds event args to the event data dictionary.

## Rationale

1. From the doc block on the `get_dict()` method, it looks like the original intent of #120 was to include `args` in the response but it was never implemented.
2. While writing an integration test for events I found that by retrieving the arg list I no longer needed to parse the `display_text`.

This may not have been included in the initial implementation because the `args` member can be accessed directly from the `EventData` object.

## Testing/Review Recommendations

I have retrieved the arg list in integration tests to verify this works. I'm happy to contribute automated tests if someone can point me in the right direction.
