### PR TITLE
Set the default configuration file path to $FPRIME_GDS_CONFIG_PATH when set

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -390,7 +390,7 @@ class ConfigDrivenParser(ParserBase):
                 "required": False,
                 "default": self.DEFAULT_CONFIGURATION_PATH,
                 "type": Path,
-                "help": f"Argument configuration file path.",
+                "help": "Argument configuration file path. [default: %(default)s]",
             }
         }
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -6,6 +6,7 @@
 import os
 import sys
 import copy
+import pathlib
 import webbrowser
 
 from fprime_gds.executables.cli import (
@@ -39,6 +40,12 @@ def parse_args():
         CommParser,
         PluginArgumentParser,
     ]
+    # If the FPRIME_GDS_CONFIG_PATH environment variable is set, set its value to be the default
+    # config path
+    if "FPRIME_GDS_CONFIG_PATH" in os.environ:
+        ConfigDrivenParser.set_default_configuration(
+            pathlib.Path(os.environ["FPRIME_GDS_CONFIG_PATH"])
+        )
     # Parse the arguments, and refine through all handlers
     args, parser = ConfigDrivenParser.parse_args(
         arg_handlers, "Run F prime deployment and GDS"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4204 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This modifies the `run_deployment` executable to check if the FPRIME_GDS_CONFIG_PATH environment variable is set and, if so, sets the `ConfigDrivenParser` default path to be this value so it becomes the default value for the `-c`/`--config` command-line argument.

## Rationale

We deliver our project in a containerized environment where the `fprime-gds.yml` file cannot always be installed in the end user's current directory. It is more convenient to have an environment variable configured to point to the configuration file instead of requiring the end user to pass `-c <long/path>` every time they launch the GDS.

## Testing/Review Recommendations

Set the `FPRIME_GDS_CONFIG_PATH` environment variable and verify that the config file from that path is loaded successfully.

## Future Work

N/A
