### PR TITLE
Add GUI button in File Uplink to send a cancel packet

### DIFF
--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -89,13 +89,11 @@ class UplinkQueue:
         try:
             first = None
             found = self.queue.get_nowait()
-            # TODO: there is a bug here? remove() is never reached in Python through the GUI
-            # because Javascript handles the file form, but this loop seems off
             while found != first and found.source != source:
                 if first is None:
                     first = found
-            self.queue.put_nowait(found)
-            found = self.queue.get_nowait()
+                self.queue.put_nowait(found)
+                found = self.queue.get_nowait()
         except queue.Empty:
             return
         self.__file_store.remove(found)
@@ -215,7 +213,8 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
         """
         Sends a cancel packet regardless of state. This is to be manually used by the user.
         """
-        self.send(CancelPacketData(self.get_next_sequence()))
+        self.send(CancelPacketData(self.get_next_sequence()), handshake=False)
+        self.sequence = 0
 
     def current_files(self):
         """
@@ -251,14 +250,18 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
             )
         )
 
-    def send(self, packet_data):
+    def send(self, packet_data, handshake=True):
         """
         A function to send the packet out.  Starts timeout and then pushes the packet to the file encoder.
 
         :param packet_data: packet data to send that will be pushed to the encoder
+        :param handshake: (optional) if true, expect a handshake back. Default: True
         """
-        self.__timeout.restart()
-        self.__expected = self.file_encoder.data_callback(packet_data)[8:]
+        ret = self.file_encoder.data_callback(packet_data)[8:]
+        if handshake:
+            self.__timeout.restart()
+            # only expect it back if not no_timeout
+            self.__expected = ret
 
     def data_callback(self, data, sender=None):
         """

--- a/src/fprime_gds/common/files/uplinker.py
+++ b/src/fprime_gds/common/files/uplinker.py
@@ -89,6 +89,8 @@ class UplinkQueue:
         try:
             first = None
             found = self.queue.get_nowait()
+            # TODO: there is a bug here? remove() is never reached in Python through the GUI
+            # because Javascript handles the file form, but this loop seems off
             while found != first and found.source != source:
                 if first is None:
                     first = found
@@ -155,7 +157,7 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
         """
         self.state = FileStates.IDLE
         self.queue = UplinkQueue(self)
-        self.active = None
+        self.active: TransmitFile = None
         self.sequence = 0
         self.chunk = chunk
         self.file_encoder = file_encoder
@@ -208,6 +210,12 @@ class FileUplinker(fprime_gds.common.handlers.DataHandler):
             self.cancel()
         else:
             self.queue.remove(file)
+
+    def send_cancel_packet(self):
+        """
+        Sends a cancel packet regardless of state. This is to be manually used by the user.
+        """
+        self.send(CancelPacketData(self.get_next_sequence()))
 
     def current_files(self):
         """

--- a/src/fprime_gds/flask/static/index.html
+++ b/src/fprime_gds/flask/static/index.html
@@ -245,7 +245,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                         <div class="form-group col-md-4 mt-2">
                             <div class="form-row">
                                 <div class="col-md-5">
-                                    <button type="button" class="btn btn-primary btn-block" v-on:click="uplinkFiles">
+                                    <button type="button" class="btn btn-primary btn-block" v-on:click="uplinkFiles" title="Begin uplinking all uploaded files">
                                         <i class="fas fa-satellite-dish"></i>
                                         <span class="d-md-none d-lg-inline">Uplink</span>
                                     </button>
@@ -255,27 +255,31 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
 
                         <div class="form-group col-md-4 mt-2">
                             <div class="form-row">
-                                <div class="col-md-4 mb-1"></div>
                                 <div class="col-md-4 mb-1">
                                     <input type="file" id="chooseUplinkFile" v-bind:files="selected" multiple
                                         v-on:change="handleFiles" style="display: none;">
