### PR TITLE
Fix chain framer to proces multiple packets

### DIFF
--- a/src/fprime_gds/common/communication/ccsds/chain.py
+++ b/src/fprime_gds/common/communication/ccsds/chain.py
@@ -69,18 +69,42 @@ class ChainedFramerDeframer(FramerDeframer, ABC):
             if hasattr(composite, "check_arguments"):
                 composite.check_arguments(**subset_arguments)
 
-    def deframe(self, data, no_copy=False):
-        """ Deframe via a chain of children deframers """
-        packet = data[:] if not no_copy else data
-        remaining = None
-        discarded = b""
+    def deframe_all(self, data, no_copy):
+        """ Deframe all available frames"
 
+        Since packets can be composites of multiple underlying packets, the chaining framer must override deframe_all
+        in order to allow for these composite packets
+        """
+        # Packet the incoming data as an array of 1 packet. This will set up the standard algorithm where each packet
+        # is processed in seeries
+        packets = [data if no_copy else data[:]]
+        # Remaining data (left over from first packet) is unset, but will be set after the processing of the first
+        # packet as the first represents the outer frame
+        remaining = None
+        # Aggregate discarded data across all packets
+        discarded_aggregate = b""
+        # Loop over ever deframer
         for deframer in self.deframers:
-            new_packet, new_remaining, new_discarded = deframer.deframe(packet, True)
-            discarded += new_discarded
-            remaining = new_remaining if remaining is None else remaining
-            packet = new_packet
-        return packet, remaining, discarded
+            deframer_packets = []
+            # Loop over the list of packets from the previous deframer
+            for packet_data in packets:
+                # Deframe all packets available in this current packet. The packet list is updated from the return
+                # value as we use the chanined deframers to continually break into it
+                new_packets, new_remaining, new_discarded = deframer.deframe_all(packet_data, True)
+                # If the first packet reamining hasn't be updated, then we set reamining. Otherwise we retain the old
+                # value because reamining is defined as the outer-most packet.
+                remaining =  new_remaining if remaining is None else remaining
+                # Discarded data is aggregated regardless of where it comes from
+                discarded_aggregate += new_discarded
+                # Append all packets from this layer into the list of processing for the next layer
+                deframer_packets.extend(new_packets)
+            # Update the list of packets for the next deframer as the concatenated output of each run of this layer.
+            packets = deframer_packets
+        # Return list of packets from the last layer, remaining from the outer layer, and discarded from all layers
+        return packets, remaining, discarded_aggregate
+    
+    def deframe(self, data, no_copy=False):
+        assert False, "Should never be called"
 
     def frame(self, data):
         """ Frame via a chain of children framers """

--- a/src/fprime_gds/common/communication/ccsds/chain.py
+++ b/src/fprime_gds/common/communication/ccsds/chain.py
@@ -108,7 +108,7 @@ class ChainedFramerDeframer(FramerDeframer, ABC):
 
     def frame(self, data):
         """ Frame via a chain of children framers """
-        return reduce(lambda framed_data, framer: framer.fragit push --set-upstream origin fix/aggregated-ccsdsme(framed_data), self.framers, data)
+        return reduce(lambda framed_data, framer: framer.frame(framed_data), self.framers, data)
 
 
 @gds_plugin(FramerDeframer)

--- a/src/fprime_gds/common/communication/ccsds/chain.py
+++ b/src/fprime_gds/common/communication/ccsds/chain.py
@@ -76,7 +76,7 @@ class ChainedFramerDeframer(FramerDeframer, ABC):
         in order to allow for these composite packets
         """
         # Packet the incoming data as an array of 1 packet. This will set up the standard algorithm where each packet
-        # is processed in seeries
+        # is processed in series
         packets = [data if no_copy else data[:]]
         # Remaining data (left over from first packet) is unset, but will be set after the processing of the first
         # packet as the first represents the outer frame
@@ -89,10 +89,10 @@ class ChainedFramerDeframer(FramerDeframer, ABC):
             # Loop over the list of packets from the previous deframer
             for packet_data in packets:
                 # Deframe all packets available in this current packet. The packet list is updated from the return
-                # value as we use the chanined deframers to continually break into it
+                # value as we use the chained deframers to continually break into it
                 new_packets, new_remaining, new_discarded = deframer.deframe_all(packet_data, True)
-                # If the first packet reamining hasn't be updated, then we set reamining. Otherwise we retain the old
-                # value because reamining is defined as the outer-most packet.
+                # If the first packet remaining hasn't be updated, then we set remaining. Otherwise we retain the old
+                # value because remaining is defined as the outer-most packet.
                 remaining =  new_remaining if remaining is None else remaining
                 # Discarded data is aggregated regardless of where it comes from
                 discarded_aggregate += new_discarded
@@ -108,7 +108,7 @@ class ChainedFramerDeframer(FramerDeframer, ABC):
 
     def frame(self, data):
         """ Frame via a chain of children framers """
-        return reduce(lambda framed_data, framer: framer.frame(framed_data), self.framers, data)
+        return reduce(lambda framed_data, framer: framer.fragit push --set-upstream origin fix/aggregated-ccsdsme(framed_data), self.framers, data)
 
 
 @gds_plugin(FramerDeframer)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The chain Framer in the F Prime GDS, does not properly support possible aggregated packets.  It overrides `deframe` and not `deframe_all` thus not allowing for multiple internal packets.  We fix that in this PR.