### PR TITLE
Get type constructors with variable arguments working

### DIFF
--- a/src/fprime_gds/common/fpy/README.md
+++ b/src/fprime_gds/common/fpy/README.md
@@ -75,7 +75,7 @@ Fpy supports the following math operations:
 
 The behavior of these operators is designed to mimic Python. Note that **division always returns a float**. This means that `5 / 2 == 2.5`, not `2`. This may be confusing coming from C++, but it is consistent with Python.
 
-## 5. Variable Arguments to Commands
+## 5. Variable Arguments to Commands, Macros and Constructors
 
 Where this really gets interesting is when you pass variables or expressions into commands:
 ```py
@@ -86,7 +86,7 @@ param4: F32 = 15.0
 Ref.recvBuffComp.PARAMETER4_PRM_SET(param4)
 ```
 
-The same syntax works with the [`sleep`](#11-relative-and-absolute-sleep), [`exit`](#12-exit-macro), and `log` macros.
+You can also pass variable arguments to the [`sleep`](#11-relative-and-absolute-sleep), [`exit`](#12-exit-macro), and `log` macros, as well as to constructors.
 
 There are some restrictions on passing string values, or complex types containing string values, to commands. See [Strings](#13-strings).
 

--- a/src/fprime_gds/common/fpy/README.md
+++ b/src/fprime_gds/common/fpy/README.md
@@ -42,7 +42,7 @@ For types, Fpy has most of the same basic ones that FPP does:
 
 Float literals are denoted with a decimal point (`5.0`, `0.123`) and Boolean literals have a capitalized first letter: `True`, `False`. There is no way to differentiate between signed and unsigned integer literals, so the compiler looks at where the literal is used to determine the signedness.
 
-Note there is currently no built-in `string` type. See [Strings](#13-strings).
+Note there is currently no built-in `string` type. See [Strings](#12-strings).
 
 ## 3. Dictionary Types
 
@@ -86,11 +86,11 @@ param4: F32 = 15.0
 Ref.recvBuffComp.PARAMETER4_PRM_SET(param4)
 ```
 
-You can also pass variable arguments to the [`sleep`](#11-relative-and-absolute-sleep), [`exit`](#12-exit-macro), and `log` macros, as well as to constructors.
+You can also pass variable arguments to the [`sleep`](#10-relative-and-absolute-sleep), [`exit`](#11-exit-macro), and `log` macros, as well as to constructors.
 
-There are some restrictions on passing string values, or complex types containing string values, to commands. See [Strings](#13-strings).
+There are some restrictions on passing string values, or complex types containing string values, to commands. See [Strings](#12-strings).
 
-## 6. Getting Telemetry Channels
+## 6. Getting Telemetry Channels and Parameters
 
 Fpy supports getting the value of telemetry channels:
 ```py
@@ -101,8 +101,6 @@ signal_pair: Ref.SignalPair = Ref.SG1.PairOutput
 
 It's important to note that if your component hasn't written telemetry to the telemetry database (`TlmPacketizer` or `TlmChan`) in a while, the value the sequence sees may be old. Make sure to regularly write your telemetry!
 
-## 7. Getting Parameters
-
 Fpy supports getting the value of parameters:
 ```py
 prm_3: U8 = Ref.sendBuffComp.parameter3
@@ -110,7 +108,8 @@ prm_3: U8 = Ref.sendBuffComp.parameter3
 
 A significant limitation of this is that it will only return the value most recently saved to the parameter database. This means you must command `_PRM_SAVE` before the sequence will see the new value.
 
-## 8. Conditionals
+#### Note:  If a telemetry channel and parameter have the same fully-qualified name, the fully-qualified name will get the value of the telemetry channel
+## 7. Conditionals
 Fpy supports comparison operators:
 ```py
 value: bool = 1 > 2 and (3 + 4) != 5
@@ -126,7 +125,7 @@ record1: Svc.DpRecord = Svc.DpRecord(0, 1, 2, 3, 4, 5, Fw.DpState.UNTRANSMITTED)
 record2: Svc.DpRecord = Svc.DpRecord(0, 1, 2, 3, 4, 5, Fw.DpState.UNTRANSMITTED)
 records_equal: bool = record1 == record2 # == True
 ```
-## 9. If/elif/else
+## 8. If/elif/else
 
 You can branch off of conditionals with `if`, `elif` and `else`:
 ```py
@@ -149,7 +148,7 @@ if CdhCore.cmdDisp.CommandsDispatched >= 1:
     CdhCore.cmdDisp.CMD_NO_OP_STRING("should happen")
 ```
 
-## 10. Getting Struct Members and Array Items
+## 9. Getting Struct Members and Array Items
 
 You can access members of structs by name, or array elements by index:
 ```py
@@ -173,7 +172,7 @@ com_queue_depth: Svc.ComQueueDepth = ComCcsds.comQueue.comQueueDepth
 com_queue_depth[0] = 1
 ```
 
-## 11. Relative and Absolute Sleep
+## 10. Relative and Absolute Sleep
 You can pause the execution of a sequence for a relative duration, or until an absolute time:
 ```py
 CdhCore.cmdDisp.CMD_NO_OP_STRING("second 0")
@@ -191,7 +190,7 @@ CdhCore.cmdDisp.CMD_NO_OP_STRING("much later")
 
 Make sure that the `Svc.FpySequencer.checkTimers` port is connected to a rate group. The sequencer only checks if a sleep is done when the port is called, so the more frequently you call it, the more accurate the wakeup time.
 
-## 12. Exit Macro
+## 11. Exit Macro
 You can end the execution of the sequence early by calling the `exit` macro:
 ```py
 # exit takes a boolean argument
@@ -201,5 +200,5 @@ exit(True)
 exit(False)
 ```
 
-## 13. Strings
+## 12. Strings
 Fpy does not support a fully-fledged `string` type yet. You can pass a string literal as an argument to a command, but you cannot pass a string from a telemetry channel. You also cannot store a string in a variable, or perform any string manipulation. These features will be added in a later Fpy update.

--- a/src/fprime_gds/common/fpy/codegen.py
+++ b/src/fprime_gds/common/fpy/codegen.py
@@ -730,7 +730,7 @@ class CalculateConstExprValues(Visitor):
         arg_values = [
             state.expr_values[e] for e in (node.args if node.args is not None else [])
         ]
-        unknown_value = any(v for v in arg_values if v is None)
+        unknown_value = any(v is None for v in arg_values)
         if unknown_value:
             # we will have to calculate this at runtime
             state.expr_values[node] = None
@@ -739,6 +739,7 @@ class CalculateConstExprValues(Visitor):
         expr_value = None
 
         if isinstance(func, FpyTypeCtor):
+            print(func.return_type, arg_values)
             # actually construct the type
             if issubclass(func.type, SerializableType):
                 instance = func.type()
@@ -1101,8 +1102,14 @@ class GenerateExprMacrosAndCmds(Visitor):
                 dirs.extend(node_dirs)
 
             dirs.append(func.dir())
+        elif isinstance(func, FpyTypeCtor):
+            # put arg values onto stack in correct order for serialization
+            for arg_node in node_args:
+                node_dirs = state.directives[arg_node]
+                assert len(node_dirs) >= 1
+                dirs.extend(node_dirs)
         else:
-            dirs = None
+            assert False, func
 
         # perform type conversion if called for
         coerced_type = state.type_coercions.get(node, None)

--- a/src/fprime_gds/common/fpy/codegen.py
+++ b/src/fprime_gds/common/fpy/codegen.py
@@ -739,7 +739,6 @@ class CalculateConstExprValues(Visitor):
         expr_value = None
 
         if isinstance(func, FpyTypeCtor):
-            print(func.return_type, arg_values)
             # actually construct the type
             if issubclass(func.type, SerializableType):
                 instance = func.type()

--- a/test/fprime_gds/common/fpy/test_seqs.py
+++ b/test/fprime_gds/common/fpy/test_seqs.py
@@ -43,6 +43,7 @@ var: I64 = 0123_456
 
     assert_compile_failure(fprime_test_api, seq)
 
+
 def test_float_literal(fprime_test_api):
     seq = """
 var: F32 = 1.000e-5
@@ -375,11 +376,29 @@ sleep_until(Fw.Time(0, 0, 123, 123))
 """
     assert_run_success(fprime_test_api, seq)
 
+
+def test_wait_abs_var_arg(fprime_test_api):
+    seq = """
+x: U32 = 123
+sleep_until(Fw.Time(0, 0, x, 123))
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_wait_abs_var_arg_2(fprime_test_api):
+    seq = """
+x: Fw.Time = Fw.Time(0, 1, 2, 3)
+sleep_until(x)
+"""
+    assert_run_success(fprime_test_api, seq)
+
+
 def test_wait_abs_bad_arg(fprime_test_api):
     seq = """
 sleep_until(0, 1, 2, 3)
 """
     assert_compile_failure(fprime_test_api, seq)
+
 
 def test_time_type_ctor(fprime_test_api):
     seq = """
@@ -390,6 +409,31 @@ exit(False)
 """
     assert_run_success(fprime_test_api, seq)
 
+def test_struct_ctor_var_arg(fprime_test_api):
+    seq = """
+id: U32 = 111
+priority: U32 = 3
+state: Fw.DpState = Fw.DpState.UNTRANSMITTED
+var: Svc.DpRecord = Svc.DpRecord(id, 1, 2, priority, 4, 5, state)
+if var.priority == priority and var.id == id and state == var.state:
+    exit(True)
+exit(False)
+"""
+
+    assert_run_success(fprime_test_api, seq)
+
+
+def test_array_ctor_var_arg(fprime_test_api):
+    seq = """
+arr_0: U32 = 123
+arr_1: U32 = 456
+val: Svc.ComQueueDepth = Svc.ComQueueDepth(arr_0, arr_1)
+if val[0] == arr_0 and val[1] == arr_1:
+    exit(True)
+exit(False)
+"""
+
+    assert_run_success(fprime_test_api, seq)
 
 def test_f32_f64_cmp(fprime_test_api):
     seq = """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  nasa/fprime#4310 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description
This PR adds the ability to call constructors with variable values for their arguments. For instance, now you can do:
```
seconds: U32 = 123
time: Fw.Time = Fw.Time(0, 1, seconds, 0)
```

Some test cases have been added to make sure this doesn't regress.