### PR TITLE
Make timeToString configurable in fprime-gds front-end

### DIFF
--- a/src/fprime_gds/flask/static/addons/commanding/command-history.js
+++ b/src/fprime_gds/flask/static/addons/commanding/command-history.js
@@ -71,7 +71,7 @@ Vue.component("command-history", {
             for (let i = 0; i < command_copy.args.length; i++) {
                 command_argument_assignment_helper(command_copy.args[i], item.args[i]);
             }
-            return [timeToString(item.datetime || item.time), command_display_string(command_copy)];
+            return [timeToString(item.time), command_display_string(command_copy)];
         },
         /**
          * Take the given item and converting it to a unique key by merging the id and time together with a prefix

--- a/src/fprime_gds/flask/static/js/config.js
+++ b/src/fprime_gds/flask/static/js/config.js
@@ -23,6 +23,8 @@ export let config = {
     },
     // Summary counter fields containing object of field: bootstrap class
     summaryFields: {"WARNING_HI": "warning", "FATAL": "danger", "GDS_Errors": "danger"},
+    // Function to use for formatting timestamps in the tables. null provides default formatting
+    timeToStringFn: null,
 
     // Dashboards are a security vulnerability in that users are uploading artifacts that trigger
     // arbitrary rendering and code execution. This is explained in more detail here:

--- a/src/fprime_gds/flask/static/js/vue-support/channel.js
+++ b/src/fprime_gds/flask/static/js/vue-support/channel.js
@@ -9,6 +9,7 @@
 import {listExistsAndItemNameNotInList, timeToString} from "./utils.js"
 import "./fptable.js";
 import {_datastore, _dictionaries} from "../datastore.js";
+
 /**
  * channel-table:
  *
@@ -67,7 +68,7 @@ Vue.component("channel-table", {
             if (item.time == null || item.val == null) {
                 return ["", "0x" + item.id.toString(16), template.full_name, ""];
             }
-            return [timeToString(item.time || item.datetime), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time), "0x" + item.id.toString(16), template.full_name,
                 (typeof(item.display_text) !== "undefined")? item.display_text : item.val]
         },
         /**

--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -80,7 +80,7 @@ Vue.component("event-list", {
                 const msg = '<span title="' + groups[0] + '">' + command_mnemonic + '</span>'
                 display_text = display_text.replace(OPREG, msg);
             }
-            return [timeToString(item.time || item.datetime), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time), "0x" + item.id.toString(16), template.full_name,
                 template.severity.value.replace("EventSeverity.", ""), display_text];
         },
         /**

--- a/src/fprime_gds/flask/static/js/vue-support/utils.js
+++ b/src/fprime_gds/flask/static/js/vue-support/utils.js
@@ -103,17 +103,14 @@ export function timeToDate(time) {
 }
 
 /**
- * Convert a given F´ time into a string for display purposes.
+ * Default implementation to convert a given F´ time into a string for display purposes.
  * @param time: f´ time to convert
  * @return {string} stringified time
  */
-export function timeToString(time) {
+function timeToStringDefault(time) {
     let date = null;
     // If we have a workstation time, convert it to calendar time
-    if (time instanceof Date) {
-        date = time;
-    }
-    else if (time.base === 2) {
+    if (time.base === 2) {
         date = timeToDate(time);
     }
     // Convert date
@@ -122,6 +119,18 @@ export function timeToString(time) {
         return dateFn(date);
     }
     return time.seconds + "." + time.microseconds;
+}
+
+/**
+ * Convert a given F´ time into a string for display purposes.
+ * @param time: f´ time to convert
+ * @return {string} stringified time
+ */
+export function timeToString(time) {
+    let timeFn = (config.timeToStringFn instanceof Function
+                    ? config.timeToStringFn
+                    : timeToStringDefault);
+    return timeFn(time);
 }
 
 /**


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [fprime #4468](https://github.com/nasa/fprime/issues/4468) |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This adds a `timeToStringFn` field to the front-end JavaScript configuration allowing projects to set a custom function to interpret and display timestamps for events, channels, and command history in the GUI.

## Rationale

This allows projects to choose how to interpret and format times in the GUI, adding support to handle time bases not provided by standard fprime.

## Testing/Review Recommendations

I manually tested supplying a project-level front-end configuration file that sets the new `timeToStringFn` field to a custom function:
1. Created a blank project and a deployment with `fprime-util new --deployment` using defaults.
2. Created a JavaScript file at the project root, copying ./fprime-gds/src/fprime_gds/flask/static/js/config.js
3. In the new project JavaScript file, changed the value for timeToStringFn to an arrow function returning a string using the time argument but obviously different than the default timestamp string.
4. Created a Python script at the project root that assigns to JS_CONFIGURATION_FILE a string pointing to the filename of the JavaScript file from step 2 (path based on the back-end host's filesystem root).
5. Set environment variable FP_FLASK_SETTINGS on the back-end host to the path to the Python script from step 4.
6. Run fprime-gds.
7. Observe the new time format in the Events and Channels tabs and in the Command History table after sending a NO_OP.

I also tested the same as the above, but with Step 3 assigning to timeToStringFn a function defined in the same file but outside the config object, and observed the same success.

I also tested running the GDS without pointing to a custom configuration, to verify that the defaults run as usual. This used the same setup Steps 1-4 but then unset the FP_FLASK_SETTINGS environment variable. Observed that the timestamps were then displayed in the default format.

No automated tests added.

## Future Work

After merging this PR, I recommend also merging follow-on PR #267, which allows the front-end config to fall back to defaults for any config field not set by the project. This should add robustness for projects in the face of new config fields added by fprime-gds updates. The PR #267 also adds documentation previously missing on how to establish project-specific front-end config values without forking fprime-gds. This PR does not include the documentation since the follow-on involved a change in the interface with project.

Continue analysis in [fprime #3605](https://github.com/nasa/fprime/issues/3605) to determine what other changes are necessary to support custom time bases.