### PR TITLE
Add automatic decoding for hashed files

### DIFF
--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -80,16 +80,14 @@ class EventData(sys_data.SysData):
             except ValueError:
                 continue
 
-            hash_file = os.environ['HASH_FILE']
-            with open(hash_file) as file_handle:
-                lines = filter(
-                    lambda line: hash_value == int(line.split(" ")[-1], 0),
-                    file_handle.readlines(),
-                )
-            line = next(lines, None)
-            if line is not None:
-                file = Path(line.split(':')[0].strip()).absolute()
-                self.args[index].val = str(file)
+            hash_file = Path(os.environ['HASH_FILE'])
+            with hash_file.open() as file_handle:
+                for line in file_handle:
+                    if hash_value == int(line.split(" ")[-1], 0):
+                        rel_file_path = line.split(':')[0].strip()
+                        abs_file_path = (hash_file.parent.parent / rel_file_path).absolute()
+                        arg.val = str(abs_file_path) if abs_file_path.exists() else rel_file_path
+                        break
 
     def get_args(self):
         return self.args

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -68,7 +68,7 @@ class EventData(sys_data.SysData):
             )
 
     def _decode_hashed_files(self):
-        "Searches event args for hashed files and replaces them with their corresponding file names"
+        "Searches event args for hashed files and replaces each with its corresponding file name"
 
         args_template = self.template.get_args()
         for index, arg in enumerate(self.args):
@@ -81,13 +81,13 @@ class EventData(sys_data.SysData):
                 continue
 
             hash_file = Path(os.environ['HASH_FILE'])
-            
             with open(hash_file) as file_handle:
                 lines = filter(
                     lambda line: hash_value == int(line.split(" ")[-1], 0),
                     file_handle.readlines(),
                 )
