### PR TITLE
Update deprecated `datetime` call

### DIFF
--- a/src/fprime_gds/common/files/helpers.py
+++ b/src/fprime_gds/common/files/helpers.py
@@ -149,7 +149,7 @@ class TransmitFile:
 
         self.__state = "TRANSMITTING"
         self.__fd = open(filepath, filemode)
-        self.__start = datetime.datetime.utcnow()
+        self.__start = datetime.datetime.now(datetime.UTC)
         if self.__log_dir is not None:
             self.__log_handler = logging.FileHandler(
                 os.path.join(self.__log_dir, f"{os.path.basename(filepath)}.log"),
@@ -203,7 +203,7 @@ class TransmitFile:
         if self.__fd is not None:
             self.__fd.close()
             self.__fd = None
-            self.__end = datetime.datetime.utcnow()
+            self.__end = datetime.datetime.now(datetime.UTC)
 
     @property
     def start(self):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

This PR is updates a deprecated call to the `datetime` library.

## Rationale

Fixing warnings:

```sh
FprimeZephyrReference/test/int/rtc_test.py::test_04_sequence_cancellation_on_time_set
  /Users/nate/code/github.com/open-source-space-foundation/proves-core-reference/fprime-venv/lib/python3.13/site-packages/fprime_gds/common/files/helpers.py:150: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self.__start = datetime.datetime.utcnow()
```

## Testing/Review Recommendations

This does is not expected to change any behavior and compatible with Python 3.9+ which is the stated supported versions in the `pyproject.toml`

## Future Work

Note any additional work that will be done relating to this issue.
