### PR TITLE
delete file if it exists when the start packet is received

### DIFF
--- a/src/fprime_gds/common/files/helpers.py
+++ b/src/fprime_gds/common/files/helpers.py
@@ -141,6 +141,8 @@ class TransmitFile:
         self.__mode = mode
         if mode == TransmitFileState.WRITE:
             filepath = self.__destination
+            if os.path.exists(filepath):
+                os.remove(filepath)
             Path(filepath).touch(exist_ok=True)
             filemode = "rb+"
         else:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  NA |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**| N |

---
## Change Description

We noticed an issue where files with the same name are overwritten, but instead of being truncated, they are appended to from the zeroth index. This resulted in the file on disk (on the target) not matching the file in the fprime-downlinks folder.

This PR is as an attempt at a fix to this issue, with some limited understanding of how GDS works. Please feel free to re-write this patch or treat it as an issue.

## Rationale

This PR prevents files from being in an inconsistent state as it removes a file if it already exists when the START_PACKET is received.

## Testing/Review Recommendations

Suggest creating a file in the downlinks folder of a specific length (say 100 bytes of 0s) and then downlinking a file of a shorter length (perhaps 50 bytes of 1s). Both files must have the same name. After issuing the downlink command, the resulting file in the downlinks folder would be half 1s and half 0s, in state that is not consistent with the file on disk (for the target) Should be 50 bytes of 1's in this example.

## Future Work

None come to mind.