-            self.args[index].val = next(lines).split(':')[0].strip()
+            if len(list(lines)) > 0:
+                self.args[index].val = next(lines).split(':')[0].strip()
 
     def get_args(self):
         return self.args

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -11,7 +11,10 @@ from fprime_gds.common.models.serialize import time_type
 
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
-import subprocess
+from fprime.fbuild.builder import Build
+from pathlib import Path
+
+import os
 
 class EventData(sys_data.SysData):
     """
@@ -46,21 +49,27 @@ class EventData(sys_data.SysData):
             return
 
         args_template = self.template.get_args()
-        for index, arg in enumerate(event_args):
+        if event_temp.name.startswith('AF_'):
+            for index, arg in enumerate(event_args):
 
-            # determine if args contain a hashed file
-            if args_template[index][0] != 'file':
-                continue
-            try:
-                int(arg.val, 16)
-            except ValueError:
-                continue
+                # determine if args contain a hashed file
+                if args_template[index][0] != 'file':
+                    continue
+                try:
+                    hash_value = int(arg.val, 16)
+                except ValueError:
+                    continue
 
-            # if so decode the filename and insert into arg
-            command = ['fprime-util', 'hash-to-file', arg.val]
-            result = subprocess.run(command, capture_output=True, text=True)
-            file = result.stdout.split('\n')[-2].split(':')[0].strip()
-            event_args[index].val = file
+                # if so decode the filename and insert into arg
+                build_dir = Path(os.environ['BUILD_DIR'])
+                parent_dir = build_dir.parent
+
+                build = Build(0, Build.find_nearest_parent_project(build_dir))
+                build.build_dir = build_dir
+                lines = build.find_hashed_file(hash_value)
+
+                file = parent_dir / Path(lines[0].split(':')[0].strip())
+                event_args[index].val = str(file)
 
         if event_temp.format_str == "":
             self.display_text = str(

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -11,7 +11,6 @@ from fprime_gds.common.models.serialize import time_type
 
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
-from pathlib import Path
 
 import os
 
@@ -83,7 +82,7 @@ class EventData(sys_data.SysData):
                 continue
 
             hash_file = os.environ['FPRIME_HASHES_TXT_FILE']
-            with hash_file.open() as file_handle:
+            with open(hash_file) as file_handle:
                 for line in file_handle:
                     if hash_value == int(line.split(" ")[-1], 0):
                         arg.val = line.split(':')[0].strip()

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -11,7 +11,6 @@ from fprime_gds.common.models.serialize import time_type
 
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
-from fprime.fbuild.builder import Build
 from pathlib import Path
 
 import os
@@ -48,7 +47,10 @@ class EventData(sys_data.SysData):
             self.display_text = event_temp.description
             return
 
-        if event_temp.name.startswith('AF_ASSERT') or event_temp.name == "AF_UNEXPECTED_ASSERT":
+        if (
+            (event_temp.name.startswith('AF_ASSERT') or event_temp.name == "AF_UNEXPECTED_ASSERT") and
+            'HASH_FILE' in os.environ
+        ):
             self._decode_hashed_files()
                 
         if event_temp.format_str == "":
@@ -66,11 +68,11 @@ class EventData(sys_data.SysData):
             )
 
     def _decode_hashed_files(self):
-        args_template = self.template.get_args()
+        "Searches event args for hashed files and replaces them with their corresponding file names"
 
+        args_template = self.template.get_args()
         for index, arg in enumerate(self.args):
 
-            # determine if args contain a hashed file
             if args_template[index][0] != 'file':
                 continue
             try:
@@ -78,16 +80,14 @@ class EventData(sys_data.SysData):
             except ValueError:
                 continue
 
-            # if so decode the filename and insert into arg
-            build_dir = Path(os.environ['BUILD_DIR'])
-            parent_dir = build_dir.parent
-
-            build = Build(0, Build.find_nearest_parent_project(build_dir))
-            build.build_dir = build_dir
-            lines = build.find_hashed_file(hash_value)
-
-            file = parent_dir / Path(lines[0].split(':')[0].strip())
-            self.args[index].val = str(file)
+            hash_file = Path(os.environ['HASH_FILE'])
+            
+            with open(hash_file) as file_handle:
+                lines = filter(
+                    lambda line: hash_value == int(line.split(" ")[-1], 0),
+                    file_handle.readlines(),
+                )
+            self.args[index].val = next(lines).split(':')[0].strip()
 
     def get_args(self):
         return self.args

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -80,14 +80,16 @@ class EventData(sys_data.SysData):
             except ValueError:
                 continue
 
-            hash_file = Path(os.environ['HASH_FILE'])
+            hash_file = os.environ['HASH_FILE']
             with open(hash_file) as file_handle:
                 lines = filter(
                     lambda line: hash_value == int(line.split(" ")[-1], 0),
                     file_handle.readlines(),
                 )
-            if len(list(lines)) > 0:
-                self.args[index].val = next(lines).split(':')[0].strip()
+            line = next(lines, None)
+            if line is not None:
+                file = Path(line.split(':')[0].strip()).absolute()
+                self.args[index].val = str(file)
 
     def get_args(self):
         return self.args

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -49,7 +49,7 @@ class EventData(sys_data.SysData):
 
         if (
             (event_temp.name.startswith('AF_ASSERT') or event_temp.name == "AF_UNEXPECTED_ASSERT") and
-            'HASH_FILE' in os.environ
+            'FPRIME_HASHES_TXT_FILE' in os.environ
         ):
             self._decode_hashed_files()
                 
@@ -80,7 +80,7 @@ class EventData(sys_data.SysData):
             except ValueError:
                 continue
 
-            hash_file = Path(os.environ['HASH_FILE'])
+            hash_file = Path(os.environ['FPRIME_HASHES_TXT_FILE'])
             with hash_file.open() as file_handle:
                 for line in file_handle:
                     if hash_value == int(line.split(" ")[-1], 0):

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -11,7 +11,7 @@ from fprime_gds.common.models.serialize import time_type
 
 from fprime_gds.common.data_types import sys_data
 from fprime_gds.common.utils.string_util import format_string_template
-
+import subprocess
 
 class EventData(sys_data.SysData):
     """
