### PR TITLE
Fix empty fprime-gds.yml options error

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -374,7 +374,7 @@ class ConfigDrivenParser(ParserBase):
     def flatten_options(configured_options):
         """Flatten options down to arguments"""
         flattened = []
-        if not configured_options:
+        if configured_options is None:
             return flattened
         for option, value in configured_options.items():
             flattened.append(f"--{option}")

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -374,6 +374,8 @@ class ConfigDrivenParser(ParserBase):
     def flatten_options(configured_options):
         """Flatten options down to arguments"""
         flattened = []
+        if not configured_options:
+            return flattened
         for option, value in configured_options.items():
             flattened.append(f"--{option}")
             if value is not None:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

When using the following fprime-gds.yml file:
```
command-line-options:
# Nothing specified
```

Get the following error:
```
fprime-gds
[INFO] Reading command-line configuration from: fprime-gds.yml
Traceback (most recent call last):
  File "<>/venv/live/bin/fprime-gds", line 7, in <module>
    sys.exit(main())
             ^^^^^^
  File "<>/fprime-gds/src/fprime_gds/executables/run_deployment.py", line 214, in main
    parsed_args = parse_args()
                  ^^^^^^^^^^^^
  File "<>/fprime-gds/src/fprime_gds/executables/run_deployment.py", line 50, in parse_args
    args, parser = ConfigDrivenParser.parse_args(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/fprime-gds/src/fprime_gds/executables/cli.py", line 364, in parse_args
    config_args = cls.flatten_options(config_options)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<>/fprime-gds/src/fprime_gds/executables/cli.py", line 377, in flatten_options
    for option, value in configured_options.items():
                         ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'items'
```

This PR fixes the above.