### PR TITLE
Warn if file downlink encounters a packet at an unexpected offset

### DIFF
--- a/src/fprime_gds/common/files/downlinker.py
+++ b/src/fprime_gds/common/files/downlinker.py
@@ -134,6 +134,14 @@ class FileDownlinker(fprime_gds.common.handlers.DataHandler):
                     self.sequence,
                     data.seqID,
                 )
+            # Log if there is likely a hole in the file
+            if offset != self.active.seek:
+                if offset > self.active.seek:
+                    LOGGER.warning("Missing data packet at offset: %d. Gap of %d bytes", self.active.seek, offset - self.active.seek)
+                else:
+                    LOGGER.warning("Received data packet at offset: %d. Expecting packet at offset: %d", offset, self.active.seek)
+
+
             data_bytes = data.dataVar
             # Write the data information to the file
             self.active.write(data_bytes, offset)


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Add 2 new warnings if the downlinker sees a packet come in at an offset different from the expected (previous + length of last packet)

## Rationale

Helpful in debugging file downlink corruption & easily enables users to generate appropriate send partial commands.

## Testing/Review Recommendations

Ensure the warning messages are clear & provide the appropriate context to the user in each case.

## Future Work

Not currently planned, but if desired, a very rudimentary form of guaranteed delivery could be created by automatically calling send partial upon finding a packet gap.
