### PR TITLE
Fixed AttributeError when using dat subparser

### DIFF
--- a/src/fprime_gds/common/tools/params.py
+++ b/src/fprime_gds/common/tools/params.py
@@ -211,6 +211,10 @@ def main():
         output_path = args.json_file.with_suffix("." + output_format)
     else:
         output_path = args.output
+
+    # when using dat need a save attribute
+    if not hasattr(args, "save"):
+        args.save = False
     
     convert_json(args.json_file, args.dictionary, output_path, output_format, args.defaults, args.save)
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| n |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Added a check for the attribute `save` when using the dat subparser.

## Rationale

The current state of the `fprime-prm-write dat` command breaks because there is no args.save. The way the source code is written this is a requirement. This change fixes this issue without changing the fundamental functionality. 

## Testing/Review Recommendations

Attempt to run `fprime-prm-write dat` with the intended arguments described in --help.
