### PR TITLE
Updated StandardPipeline.setup() to set dictionary_path

### DIFF
--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -45,7 +45,6 @@ class StandardPipeline:
         self.distributor = None
         self.client_socket = None
         self.logger = None
-        self.dictionary_path = None
         self.up_store = None
         self.down_store = None
 
@@ -251,3 +250,8 @@ class StandardPipeline:
     def dictionaries(self):
         """Dictionaries member"""
         return self.__dictionaries
+
+    @property
+    def dictionary_path(self):
+        """Dictionary file path"""
+        return self.dictionaries.dictionary_path if self.dictionaries else None

--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -89,7 +89,6 @@ class StandardPipeline:
                 f"{file_store} is not writable. Fix permissions or change storage directory with --file-storage-directory."
             )
         self.__dictionaries = dictionaries
-        self.dictionary_path = getattr(self.dictionaries,"_dictionary_path")
         self.coders.setup_coders(
             self.dictionaries, self.distributor, self.client_socket
         )

--- a/src/fprime_gds/common/pipeline/standard.py
+++ b/src/fprime_gds/common/pipeline/standard.py
@@ -90,6 +90,7 @@ class StandardPipeline:
                 f"{file_store} is not writable. Fix permissions or change storage directory with --file-storage-directory."
             )
         self.__dictionaries = dictionaries
+        self.dictionary_path = getattr(self.dictionaries,"_dictionary_path")
         self.coders.setup_coders(
             self.dictionaries, self.distributor, self.client_socket
         )


### PR DESCRIPTION
`IntegrationTestApi.get_deployment()` uses the `dictionary_path` property of self.pipeline, so `StandardPipeline.setup()`  needs to set that value

| | |
|:---|:---|
|**_Related Issue(s)_**|  none |
|**_Has Unit Tests (y/n)_**|  no |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Update StandardPipeline.setup()  to set the object's `dictionary_path` field 

## Rationale

Without this change, `IntegrationTestApi.get_deployment()` always fails 

## Testing/Review Recommendations

Add `get_deployment()` to any test using `fprime_test_api`, without this change it will fail with `Error: File not found at path: None`. With this change it'll work 

## Future Work

Note any additional work that will be done relating to this issue.
