### PR TITLE
Hotfix: TimeType to_jsonable return correct context

### DIFF
--- a/src/fprime_gds/common/models/serialize/time_type.py
+++ b/src/fprime_gds/common/models/serialize/time_type.py
@@ -134,8 +134,8 @@ class TimeType(type_base.BaseType):
         """
         return {
             "type": self.__repr__(),
-            "base": self.__timeBase.numeric_value,
-            "context": self.__timeContext,
+            "base": self.timeBase.numeric_value,
+            "context": self.timeContext,
             "seconds": self.seconds,
             "microseconds": self.useconds,
         }


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Used to return "U8". Now returns the numeric value.