### PR TITLE
Add ERT and Anchored mode for displaying Charts

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -131,6 +131,7 @@ ENDC
 endcond
 errorhandler
 errorrs
+ert
 ev
 Evn
 evr

--- a/src/fprime_gds/common/data_types/ch_data.py
+++ b/src/fprime_gds/common/data_types/ch_data.py
@@ -7,6 +7,8 @@
 @bug No known bugs
 """
 
+import datetime
+
 from fprime_gds.common.models.serialize import time_type
 from fprime_gds.common.models.serialize.array_type import ArrayType
 from fprime_gds.common.models.serialize.serializable_type import SerializableType
@@ -41,6 +43,8 @@ class ChData(sys_data.SysData):
         self.template = ch_temp
         self.pkt = None
         self.display_text = self._compute_display_text(ch_val_obj, ch_temp)
+        # Earth Received Time - timestamp when GDS created this channel data object
+        self.ert = datetime.datetime.now(datetime.timezone.utc)
 
     @staticmethod
     def get_empty_obj(ch_temp):

--- a/src/fprime_gds/flask/json.py
+++ b/src/fprime_gds/flask/json.py
@@ -98,10 +98,10 @@ def minimal_event(obj):
 
 
 def minimal_channel(obj):
-    """Minimal channel serialization: time, id, val, and display_text
+    """Minimal channel serialization: time, id, val, display_text, and ert
 
     Minimally serializes channel values for use with the flask layer. This does away with any unnecessary data by
-    serializing only the id, value, and optional display text
+    serializing only the id, value, optional display text, and Earth Received Time (ERT)
 
     Args:
         obj: object to serialize into JSON
@@ -114,6 +114,7 @@ def minimal_channel(obj):
         "id": obj.id,
         "val": obj.val_obj.val,
         "display_text": obj.display_text,
+        "ert": obj.ert.isoformat() if hasattr(obj, 'ert') else None,
     }
 
 

--- a/src/fprime_gds/flask/static/addons/chart-display/addon-templates.js
+++ b/src/fprime_gds/flask/static/addons/chart-display/addon-templates.js
@@ -51,13 +51,19 @@ export let chart_wrapper_template = `
             <div v-if="isHelpActive">
                 <div class="alert alert-warning alert-dismissible mt-2 fade show" role="alert">
                     <div class="row">
-                        <div class="col-6">
+                        <div class="col-4">
                             <strong>Zoom in and out</strong> by holding <strong>ALT</strong> and using mouse wheel to scroll while hovering over an axis <br/>
                             <strong>Zoom in</strong> by holding <strong>ALT</strong> and clicking and dragging a selection on the chart
                         </div>
-                        <div class="col-6">
+                        <div class="col-4">
                             <strong>Pan</strong> by holding <strong>SHIFT</strong> and clicking and dragging the chart <br/>
                             <strong>Change size</strong> by clicking and dragging the icon at the bottom right of the chart box
+                        </div>
+                        <div class="col-4">
+                            <strong>Time Modes:</strong><br/>
+                            <strong>Realtime</strong> - Chart scrolls and displays data using channel timestamps (scrolling based off of workstation time)<br/>
+                            <strong>Realtime (anchored)</strong> - No scrolling, chart redraws and centers around all data points using channel timestamp<br/>
+                            <strong>Earth Received Time</strong> - Chart scrolls and displays data using ground station receive time<br/>
                         </div>
                         <button type="button" class="close" v-on:click="isHelpActive = !isHelpActive">
                             <li class="fas fa-times" style="font-size: 0.75em"></i>
@@ -109,8 +115,8 @@ export let chart_display_template = `
                         </div>
                         <select v-model="timeMode" class="form-control" v-on:change="onTimeModeChange">
                             <option value="realtime">Realtime</option>
+                            <option value="anchored">Realtime (anchored)</option>
                             <option value="ert">Earth Received Time</option>
-                            <option value="firstSample">Anchored on First Sample</option>
                         </select>
                     </div>
                 </div>

--- a/src/fprime_gds/flask/static/addons/chart-display/addon-templates.js
+++ b/src/fprime_gds/flask/static/addons/chart-display/addon-templates.js
@@ -96,12 +96,22 @@ export let chart_display_template = `
                                   v-bind:value="selected" v-on:input="updateSelected($event)">
                         </v-select>
                     </div>
-                    <div class="col-md-4 input-group">
+                    <div class="col-md-3 input-group">
                         <div class="input-group-prepend">
                             <span class="input-group-text">Data Window:</span>
                         </div>
                         <input name="timespan" type="number" v-model="timespan" class="form-control" />
                         <span class="input-group-text">(S)</span>
+                    </div>
+                    <div class="col-md-3 input-group">
+                        <div class="input-group-prepend">
+                            <span class="input-group-text">Time:</span>
+                        </div>
+                        <select v-model="timeMode" class="form-control" v-on:change="onTimeModeChange">
+                            <option value="realtime">Realtime</option>
+                            <option value="ert">Earth Received Time</option>
+                            <option value="firstSample">Anchored on First Sample</option>
+                        </select>
                     </div>
                 </div>
 

--- a/src/fprime_gds/flask/static/addons/chart-display/addon.js
+++ b/src/fprime_gds/flask/static/addons/chart-display/addon.js
@@ -113,7 +113,9 @@ Vue.component("chart-display", {
             pause: false,
 
             chart: null,
-            timespan: 3600
+            timespan: 3600,
+            timeMode: "realtime",
+            firstSampleTime: null
         };
     },
     mounted() {
@@ -132,17 +134,35 @@ Vue.component("chart-display", {
             this.siblings.pause(realtimeOpts.pause);
         },
         /**
+         * Handle time mode change
+         */
+        onTimeModeChange() {
+            // Reset first sample time when switching modes
+            this.firstSampleTime = null;
+            // Re-register the chart to reset it with the new time mode
+            if (this.chart && this.selected) {
+                this.registerChart();
+            }
+        },
+        /**
          * Register a new chart object
          */
         registerChart() {
             // If there is a chart object destroy it to reset the chart
             this.destroy();
+            // Reset first sample time when registering new chart
+            this.firstSampleTime = null;
             _datastore.registerConsumer("channels", this);
-            let config = generate_chart_config(this.selected);
+            // Use realtime scale for Realtime and ERT modes, standard time scale for First Sample
+            const useRealtimeScale = this.timeMode !== "firstSample";
+            let config = generate_chart_config(this.selected, useRealtimeScale);
             config.options.plugins.zoom.zoom.onZoom = this.siblings.syncToAll;
             config.options.plugins.zoom.pan.onPan = this.siblings.syncToAll;
-            // Category IV magic: do not alter
-            config.options.scales.x.realtime.onRefresh = this.siblings.sync;
+            // Only set onRefresh callback for realtime scale
+            if (useRealtimeScale) {
+                // Category IV magic: do not alter
+                config.options.scales.x.realtime.onRefresh = this.siblings.sync;
+            }
             this.showControlBtns = true;
             try {
                 this.chart = new Chart(
@@ -230,8 +250,16 @@ Vue.component("chart-display", {
 
             // Convert to chart JS format
             new_channels = new_channels.map((channel) => {
+                let timeValue;
+                if (this.timeMode === "ert" && channel.ert) {
+                    // Use Earth Received Time (ground receive time)
+                    timeValue = new Date(channel.ert);
+                } else {
+                    // Other mode - use current time (default behavior)
+                    timeValue = channel.datetime || timeToDate(channel.time);
+                }
                 return {
-                    x: channel.datetime || timeToDate(channel.time),
+                    x: timeValue,
                     y: getValue(channel, serial_path),
                 };
             });
@@ -240,7 +268,10 @@ Vue.component("chart-display", {
             let data_array = this.chart.data.datasets[0].data;
             data_array.push(...new_channels);
 
-            this.chart.options.scales.x.realtime.ttl = this.timespan * 1000;
+            // Only set TTL for realtime scale (Realtime and ERT modes)
+            if (this.timeMode !== "firstSample") {
+                this.chart.options.scales.x.realtime.ttl = this.timespan * 1000;
+            }
             this.chart.update("quiet");
 
             // Calculate the window span by max samples

--- a/src/fprime_gds/flask/static/addons/chart-display/addon.js
+++ b/src/fprime_gds/flask/static/addons/chart-display/addon.js
@@ -114,8 +114,7 @@ Vue.component("chart-display", {
 
             chart: null,
             timespan: 3600,
-            timeMode: "realtime",
-            firstSampleTime: null
+            timeMode: "realtime",  // mode for X-axis chart rendering: realtime, ert, anchored
         };
     },
     mounted() {
@@ -137,8 +136,6 @@ Vue.component("chart-display", {
          * Handle time mode change
          */
         onTimeModeChange() {
-            // Reset first sample time when switching modes
-            this.firstSampleTime = null;
             // Re-register the chart to reset it with the new time mode
             if (this.chart && this.selected) {
                 this.registerChart();
@@ -150,11 +147,9 @@ Vue.component("chart-display", {
         registerChart() {
             // If there is a chart object destroy it to reset the chart
             this.destroy();
-            // Reset first sample time when registering new chart
-            this.firstSampleTime = null;
             _datastore.registerConsumer("channels", this);
-            // Use realtime scale for Realtime and ERT modes, standard time scale for First Sample
-            const useRealtimeScale = this.timeMode !== "firstSample";
+            // Use realtime scale for Realtime and ERT modes, standard time scale for Anchored mode
+            const useRealtimeScale = this.timeMode !== "anchored";
             let config = generate_chart_config(this.selected, useRealtimeScale);
             config.options.plugins.zoom.zoom.onZoom = this.siblings.syncToAll;
             config.options.plugins.zoom.pan.onPan = this.siblings.syncToAll;
@@ -269,7 +264,7 @@ Vue.component("chart-display", {
             data_array.push(...new_channels);
 
             // Only set TTL for realtime scale (Realtime and ERT modes)
-            if (this.timeMode !== "firstSample") {
+            if (this.timeMode !== "anchored") {
                 this.chart.options.scales.x.realtime.ttl = this.timespan * 1000;
             }
             this.chart.update("quiet");

--- a/src/fprime_gds/flask/static/addons/chart-display/config.js
+++ b/src/fprime_gds/flask/static/addons/chart-display/config.js
@@ -100,14 +100,24 @@ export let zoom_config = {
 /**
  * Returns a new chart config object for the given labeled data set.
  * @param label
+ * @param useRealtimeScale - If true, use realtime streaming scale; if false, use standard time scale
  * @return {{data: {datasets: [*]}, options: *, type: string}}
  */
-export function generate_chart_config(label) {
-    let final_realtime_config = Object.assign({}, realtime_config);
-    let scales = {
-        x: {type: "realtime", realtime: final_realtime_config, ticks: ticks_config},
-        y: {title: {display: true, text: "Value"}}
-    };
+export function generate_chart_config(label, useRealtimeScale = true) {
+    let scales;
+    if (useRealtimeScale) {
+        let final_realtime_config = Object.assign({}, realtime_config);
+        scales = {
+            x: {type: "realtime", realtime: final_realtime_config, ticks: ticks_config},
+            y: {title: {display: true, text: "Value"}}
+        };
+    } else {
+        // Use standard time scale for historical data
+        scales = {
+            x: {type: "time", time: {displayFormats: {millisecond: 'HH:mm:ss.SSS', second: 'HH:mm:ss', minute: 'HH:mm', hour: 'HH:mm'}}, ticks: ticks_config},
+            y: {title: {display: true, text: "Value"}}
+        };
+    }
     let plugins = {zoom: zoom_config};
 
     let final_dataset_config = Object.assign({label: label}, dataset_config, {data: []});


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/3255 by:

- add ERT capture when creating a `ChData` object
- add three time modes for visualizing charts:
   - Realtime: default mode, no changes
   - ERT: plots by ERT, meaning it will show wall clock, and data will be plotted as it is received
   - Anchored: this was the tricky one to figure out, maybe we don't need it. But it works. Instead of "streaming" the wallclock time, it'll just render the chart statically every time a new channel is added. Meaning the SC timestamp is displayed correctly. See example below when I've taken `Svc.PosixTime` and subtracted a year (-> Dec 2024) to the value before sending it out

<img width="2050" height="879" alt="image" src="https://github.com/user-attachments/assets/0ac366b4-9f18-4ee8-a7a0-a10d500d9db5" />

<img width="2035" height="770" alt="image" src="https://github.com/user-attachments/assets/72ed2ef5-90e7-423f-b043-f1c5fc2889b4" />



## Rationale

Long standing request