### PR TITLE
Fix Fw.Time constructor bug

### DIFF
--- a/src/fprime_gds/common/fpy/README.md
+++ b/src/fprime_gds/common/fpy/README.md
@@ -184,7 +184,8 @@ CdhCore.cmdDisp.CMD_NO_OP_STRING("second 1")
 
 CdhCore.cmdDisp.CMD_NO_OP_STRING("today")
 # sleep until 12345678900 seconds and 0 microseconds after the epoch
-sleep_until(0, 0, 12345678900, 0)
+# time base of 0, time context of 1
+sleep_until(Fw.Time(0, 1, 12345678900, 0))
 CdhCore.cmdDisp.CMD_NO_OP_STRING("much later")
 ```
 

--- a/src/fprime_gds/common/fpy/SPEC.md
+++ b/src/fprime_gds/common/fpy/SPEC.md
@@ -1,6 +1,4 @@
-Nothing type is a type whose set of values is an empty set
-Unit type is a type whose set of values is a set with one element
-BIG question: what if we made an arbitrary precision int type? and float type?
+# The SPEC is currently work-in-progress
 
 # Types
 

--- a/src/fprime_gds/common/fpy/codegen.py
+++ b/src/fprime_gds/common/fpy/codegen.py
@@ -754,7 +754,7 @@ class CalculateConstExprValues(Visitor):
                 expr_value = instance
 
             elif func.type == TimeType:
-                expr_value = TimeType(*arg_values)
+                expr_value = TimeType(*[v._val for v in arg_values])
 
             else:
                 # no other FppTypeClasses have ctors

--- a/test/fprime_gds/common/fpy/test_seqs.py
+++ b/test/fprime_gds/common/fpy/test_seqs.py
@@ -369,6 +369,13 @@ sleep(1, 1000)
     assert_run_success(fprime_test_api, seq)
 
 
+def test_wait_abs(fprime_test_api):
+    seq = """
+sleep_until(Fw.Time(0, 0, 123, 123))
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
 def test_f32_f64_cmp(fprime_test_api):
     seq = """
 val: F32 = 0.0

--- a/test/fprime_gds/common/fpy/test_seqs.py
+++ b/test/fprime_gds/common/fpy/test_seqs.py
@@ -375,6 +375,21 @@ sleep_until(Fw.Time(0, 0, 123, 123))
 """
     assert_run_success(fprime_test_api, seq)
 
+def test_wait_abs_bad_arg(fprime_test_api):
+    seq = """
+sleep_until(0, 1, 2, 3)
+"""
+    assert_compile_failure(fprime_test_api, seq)
+
+def test_time_type_ctor(fprime_test_api):
+    seq = """
+var: Fw.Time = Fw.Time(0, 1, 2, 3)
+if var.time_base == 0 and var.time_context == 1 and var.seconds == 2 and var.useconds == 3:
+    exit(True)
+exit(False)
+"""
+    assert_run_success(fprime_test_api, seq)
+
 
 def test_f32_f64_cmp(fprime_test_api):
     seq = """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4308 |
|**_Has Unit Tests (y/n)_**|  y|
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Fix a bug in the way TimeType is constructed that prevented users from creating it. Also add some tests and update docs related to this.