-                                    <label for="chooseUplinkFile" class="btn btn-secondary btn-block">
+                                    <label for="chooseUplinkFile" class="btn btn-secondary btn-block" title="Select files to upload">
                                         <i class="fas fa-upload"></i>
                                         <span class="d-md-none d-lg-inline">Upload</span>
                                     </label>
                                 </div>
-                                <div class="col-md-4 mb-1" v-if="flags.uploading">
-                                    <button type="button" class="btn btn-secondary btn-block"
-                                    v-on:click="pauseUplink">
+                                <div class="col-md-4 mb-1">
+                                    <button v-if="flags.uploading" type="button" class="btn btn-secondary btn-block"
+                                    v-on:click="pauseUplink" title="Pause file uplink">
                                         <i class="fas fa-pause"></i>
                                         <span class="d-md-none d-lg-inline">Pause</span>
                                     </button>
-                                </div>
-                                <div class="col-md-4 mb-1" v-if="!flags.uploading">
-                                    <button type="button" class="btn btn-secondary btn-block"
-                                    v-on:click="unpauseUplink">
+                                    <button v-if="!flags.uploading" type="button" class="btn btn-secondary btn-block"
+                                    v-on:click="unpauseUplink" title="Resume file uplink">
                                         <i class="fas fa-play"></i>
                                         <span class="d-md-none d-lg-inline">Unpause</span>
+                                    </button>
+                                </div>
+                                <div class="col-md-4 mb-1">
+                                    <button type="button" class="btn btn-secondary btn-block"
+                                    v-on:click="sendCancelPacket" title="Send a cancel packet to FSW">
+                                        <i class="fas fa-stop"></i>
+                                        <span class="d-md-none d-lg-inline">Send Cancel Packet</span>
                                     </button>
                                 </div>
                             </div>

--- a/src/fprime_gds/flask/static/index.html
+++ b/src/fprime_gds/flask/static/index.html
@@ -239,31 +239,33 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                     </div>
                     <div class="form-row">
                         <div class="form-group col-md-4 mt-2">
-                            <input class="form-control" type="text" v-model.trim="destination" pattern="/.*" />
-                            <label>Destination Folder</label>
+                            <input class="form-control" type="text" v-model.trim="destination" pattern="/.*" 
+                                   placeholder="/path/to/destination/folder"
+                                   title="Destination folder path on the spacecraft where files will be uploaded" id="file-uplink-destination"/>
+                            <label for="file-uplink-destination">Destination Folder</label>
                         </div>
                         <div class="form-group col-md-4 mt-2">
                             <div class="form-row">
-                                <div class="col-md-5">
-                                    <button type="button" class="btn btn-primary btn-block" v-on:click="uplinkFiles" title="Begin uplinking all uploaded files">
-                                        <i class="fas fa-satellite-dish"></i>
-                                        <span class="d-md-none d-lg-inline">Uplink</span>
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div class="form-group col-md-4 mt-2">
-                            <div class="form-row">
-                                <div class="col-md-4 mb-1">
+                                <div class="col-md-6 mb-1">
                                     <input type="file" id="chooseUplinkFile" v-bind:files="selected" multiple
                                         v-on:change="handleFiles" style="display: none;">
                                     <label for="chooseUplinkFile" class="btn btn-secondary btn-block" title="Select files to upload">
                                         <i class="fas fa-upload"></i>
-                                        <span class="d-md-none d-lg-inline">Upload</span>
+                                        <span class="d-md-none d-lg-inline">Add Files</span>
                                     </label>
                                 </div>
-                                <div class="col-md-4 mb-1">
+                                <div class="col-md-6">
+                                    <button type="button" class="btn btn-primary btn-block" v-on:click="uplinkFiles" title="Begin uplinking all uploaded files">
+                                        <i class="fas fa-satellite-dish"></i>
+                                        <span class="d-md-none d-lg-inline">Begin Uplink</span>
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group col-md-1 mt-2"></div>
+                        <div class="form-group col-md-3 mt-2">
+                            <div class="form-row">
+                                <div class="col-md-6 mb-1">
                                     <button v-if="flags.uploading" type="button" class="btn btn-secondary btn-block"
                                     v-on:click="pauseUplink" title="Pause file uplink">
                                         <i class="fas fa-pause"></i>