@@ -40,10 +40,29 @@ class EventData(sys_data.SysData):
         self.args = event_args
         self.time = event_time
         self.template = event_temp
+
         if event_args is None:
             self.display_text = event_temp.description
-        elif event_temp.format_str == "":
-            args_template = self.template.get_args()
+            return
+
+        args_template = self.template.get_args()
+        for index, arg in enumerate(event_args):
+
+            # determine if args contain a hashed file
+            if args_template[index][0] != 'file':
+                continue
+            try:
+                int(arg.val, 16)
+            except ValueError:
+                continue
+
+            # if so decode the filename and insert into arg
+            command = ['fprime-util', 'hash-to-file', arg.val]
+            result = subprocess.run(command, capture_output=True, text=True)
+            file = result.stdout.split('\n')[-2].split(':')[0].strip()
+            event_args[index].val = file
+
+        if event_temp.format_str == "":
             self.display_text = str(
                 [
                     {args_template[index][0]: arg.val}

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -73,6 +73,8 @@ class EventData(sys_data.SysData):
         args_template = self.template.get_args()
         for index, arg in enumerate(self.args):
 
+            if not args_template[index]:
+                continue
             if args_template[index][0] != 'file':
                 continue
             try:
@@ -80,13 +82,11 @@ class EventData(sys_data.SysData):
             except ValueError:
                 continue
 
-            hash_file = Path(os.environ['FPRIME_HASHES_TXT_FILE'])
+            hash_file = os.environ['FPRIME_HASHES_TXT_FILE']
             with hash_file.open() as file_handle:
                 for line in file_handle:
                     if hash_value == int(line.split(" ")[-1], 0):
-                        rel_file_path = line.split(':')[0].strip()
-                        abs_file_path = (hash_file.parent.parent / rel_file_path).absolute()
-                        arg.val = str(abs_file_path) if abs_file_path.exists() else rel_file_path
+                        arg.val = line.split(':')[0].strip()
                         break
 
     def get_args(self):

--- a/src/fprime_gds/common/data_types/event_data.py
+++ b/src/fprime_gds/common/data_types/event_data.py
@@ -48,30 +48,12 @@ class EventData(sys_data.SysData):
             self.display_text = event_temp.description
             return
 
-        args_template = self.template.get_args()
-        if event_temp.name.startswith('AF_'):
-            for index, arg in enumerate(event_args):
-
-                # determine if args contain a hashed file
-                if args_template[index][0] != 'file':
-                    continue
-                try:
-                    hash_value = int(arg.val, 16)
-                except ValueError:
-                    continue
-
-                # if so decode the filename and insert into arg
-                build_dir = Path(os.environ['BUILD_DIR'])
-                parent_dir = build_dir.parent
-
-                build = Build(0, Build.find_nearest_parent_project(build_dir))
-                build.build_dir = build_dir
-                lines = build.find_hashed_file(hash_value)
-
-                file = parent_dir / Path(lines[0].split(':')[0].strip())
-                event_args[index].val = str(file)
-
+        if event_temp.name.startswith('AF_ASSERT') or event_temp.name == "AF_UNEXPECTED_ASSERT":
+            self._decode_hashed_files()
+                
         if event_temp.format_str == "":
+            args_template = self.template.get_args()
+
             self.display_text = str(
                 [
                     {args_template[index][0]: arg.val}
@@ -82,6 +64,30 @@ class EventData(sys_data.SysData):
             self.display_text = format_string_template(
                 event_temp.format_str, tuple([arg.val for arg in event_args])
             )
+
+    def _decode_hashed_files(self):
+        args_template = self.template.get_args()
+
+        for index, arg in enumerate(self.args):
+
+            # determine if args contain a hashed file
+            if args_template[index][0] != 'file':
+                continue
+            try:
+                hash_value = int(arg.val, 16)
+            except ValueError:
+                continue
+
+            # if so decode the filename and insert into arg
+            build_dir = Path(os.environ['BUILD_DIR'])
+            parent_dir = build_dir.parent
+
+            build = Build(0, Build.find_nearest_parent_project(build_dir))
+            build.build_dir = build_dir
+            lines = build.find_hashed_file(hash_value)
+
+            file = parent_dir / Path(lines[0].split(':')[0].strip())
+            self.args[index].val = str(file)
 
     def get_args(self):
         return self.args

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -478,33 +478,6 @@ class DetectionParser(ParserBase):
         args.deployment = child_directories[0]
         return args
 
-class HashFileParser(ParserBase):
-    """Parser for detecting and loading the hashes.txt file for hash decoding"""
-
-    DESCRIPTION = "Hash file options"
-
-    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
-        return {
-            ("--hash-file",): {
-                "dest": "hash_file",
-                "action": "store",
-                "required": False,
-                "type": str,
-                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
-            }
-        }
-    
-    def handle_arguments(self, args, **kwargs):
-        if args.hash_file:
-            args.hash_file = Path(args.hash_file)
-            if not args.hash_file.exists():
-                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
-                print(msg, file=sys.stderr)
-                sys.exit(-1)
-        elif args.deployment:
-            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
-            args.hash_file = hash_file if hash_file.exists() else None
-        return args
 
 class BareArgumentParser(ParserBase):
     """Takes in the argument specification (used in plugins and get_arguments) to parse args
@@ -1126,6 +1099,87 @@ class FileHandlingParser(ParserBase):
                 f"{args.files_storage_directory} is not writable. Fix permissions or change storage directory with --file-storage-directory."
             )
         return args
+    
+
+class BinaryDeployment(DetectionParser):
+    """
+    Parsing subclass used to read the arguments of the binary application. This derives functionality from a comm parser
+    and represents the flight-side of the equation.
+    """
+
+    DESCRIPTION = "FPrime binary options"
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """Return arguments necessary to run a binary deployment via the GDS"""
+        return {
+            **super().get_arguments(),
+            **{
+                ("-n", "--no-app"): {
+                    "dest": "noapp",
+                    "action": "store_true",
+                    "default": False,
+                    "help": "Do not run deployment binary. Overrides --app.",
+                },
+                ("--app",): {
+                    "dest": "app",
+                    "action": "store",
+                    "required": False,
+                    "type": str,
+                    "help": "Path to app to run. Overrides automatic app detection.",
+                },
+            },
+        }
+    
+    def handle_arguments(self, args, **kwargs):
+        """
+        Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
+        program. This will throw if there is an error.
+
+        :param args: parsed arguments in namespace
+        :return: args namespaces
+        """
+        # No app, stop processing now
+        if args.noapp:
+            return args
+        args = super().handle_arguments(args, **kwargs)
+        args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
+        if not args.app.is_file():
+            msg = f"F prime binary '{args.app}' does not exist or is not a file"
+            raise ValueError(msg)
+        return args
+
+
+class HashFileParser(BinaryDeployment):
+    """Parser for detecting and loading the hashes.txt file for hash decoding"""
+
+    DESCRIPTION = "Hash file options"
+
+    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
+        return {
+            ("--hash-file",): {
+                "dest": "hash_file",
+                "action": "store",
+                "required": False,
+                "type": str,
+                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
+            }
+        }
+    
+    def handle_arguments(self, args, **kwargs):
+        if args.hash_file:
+            args.hash_file = Path(args.hash_file)
+            if not args.hash_file.exists():
+                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
+                print(msg, file=sys.stderr)
+                sys.exit(-1)
+            return args
+        
+        if not args.deployment:
+            args = super().handle_arguments(args, **kwargs)
+        if args.deployment:
+            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
+            args.hash_file = hash_file if hash_file.exists() else None
+        return args
 
 
 class StandardPipelineParser(CompositeParser):
@@ -1176,7 +1230,6 @@ class CommParser(CompositeParser):
 
     CONSTITUENTS = [
         DictionaryParser,  # needed to get types from dictionary for framing
-        HashFileParser,
         CommExtraParser,
         MiddleWareParser,
         LogDeployParser,
@@ -1243,54 +1296,6 @@ class GdsParser(ParserBase):
         :param args: parsed args into a namespace
         :return: args namespace
         """
-        return args
-
-
-class BinaryDeployment(DetectionParser):
-    """
-    Parsing subclass used to read the arguments of the binary application. This derives functionality from a comm parser
-    and represents the flight-side of the equation.
-    """
-
-    DESCRIPTION = "FPrime binary options"
-
-    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
-        """Return arguments necessary to run a binary deployment via the GDS"""
-        return {
-            **super().get_arguments(),
-            **{
-                ("-n", "--no-app"): {
-                    "dest": "noapp",
-                    "action": "store_true",
-                    "default": False,
-                    "help": "Do not run deployment binary. Overrides --app.",
-                },
-                ("--app",): {
-                    "dest": "app",
-                    "action": "store",
-                    "required": False,
-                    "type": str,
-                    "help": "Path to app to run. Overrides automatic app detection.",
-                },
-            },
-        }
-
-    def handle_arguments(self, args, **kwargs):
-        """
-        Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
-        program. This will throw if there is an error.
-
-        :param args: parsed arguments in namespace
-        :return: args namespaces
-        """
-        # No app, stop processing now
-        if args.noapp:
-            return args
-        args = super().handle_arguments(args, **kwargs)
-        args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
-        if not args.app.is_file():
-            msg = f"F prime binary '{args.app}' does not exist or is not a file"
-            raise ValueError(msg)
         return args
 
 

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -500,7 +500,7 @@ class HashFileParser(ParserBase):
                 print(msg, file=sys.stderr)
                 sys.exit(-1)
         elif args.deployment:
-            hash_file = args.deployment.parent.parent / "hashes.txt"
+            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
             args.hash_file = hash_file if hash_file.exists() else None
         return args
 

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1176,7 +1176,6 @@ class CommParser(CompositeParser):
 
     CONSTITUENTS = [
         DictionaryParser,  # needed to get types from dictionary for framing
-        HashFileParser,
         CommExtraParser,
         MiddleWareParser,
         LogDeployParser,

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1045,7 +1045,7 @@ class DictionaryParser(DetectionParser):
         return args
 
 
-class HashFileParser(DetectionParser):
+class HashFileParser(DictionaryParser):
     """Parser for detecting and loading the hashes.txt file for hash decoding"""
 
     DESCRIPTION = "Hash file options"

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -478,6 +478,33 @@ class DetectionParser(ParserBase):
         args.deployment = child_directories[0]
         return args
 
+class HashFileParser(ParserBase):
+    """Parser for detecting and loading the hashes.txt file for hash decoding"""
+
+    DESCRIPTION = "Hash file options"
+
+    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
+        return {
+            ("--hash-file",): {
+                "dest": "hash_file",
+                "action": "store",
+                "required": False,
+                "type": str,
+                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
+            }
+        }
+    
+    def handle_arguments(self, args, **kwargs):
+        if args.hash_file:
+            args.hash_file = Path(args.hash_file)
+            if not args.hash_file.exists():
+                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
+                print(msg, file=sys.stderr)
+                sys.exit(-1)
+        elif args.deployment:
+            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
+            args.hash_file = hash_file if hash_file.exists() else None
+        return args
 
 class BareArgumentParser(ParserBase):
     """Takes in the argument specification (used in plugins and get_arguments) to parse args
@@ -1099,87 +1126,6 @@ class FileHandlingParser(ParserBase):
                 f"{args.files_storage_directory} is not writable. Fix permissions or change storage directory with --file-storage-directory."
             )
         return args
-    
-
-class BinaryDeployment(DetectionParser):
-    """
-    Parsing subclass used to read the arguments of the binary application. This derives functionality from a comm parser
-    and represents the flight-side of the equation.
-    """
-
-    DESCRIPTION = "FPrime binary options"
-
-    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
-        """Return arguments necessary to run a binary deployment via the GDS"""
-        return {
-            **super().get_arguments(),
-            **{
-                ("-n", "--no-app"): {
-                    "dest": "noapp",
-                    "action": "store_true",
-                    "default": False,
-                    "help": "Do not run deployment binary. Overrides --app.",
-                },
-                ("--app",): {
-                    "dest": "app",
-                    "action": "store",
-                    "required": False,
-                    "type": str,
-                    "help": "Path to app to run. Overrides automatic app detection.",
-                },
-            },
-        }
-    
-    def handle_arguments(self, args, **kwargs):
-        """
-        Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
-        program. This will throw if there is an error.
-
-        :param args: parsed arguments in namespace
-        :return: args namespaces
-        """
-        # No app, stop processing now
-        if args.noapp:
-            return args
-        args = super().handle_arguments(args, **kwargs)
-        args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
-        if not args.app.is_file():
-            msg = f"F prime binary '{args.app}' does not exist or is not a file"
-            raise ValueError(msg)
-        return args
-
-
-class HashFileParser(BinaryDeployment):
-    """Parser for detecting and loading the hashes.txt file for hash decoding"""
-
-    DESCRIPTION = "Hash file options"
-
-    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
-        return {
-            ("--hash-file",): {
-                "dest": "hash_file",
-                "action": "store",
-                "required": False,
-                "type": str,
-                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
-            }
-        }
-    
-    def handle_arguments(self, args, **kwargs):
-        if args.hash_file:
-            args.hash_file = Path(args.hash_file)
-            if not args.hash_file.exists():
-                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
-                print(msg, file=sys.stderr)
-                sys.exit(-1)
-            return args
-        
-        if not args.deployment:
-            args = super().handle_arguments(args, **kwargs)
-        if args.deployment:
-            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
-            args.hash_file = hash_file if hash_file.exists() else None
-        return args
 
 
 class StandardPipelineParser(CompositeParser):
@@ -1230,6 +1176,7 @@ class CommParser(CompositeParser):
 
     CONSTITUENTS = [
         DictionaryParser,  # needed to get types from dictionary for framing
+        HashFileParser,
         CommExtraParser,
         MiddleWareParser,
         LogDeployParser,
@@ -1296,6 +1243,54 @@ class GdsParser(ParserBase):
         :param args: parsed args into a namespace
         :return: args namespace
         """
+        return args
+
+
+class BinaryDeployment(DetectionParser):
+    """
+    Parsing subclass used to read the arguments of the binary application. This derives functionality from a comm parser
+    and represents the flight-side of the equation.
+    """
+
+    DESCRIPTION = "FPrime binary options"
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """Return arguments necessary to run a binary deployment via the GDS"""
+        return {
+            **super().get_arguments(),
+            **{
+                ("-n", "--no-app"): {
+                    "dest": "noapp",
+                    "action": "store_true",
+                    "default": False,
+                    "help": "Do not run deployment binary. Overrides --app.",
+                },
+                ("--app",): {
+                    "dest": "app",
+                    "action": "store",
+                    "required": False,
+                    "type": str,
+                    "help": "Path to app to run. Overrides automatic app detection.",
+                },
+            },
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        """
+        Takes the arguments from the parser, and processes them into the needed map of key to dictionaries for the
+        program. This will throw if there is an error.
+
+        :param args: parsed arguments in namespace
+        :return: args namespaces
+        """
+        # No app, stop processing now
+        if args.noapp:
+            return args
+        args = super().handle_arguments(args, **kwargs)
+        args.app = Path(args.app) if args.app else Path(find_app(args.deployment))
+        if not args.app.is_file():
+            msg = f"F prime binary '{args.app}' does not exist or is not a file"
+            raise ValueError(msg)
         return args
 
 

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -481,6 +481,8 @@ class DetectionParser(ParserBase):
 class HashFileParser(ParserBase):
     """Parser for detecting and loading the hashes.txt file for hash decoding"""
 
+    DESCRIPTION = "Hash file options"
+
     def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
         return {
             ("--hash-file",): {
@@ -488,7 +490,7 @@ class HashFileParser(ParserBase):
                 "action": "store",
                 "required": False,
                 "type": str,
-                "help": "File containing map between hash codes and their corresponding program files",
+                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
             }
         }
     

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -478,6 +478,27 @@ class DetectionParser(ParserBase):
         args.deployment = child_directories[0]
         return args
 
+class HashFileParser(ParserBase):
+    """Parser for detecting and/or loading the hashes.txt file for hash decoding"""
+
+    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
+        return {
+            ("--hash-file",): {
+                "dest": "hash_file",
+                "action": "store",
+                "required": False,
+                "type": str,
+                "help": "File containing maps between program files and their hash codes",
+            }
+        }
+    
+    def handle_arguments(self, args, **kwargs):
+        if args.hash_file:
+            args.hash_file = Path(args.hash_file)
+        elif args.deployment:
+            hash_file = args.deployment.parent.parent / "hashes.txt"
+            args.hash_file = hash_file if hash_file.exists() else None
+        return args
 
 class BareArgumentParser(ParserBase):
     """Takes in the argument specification (used in plugins and get_arguments) to parse args
@@ -1106,6 +1127,7 @@ class StandardPipelineParser(CompositeParser):
 
     CONSTITUENTS = [
         DictionaryParser,
+        HashFileParser,
         FileHandlingParser,
         MiddleWareParser,
         LogDeployParser,
@@ -1148,6 +1170,7 @@ class CommParser(CompositeParser):
 
     CONSTITUENTS = [
         DictionaryParser,  # needed to get types from dictionary for framing
+        HashFileParser,
         CommExtraParser,
         MiddleWareParser,
         LogDeployParser,

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -479,7 +479,7 @@ class DetectionParser(ParserBase):
         return args
 
 class HashFileParser(ParserBase):
-    """Parser for detecting and/or loading the hashes.txt file for hash decoding"""
+    """Parser for detecting and loading the hashes.txt file for hash decoding"""
 
     def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
         return {
@@ -488,13 +488,17 @@ class HashFileParser(ParserBase):
                 "action": "store",
                 "required": False,
                 "type": str,
-                "help": "File containing maps between program files and their hash codes",
+                "help": "File containing map between hash codes and their corresponding program files",
             }
         }
     
     def handle_arguments(self, args, **kwargs):
         if args.hash_file:
             args.hash_file = Path(args.hash_file)
+            if not args.hash_file.exists():
+                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
+                print(msg, file=sys.stderr)
+                sys.exit(-1)
         elif args.deployment:
             hash_file = args.deployment.parent.parent / "hashes.txt"
             args.hash_file = hash_file if hash_file.exists() else None

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -478,33 +478,6 @@ class DetectionParser(ParserBase):
         args.deployment = child_directories[0]
         return args
 
-class HashFileParser(ParserBase):
-    """Parser for detecting and loading the hashes.txt file for hash decoding"""
-
-    DESCRIPTION = "Hash file options"
-
-    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
-        return {
-            ("--hash-file",): {
-                "dest": "hash_file",
-                "action": "store",
-                "required": False,
-                "type": str,
-                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
-            }
-        }
-    
-    def handle_arguments(self, args, **kwargs):
-        if args.hash_file:
-            args.hash_file = Path(args.hash_file)
-            if not args.hash_file.exists():
-                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
-                print(msg, file=sys.stderr)
-                sys.exit(-1)
-        elif args.deployment:
-            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
-            args.hash_file = hash_file if hash_file.exists() else None
-        return args
 
 class BareArgumentParser(ParserBase):
     """Takes in the argument specification (used in plugins and get_arguments) to parse args
@@ -1069,6 +1042,39 @@ class DictionaryParser(DetectionParser):
         args.dictionaries = Dictionaries.load_dictionaries_into_config(
             args.dictionary, args.packet_spec, args.packet_set_name
         )
+        return args
+
+
+class HashFileParser(DetectionParser):
+    """Parser for detecting and loading the hashes.txt file for hash decoding"""
+
+    DESCRIPTION = "Hash file options"
+
+    def get_arguments(self)-> Dict[Tuple[str, ...], Dict[str, Any]]:
+        return {
+            ("--hash-file",): {
+                "dest": "hash_file",
+                "action": "store",
+                "required": False,
+                "type": str,
+                "help": "Path to hashes.txt file map (found under build-artifacts dir by default)",
+            }
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        if args.hash_file:
+            args.hash_file = Path(args.hash_file)
+            if not args.hash_file.exists():
+                msg = f"[ERROR] hash file location {args.hash_file} does not exist"
+                print(msg, file=sys.stderr)
+                sys.exit(-1)
+            return args
+
+        if args.deployment is None:
+            super().handle_arguments(args, **kwargs)
+        if args.deployment:
+            hash_file = (Path(args.deployment) / ".."/ ".." / "hashes.txt").resolve()
+            args.hash_file = hash_file if hash_file.exists() else None
         return args
 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -125,7 +125,7 @@ def launch_html(parsed_args):
         }
     )
     if parsed_args.hash_file:
-        flask_env.update({"HASH_FILE": parsed_args.hash_file})
+        flask_env.update({"FPRIME_HASHES_TXT_FILE": parsed_args.hash_file})
     gse_args = BASE_MODULE_ARGUMENTS + [
         "flask",
         "run",

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -122,9 +122,10 @@ def launch_html(parsed_args):
             "FLASK_APP": "fprime_gds.flask.app",
             "STANDARD_PIPELINE_ARGUMENTS": "|".join(reproduced_arguments),
             "SERVE_LOGS": "YES",
-            "BUILD_DIR": parsed_args.deployment.parent.parent
         }
     )
+    if parsed_args.hash_file:
+        flask_env.update({"HASH_FILE": parsed_args.hash_file})
     gse_args = BASE_MODULE_ARGUMENTS + [
         "flask",
         "run",

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -122,6 +122,7 @@ def launch_html(parsed_args):
             "FLASK_APP": "fprime_gds.flask.app",
             "STANDARD_PIPELINE_ARGUMENTS": "|".join(reproduced_arguments),
             "SERVE_LOGS": "YES",
+            "BUILD_DIR": parsed_args.deployment.parent.parent
         }
     )
     gse_args = BASE_MODULE_ARGUMENTS + [


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
https://github.com/nasa/fprime/issues/4666
|**_Has Unit Tests (y/n)_**|  |
n
|**_Documentation Included (y/n)_**|  |
n

---
## Change Description

This PR adds a check for hashed files during `EventData` initialization and automatically decodes and replaces any that are found for display to the user. It also adds a new variable `BUILD_DIR` to the environment of the flask app to allow the new code to find the hashed files no matter where `fprime-gds` is called.

## Rationale

As outlined in issue [4666](https://github.com/nasa/fprime/issues/4666) on the fprime repository, this change allows users to benefit from using hashed file names without needing to manually call `hash-to-file` whenever an assert is triggered. 

