### PR TITLE
Handling '\-' in docstring

### DIFF
--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -53,7 +53,7 @@ def preprocess_fpp_format_str(format_str: str) -> str:
 
 
 def preprocess_c_style_format_str(format_str: str) -> str:
-    """
+    r"""
     Function to convert C-string style to python format
     without using python interpolation
     Considered the following format for C-string:


### PR DESCRIPTION
Without this 'r', pytest will try and process the regex in the docstring. Since '\-' is invalid, Python generates a SyntaxError whenever running integration test scripts. Adding the 'r' tells Python to treat the string as a raw string so that '\-' is not interpreted literraly.

| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4205 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**|n  |

---
## Change Description

Added 'r' to the docstring in order to tell Python to interpret the docstring as a raw string.

## Rationale

Without this fix, pytest and our InT scripts will fail

## Testing/Review Recommendations

Run CI

