### PR TITLE
Fix colorization for channel limits

### DIFF
--- a/src/fprime_gds/common/loaders/ch_json_loader.py
+++ b/src/fprime_gds/common/loaders/ch_json_loader.py
@@ -21,7 +21,7 @@ class ChJsonLoader(JsonLoader):
     DESC = "annotation"
     TYPE = "type"
     FMT_STR = "format"
-    LIMIT_FIELD = "limit"
+    LIMIT_FIELD = "limits"
     LIMIT_LOW = "low"
     LIMIT_HIGH = "high"
     LIMIT_RED = "red"

--- a/src/fprime_gds/flask/static/index.html
+++ b/src/fprime_gds/flask/static/index.html
@@ -139,11 +139,11 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                 </div>
             </template>
 
-            <!-- Charts: 
+            <!-- Charts:
             Display telemetry time series charts. User has option to select which telemetry channels should be plotted.
             -->
             <chart-wrapper></chart-wrapper>
-            
+
             <!--
             Dashboard:
 
@@ -154,9 +154,9 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                     <div class="fp-flex-header">
                         <div class="col-md-5 mt-2">
                             <div class="form-group">
-                                <input type="file" name="config-file" 
-                                    id="config-file" 
-                                    accept="application/xml" 
+                                <input type="file" name="config-file"
+                                    id="config-file"
+                                    accept="application/xml"
                                     v-on:change="configureDashboardFromFile($event.target.files[0])"
                                     style="display: none;"/>
                                 <label for="config-file" class="btn btn-secondary mr-1 mb-1 col-md-5">
@@ -221,6 +221,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                          :filter-text="filterText"
                          :initial-views="itemsShown"
                          :compact="compact"
+                         :row-style="calculateRowStyle"
                     ></fp-table>
                 </div>
             </template>
@@ -245,7 +246,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                             <div class="form-row">
                                 <div class="col-md-5">
                                     <button type="button" class="btn btn-primary btn-block" v-on:click="uplinkFiles">
-                                        <i class="fas fa-satellite-dish"></i> 
+                                        <i class="fas fa-satellite-dish"></i>
                                         <span class="d-md-none d-lg-inline">Uplink</span>
                                     </button>
                                 </div>
@@ -259,7 +260,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                                     <input type="file" id="chooseUplinkFile" v-bind:files="selected" multiple
                                         v-on:change="handleFiles" style="display: none;">
                                     <label for="chooseUplinkFile" class="btn btn-secondary btn-block">
-                                        <i class="fas fa-upload"></i> 
+                                        <i class="fas fa-upload"></i>
                                         <span class="d-md-none d-lg-inline">Upload</span>
                                     </label>
                                 </div>

--- a/src/fprime_gds/flask/static/js/vue-support/channel.js
+++ b/src/fprime_gds/flask/static/js/vue-support/channel.js
@@ -92,7 +92,7 @@ Vue.component("channel-table", {
             let template = _dictionaries.channels[item.id];
             // Check if any bounds are actually set
             if ((template.low_red == null) && (template.low_orange == null) && (template.low_yellow == null) &&
-                (template.high_red == null) && (template.high_orange == null) && (template.high_red == null)) {
+                (template.high_red == null) && (template.high_orange == null) && (template.high_yellow == null)) {
                 return "";
             }
             let bounds = [

--- a/src/fprime_gds/flask/static/js/vue-support/channel.js
+++ b/src/fprime_gds/flask/static/js/vue-support/channel.js
@@ -81,29 +81,43 @@ Vue.component("channel-table", {
         /**
          * Use the row's values and bounds to colorize the row. This function will color red and yellow items using
          * the boot-strap "warning" and "danger" calls.
+         * @param item: channel item
          * @return {string}: style-class to use
          */
-        calculateRowStyle() {
+        calculateRowStyle(item) {
+            if (item.val == null) {
+                // No channel value yet
+                return "";
+            }
             let template = _dictionaries.channels[item.id];
-            let value = this.channel.value;
+            // Check if any bounds are actually set
+            if ((template.low_red == null) && (template.low_orange == null) && (template.low_yellow == null) &&
+                (template.high_red == null) && (template.high_orange == null) && (template.high_red == null)) {
+                return "";
+            }
             let bounds = [
-                {"class": "fp-color-fatal", "bounds": [template.low_red, value <= template.high_red]},
+                {
+                    "class": "fp-color-fatal",
+                    "bounds": [template.low_red, template.high_red]
+                },
                 {
                     "class": "fp-color-warn-hi",
-                    "bounds": [template.low_yellow, value <= template.high_yellow]
+                    "bounds": [template.low_orange, template.high_orange]
+                },
+                {
+                    "class": "fp-color-warn-lo",
+                    "bounds": [template.low_yellow, template.high_yellow]
                 }
             ];
             // Check bounds.
             for (let i = 0; i < bounds.length; i++) {
                 let bound = bounds[i];
-                if ((bound.bounds[0] != null && value < bound.bounds[0]) ||
-                    (bound.bounds[1] != null && value < bound.bounds[1])) {
+                if ((bound.bounds[0] != null && item.val < bound.bounds[0]) ||
+                    (bound.bounds[1] != null && item.val > bound.bounds[1])) {
                     return bound.class;
-                } else if (bound.bounds[0] != null || bound.bounds[1] != null) {
-                    return "table-success";
                 }
             }
-            return "";
+            return "table-success";
         },
         /**
          * Converts an item to a name for use with the views functionality.


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/2754 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This contains the following fixes:
- channel limits were not being correctly parsed from the dictionary (11eaf6661380ea95d864a55e81b16aabec5a53e6)
- the `calculateRowStyle` colorization function was not properly hooked up to the frontend (a3ff93c4b8a1c932932db76cda18af18dc046098)
- the implementation of the colorization function itself was incorrect (a3ff93c4b8a1c932932db76cda18af18dc046098)

## Rationale

The colorization feature for channel limits did not work.

## Testing/Review Recommendations

Specify a channel limit i.e. 
```
telemetry ChannelA: U32 high { red 3, orange 2, yellow 1 }
```

## Future Work

N/A
