### PR TITLE
Add TM Fixed Frame Size CLI option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 docs/doxy/**
 *.log
 .vscode
+*.swp
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/test/fprime_gds/common/communication/ccsds/test_space_data_link.py
+++ b/test/fprime_gds/common/communication/ccsds/test_space_data_link.py
@@ -7,11 +7,11 @@ from fprime_gds.common.communication.ccsds.space_data_link import (
 
 SCID_TEST_VALUE = 0x77
 VCID_TEST_VALUE = 5
-
+FRAME_SIZE_TEST_VALUE = 2222
 
 @pytest.fixture
 def framer_deframer():
-    return SpaceDataLinkFramerDeframer(scid=SCID_TEST_VALUE, vcid=VCID_TEST_VALUE)
+    return SpaceDataLinkFramerDeframer(scid=SCID_TEST_VALUE, vcid=VCID_TEST_VALUE, frame_size=FRAME_SIZE_TEST_VALUE)
 
 
 def test_frame_valid_data(framer_deframer):
@@ -34,7 +34,7 @@ def test_frame_valid_data(framer_deframer):
 def test_deframe_valid_frame(framer_deframer):
     """Test deframing a valid TM frame."""
     FIXED_PAYLOAD_LENGTH = (
-        framer_deframer.TM_FIXED_FRAME_SIZE
+        framer_deframer.frame_size
         - SpaceDataLinkFramerDeframer.TM_HEADER_SIZE
         - SpaceDataLinkFramerDeframer.TM_TRAILER_SIZE
     )
@@ -63,7 +63,7 @@ def test_deframe_valid_frame(framer_deframer):
 def test_deframe_incorrect_crc(framer_deframer):
     """Test deframing a valid TM frame."""
     FIXED_PAYLOAD_LENGTH = (
-        framer_deframer.TM_FIXED_FRAME_SIZE
+        framer_deframer.frame_size
         - SpaceDataLinkFramerDeframer.TM_HEADER_SIZE
         - SpaceDataLinkFramerDeframer.TM_TRAILER_SIZE
     )


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

makes TM_FIXED_FRAME_SIZE a CLI argument so users can reconfigure GDS to match the value specified in ComCfg.fpp (and actually rx packets).

## Rationale

Fprime GDS does not work with TM Fixed Frame Values other than 1024 until this change is applied.

## Testing/Review Recommendations
Decide if random testing is needed on the frame size & if any more checks are needed to validate the argument.

## Future Work

N/A
