### PR TITLE
DP Write Fix & Refactor for Easier Usage as a Library

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -140,6 +140,7 @@ exts
 fastentrypoints
 fbuild
 fd
+fdp
 FEEDNAME
 feq
 FFCC

--- a/src/fprime_gds/executables/data_product_writer.py
+++ b/src/fprime_gds/executables/data_product_writer.py
@@ -769,7 +769,6 @@ class DataProductWriter:
         rootDict['dataId'] = self.read_field(headerJSON.dataId.underlyingType)
         for record in dictJSON.records:
             if record.id == rootDict['dataId']:    
-                print(f'Processing Record ID {record.id}')
                 if record.array:
                     dataSize = self.read_field(headerJSON.dataSize.type)
                     rootDict['size'] = dataSize

--- a/src/fprime_gds/executables/data_product_writer.py
+++ b/src/fprime_gds/executables/data_product_writer.py
@@ -264,13 +264,11 @@ class RecordStruct(BaseModel):
     type: Union[AliasType, StructType, ArrayType, IntegerType, FloatType, BoolType, QualifiedType, StringType]
     array: bool
     id: int
-    annotation: str
 
 class ContainerStruct(BaseModel):
     name: str
     id: int
     defaultPriority: int
-    annotation: str
 
 # -------------------------------------------------------------------------------------
 # These Pydantic classes define the FPRIME_DICTIONARY_FILE

--- a/src/fprime_gds/executables/data_product_writer.py
+++ b/src/fprime_gds/executables/data_product_writer.py
@@ -842,17 +842,17 @@ class DataProductWriter:
                 idSet.add(record.id)
 
 
-
-    # -------------------------------------------------------------------------------------------------------------------------
-    # Function process
+    # ----------------------------------------------------------------------------------------------
+    # Function: get_records
     #
-    # Description: 
-    #   Main processing
-    # -------------------------------------------------------------------------------------------------------------------------
-    def process(self):
-
+    # Description:
+    #   Reads all the records from the fdp file
+    #
+    # Returns:
+    #   List[Dict[str, obj]]: A list of dictionaries populated with the header followed by all records.
+    # ----------------------------------------------------------------------------------------------
+    def get_records(self):
         try:
-
             # Read the F prime JSON dictionary
             print(f"Parsing {self.jsonDict}...")
             try:
@@ -906,7 +906,20 @@ class DataProductWriter:
             msg = f'ValueError in JSON file {error["loc"]}: {error["msg"]}'
             self.handleException(msg)
 
+        return recordList
 
+    # ----------------------------------------------------------------------------------------------
+    # Function: write_records
+    #
+    # Description:
+    #   Writes all records to a json file
+    #
+    # Parameters:
+    #   recordList (List[Dict[str, obj]]): A list of dictionaries populated with the header followed by all records.
+    #
+    # Returns:
+    # ----------------------------------------------------------------------------------------------
+    def write_records(self, recordList):
         # Output the generated json to a file
         baseName = os.path.basename(self.binaryFileName)
         outputJsonFile = os.path.splitext(baseName)[0] + '.json'
@@ -916,6 +929,17 @@ class DataProductWriter:
             json.dump(recordList, file, indent=2)
 
         print(f'Output data generated in {outputJsonFile}')
+
+    # -------------------------------------------------------------------------------------------------------------------------
+    # Function process
+    #
+    # Description:
+    #   Main processing: parses records from the fdp file, then writes all records to a json file
+    # -------------------------------------------------------------------------------------------------------------------------
+    def process(self):
+        recordList = self.get_records()
+
+        self.write_records(recordList)
 
 
 # ------------------------------------------------------------------------------------------


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n  |

---
## Change Description

* Remove the annotation field from RecordStruct and ContainerStruct to fix crashes when run against a dictionary generated by devel
* Break the process function into two parts to enable using this script as the frontend of a python script that wants to ingest data product records

## Rationale

Scripts will need to be written to ingest data products & they will need to work regardless of if dp records and containers are annotated or not.

## Testing/Review Recommendations

Ensure the annotation member isn't needed for parsing certain dictionaries/the value would not be used.

## Future Work

N/A
