### PR TITLE
Fix property name for time base in timeToString()

### DIFF
--- a/src/fprime_gds/flask/static/js/vue-support/utils.js
+++ b/src/fprime_gds/flask/static/js/vue-support/utils.js
@@ -113,7 +113,7 @@ export function timeToString(time) {
     if (time instanceof Date) {
         date = time;
     }
-    else if (time.base.value === 2) {
+    else if (time.base === 2) {
         date = timeToDate(time);
     }
     // Convert date


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [fprime #4344](https://github.com/nasa/fprime/issues/4344) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This change fixes the timeToString() function in the front-end JavaScript so that the function accesses the time base property as it is named and passed-through from the back-end.

## Rationale

Fixes the front-end's incorrect time base detection, which was exposed after PR #206 caused the code to stop relying on `time.datetime` (in the context of `#event-list-template` and `#channel-table-template`) and exposed that `timeToString()` was not properly retrieving the time base property.

This resolves the immediate issue of https://github.com/nasa/fprime/issues/4344.

## Testing/Review Recommendations

Fix was tested using a blank project with only a cookie-cutter deployment (`fprime-util new --deployment` with no additional changes), then running fprime-gds and observing the displayed time format of the Channel and Event tables. I added temporary logging to observe the numeric value of the `time.base` at the `#event-list-template`.

When using fprime and the cookie-cutters in latest devel, the time base received at the `#event-list-template` was 2 (i.e. WORKSTATION). Without the change in this PR, the time displayed in the tables was in "seconds.microseconds" format. With the change, the time was displayed in calendar date and time format.

Additionally, I temporarily modified fprime/Svc/ChronoTime/ChronoTime.cpp to produce times in `TB_PROC_TIME` instead of `TB_WORKSTATION_TIME`, and observed that the time base received at `#event-list-template` changed to 1. With the change in this PR, the tables still displayed the time in "seconds.microseconds" format, showing no regression on the previous PR #206.

## Future Work

I recommend further analysis on the root process-based cause of #4344. I suspect that changes in the Python classes in the fprime-gds back-end directly cause changes to the JS objects in the front-end with no validation of the data structure passed via the JSON-formatted HTTP response from back-end to front-end. Some controls like a JSON Schema on the expected data structure could produce errors or warnings before releases to prevent mishaps like this.