@@ -275,9 +277,10 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
                                         <span class="d-md-none d-lg-inline">Unpause</span>
                                     </button>
                                 </div>
-                                <div class="col-md-4 mb-1">
+                                <div class="col-md-6 mb-1">
                                     <button type="button" class="btn btn-secondary btn-block"
-                                    v-on:click="sendCancelPacket" title="Send a cancel packet to FSW">
+                                    v-on:click="sendCancelPacket" title="Send a cancel packet to FSW"
+                                    :disabled="isActive">
                                         <i class="fas fa-stop"></i>
                                         <span class="d-md-none d-lg-inline">Send Cancel Packet</span>
                                     </button>

--- a/src/fprime_gds/flask/static/js/uploader.js
+++ b/src/fprime_gds/flask/static/js/uploader.js
@@ -52,6 +52,13 @@ export class Uploader {
         return _loader.load("/upload/files", "PUT", {"action": "unpause-all"});
     }
     /**
+     * Request to send a single cancel packet
+     * @return {Promise<any> | number | Promise<boolean> | void | boolean}
+     */
+    sendCancelPacket() {
+        return _loader.load("/upload/files", "PUT", {"action": "send-cancel-packet"});
+    }
+    /**
      * Send a command to the server to command a specific file. This  allows files to be canceled and/or removed from
      * the uplink queue.
      * @param file: file to operate on (source of uplinking file)

--- a/src/fprime_gds/flask/static/js/vue-support/uplink.js
+++ b/src/fprime_gds/flask/static/js/vue-support/uplink.js
@@ -57,6 +57,12 @@ Vue.component("uplink", {
             _uploader.unpause();
         },
         /**
+         * Calls the uploader to send a cancel packet to FSW.
+         */
+        sendCancelPacket() {
+            _uploader.sendCancelPacket();
+        },
+        /**
          * Handles the files event to add input files into the list being curated. This takes each file, and creates a
          * mock file object so that it displays nicely in the curateable "NOT STARTED" state.
          * @param event: event to add files

--- a/src/fprime_gds/flask/static/js/vue-support/uplink.js
+++ b/src/fprime_gds/flask/static/js/vue-support/uplink.js
@@ -24,7 +24,7 @@ Vue.component("uplink", {
             "upfiles": _datastore.upfiles, 
             "flags": _datastore.flags,
             "selected": [], 
-            "destination": "/", 
+            "destination": "", 
             "error": null
         }
     },
@@ -116,6 +116,16 @@ Vue.component("uplink", {
          */
         elements() {
             return this.selected.concat(this.upfiles.reverse());
+        },
+
+        /**
+         * Returns true if any uplinks are currently TRANSMITTING, false otherwise.
+         * @returns boolean true if any uplinks are active
+         */
+        isActive() {
+            return this.upfiles.reduce((acc, item) => {
+                return acc || (item.state == "TRANSMITTING");
+            }, false);
         }
     }
 });

--- a/src/fprime_gds/flask/updown.py
+++ b/src/fprime_gds/flask/updown.py
@@ -93,6 +93,8 @@ class FileUploads(flask_restful.Resource):
             self.uplinker.pause()
         elif action == "unpause-all":
             self.uplinker.unpause()
+        elif action == "send-cancel-packet":
+            self.uplinker.send_cancel_packet()
 
     def post(self):
         """


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3194

I was originally trying to have the button also clear out the queue and everything on the ground; but then found what I think is a bug, and ended up deciding against it. The button only sends a cancel packet, as requested by the issue above.

## Rationale

Needed in case the FSW gets stuck in uplinking.
