### PR TITLE
Update fw_testing pytest integration to include using default configuration file

### DIFF
--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -1,4 +1,4 @@
-""" pytest_integration.py: F´ fixture API fixture
+"""pytest_integration.py: F´ fixture API fixture
 
 pytest uses fixtures to provide for extra functionality when writing tests. This fixture sets up the F´ stack allowing
 our tests to use a configured test API without needing to create any specific setup to use that API. i.e. write a test
@@ -14,18 +14,19 @@ Here a test (defined by starting the name with test_) uses the fprime_test_api f
 
 @author lestarch
 """
+
 import sys
 from pathlib import Path
 import pytest
 
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
-from fprime_gds.executables.cli import StandardPipelineParser
+from fprime_gds.executables.cli import StandardPipelineParser, ConfigDrivenParser
 
 SEQUENCE_COUNTER = -1
 
 
 def pytest_addoption(parser):
-    """ Add fprime-gds options to the pytest parser
+    """Add fprime-gds options to the pytest parser
 
     Pytest allows users to add options to its parser. These options act very similar to argparse options and thus can be
     reused from the standard GDS command line processing. Note: pytest restricts the use of short flags (-[a-z]) thus we
@@ -38,7 +39,7 @@ def pytest_addoption(parser):
         # Reduce flags to only the long option (i.e. --something) form
         flags = [flag for flag in flags if flag.startswith("--")]
         parser.addoption(*flags, **specifiers)
-        
+
     # Add an option to specify JUnit XML report file
     parser.addoption(
         "--junit-xml-file",
@@ -50,7 +51,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--gen-junitxml",
         action="store_true",
-        help="Enable JUnitXML report generation to a specified location"
+        help="Enable JUnitXML report generation to a specified location",
     )
     # Add an option to specify a json config file that maps components
     parser.addoption(
@@ -60,19 +61,26 @@ def pytest_addoption(parser):
         help="Path to JSON configuration file for mapping deployment components",
     )
 
+
 def pytest_configure(config):
-    """ This is a hook to allow plugins and conftest files to perform initial configuration
-    
-    This hook is called for every initial conftest file after command line options have been parsed. After that, the 
+    """This is a hook to allow plugins and conftest files to perform initial configuration
+
+    This hook is called for every initial conftest file after command line options have been parsed. After that, the
     hook is called for other conftest files as they are registered.
     """
     # Create a JUnit XML report file to capture the test result in a specified location
     if config.getoption("--gen-junitxml"):
-        config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption("--junit-xml-file")
+        config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption(
+            "--junit-xml-file"
+        )
 
-@pytest.fixture(scope='session')
+
+import argparse
+
+
+@pytest.fixture(scope="session")
 def fprime_test_api_session(request):
-    """ Create a session-level fprime test API
+    """Create a session-level fprime test API
 
     This is a pytest session fixture. Using the options added above, this will parse the necessary options for
     connecting the standard pipeline to the running GDS. This pipeline is supplied to the fprime test API returned as
@@ -90,12 +98,25 @@ def fprime_test_api_session(request):
         fprime test API connected to the GDS.  Note: a second call will shut down that object.
     """
     pipeline_parser = StandardPipelineParser()
+    # Get configuration file data
+    config_args, _, remaining = ConfigDrivenParser.parse_config_options()
+
+    # Create a parser that **parses but does not validate** the standard pipeline options
+    aparser = argparse.ArgumentParser()
+    for flags, specifiers in StandardPipelineParser().get_arguments().items():
+        # Reduce flags to only the long option (i.e. --something) form
+        flags = [flag for flag in flags if flag.startswith("--")]
+        aparser.add_argument(*flags, **specifiers)
+
+    # Parse the superset of configuration commandline args & actual command line args
+    config_arg_ns, _ = aparser.parse_known_args(config_args + remaining)
+
     pipeline = None
     api = None
     deployment_config = None
     try:
         # Parse the command line arguments into a client connection
-        arg_ns = pipeline_parser.handle_arguments(request.config.known_args_namespace, client=True)
+        arg_ns = pipeline_parser.handle_arguments(config_arg_ns, client=True)
 
         # Build a new pipeline with the parsed and processed arguments
         pipeline = pipeline_parser.pipeline_factory(arg_ns, pipeline)
@@ -126,9 +147,9 @@ def fprime_test_api_session(request):
             print(f"[WARNING] Exception in pipeline teardown: {exc}", file=sys.stderr)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def fprime_test_api(fprime_test_api_session, request):
-    """ Provide a per-testcase fixture
+    """Provide a per-testcase fixture
 
     Although the test API should exist across all testcases and thus be created at the "session" level, individual test
     cases need a clean test API that has logged the testcases has started. Thus, the session API is refined into a

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -15,9 +15,10 @@ Here a test (defined by starting the name with test_) uses the fprime_test_api f
 @author lestarch
 """
 
+import argparse
+import pytest
 import sys
 from pathlib import Path
-import pytest
 
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
 from fprime_gds.executables.cli import StandardPipelineParser, ConfigDrivenParser
@@ -73,9 +74,6 @@ def pytest_configure(config):
         config.option.xmlpath = Path(config.getoption("--logs")) / config.getoption(
             "--junit-xml-file"
         )
-
-
-import argparse
 
 
 @pytest.fixture(scope="session")

--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -96,10 +96,15 @@ def fprime_test_api_session(request):
         fprime test API connected to the GDS.  Note: a second call will shut down that object.
     """
     pipeline_parser = StandardPipelineParser()
+
+    # The next few lines use the ConfigDrivenParser to retrieve default configuration from a file. 
+    # ConfigDrivenParser.parse_args() can NOT be used directly because it includes validation 
+    # of all arguments (including defaults) which is not applicable here
+    
     # Get configuration file data
     config_args, _, remaining = ConfigDrivenParser.parse_config_options()
 
-    # Create a parser that **parses but does not validate** the standard pipeline options
+    # Create a parser for the standard pipeline options
     aparser = argparse.ArgumentParser()
     for flags, specifiers in StandardPipelineParser().get_arguments().items():
         # Reduce flags to only the long option (i.e. --something) form

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -18,6 +18,7 @@ import os
 import platform
 import re
 import sys
+import pathlib
 
 import yaml
 
@@ -315,16 +316,56 @@ class ConfigDrivenParser(ParserBase):
     line arguments will still take precedence over the configured values.
     """
 
+    #
     DEFAULT_CONFIGURATION_PATH = Path("fprime-gds.yml")
+
+    # Takes precendence over default path
+    DEFAULT_CONFIGURATION_PATH_ENV = "FPRIME_GDS_CONFIG_PATH"
 
     @classmethod
     def set_default_configuration(cls, path: Path):
         """Set path for (global) default configuration file
 
         Set the path for default configuration file. If unset, will use 'fprime-gds.yml'. Set to None to disable default
-        configuration.
+        configuration.Calling this function disables the environment variable override
         """
         cls.DEFAULT_CONFIGURATION_PATH = path
+        del os.environ[cls.DEFAULT_CONFIGURATION_PATH_ENV]
+
+    @classmethod
+    def get_default_configuration(cls):
+        """get path for (global) default configuration file
+        If set, the environment variable (cls.DEFAULT_CONFIGURATION_PATH) overrides default config.
+
+        Get the path for default configuration file. If unset, will use 'fprime-gds.yml'. Set to None to disable default
+        configuration.Calling this function disables the environment variable override
+        """
+        if cls.DEFAULT_CONFIGURATION_PATH_ENV in os.environ:
+            return pathlib.Path(os.environ[cls.DEFAULT_CONFIGURATION_PATH_ENV])
+        else:
+            return cls.DEFAULT_CONFIGURATION_PATH
+
+    @classmethod
+    def parse_config_options(
+        cls, description="No tool description provided", arguments=None, **kwargs
+    ):
+        """Parse the arguments from the configuraiton file
+
+        Parse the configuration data, return the configuration file settings converted to
+        cmd line arguments, the name-space for config arguments, and the remaining unknown
+        arguments
+
+         Args:
+             description: description passed ot the argument parser
+             arguments: arguments to process, None to use command line input
+         Returns: list of command line options, namespace for config arguments, list of unknown arguments
+        """
+        ns_config, _, remaining = ParserBase.parse_known_args(
+            [ConfigDrivenParser], description, arguments, **kwargs
+        )
+        config_options = ns_config.config_values.get("command-line-options", {})
+        config_args = cls.flatten_options(config_options)
+        return config_args, ns_config, remaining
 
     @classmethod
     def parse_args(
@@ -345,6 +386,8 @@ class ConfigDrivenParser(ParserBase):
             arguments: arguments to process, None to use command line input
         Returns: namespace with all parsed arguments from all provided ParserBase subclasses
         """
+        # If the FPRIME_GDS_CONFIG_PATH environment variable is set, set its value to be the default
+        # config path
         arguments = sys.argv[1:] if arguments is None else arguments
 
         # Help should spill all the arguments, so delegate to the normal parsing flow including
@@ -353,14 +396,12 @@ class ConfigDrivenParser(ParserBase):
             parsers = [ConfigDrivenParser] + parser_classes
             ParserBase.parse_args(parsers, description, arguments, **kwargs)
             sys.exit(0)
-
         # Custom flow involving parsing the arguments of this parser first, then passing the configured values
         # as part of the argument source
-        ns_config, _, remaining = ParserBase.parse_known_args(
-            [ConfigDrivenParser], description, arguments, **kwargs
+        config_args, ns_config, remaining = cls.parse_config_options(
+            description=description, arguments=arguments, **kwargs
         )
-        config_options = ns_config.config_values.get("command-line-options", {})
-        config_args = cls.flatten_options(config_options)
+
         # Argparse allows repeated (overridden) arguments, thus the CLI override is accomplished by providing
         # remaining arguments after the configured ones
         ns_full, parser = ParserBase.parse_args(
@@ -389,7 +430,7 @@ class ConfigDrivenParser(ParserBase):
             ("-c", "--config"): {
                 "dest": "config",
                 "required": False,
-                "default": self.DEFAULT_CONFIGURATION_PATH,
+                "default": self.get_default_configuration(),
                 "type": Path,
                 "help": "Argument configuration file path. [default: %(default)s]",
             }
@@ -971,7 +1012,6 @@ class MiddleWareParser(ParserBase):
             if is_client
             else args.tts_addr
         )
-
         args.connection_uri = f"tcp://{tts_connection_address}:{args.tts_port}"
         args.connection_transport = ThreadedTCPSocketClient
         if args.zmq:
@@ -1038,10 +1078,21 @@ class DictionaryParser(DetectionParser):
             args = super().handle_arguments(args, **kwargs)
             args.dictionary = find_dict(args.deployment)
 
-        # Load dictionaries into global config and add it to args namespace
-        args.dictionaries = Dictionaries.load_dictionaries_into_config(
+        # Setup dictionaries encoders and decoders
+        dictionaries = Dictionaries()
+
+        dictionaries.load_dictionaries(
             args.dictionary, args.packet_spec, args.packet_set_name
         )
+        config = ConfigManager.get_instance()
+        # Update config to use type definitions defined in the JSON dictionary
+        if dictionaries.typedefs_name:
+            for type_name, type_dict in dictionaries.typedefs_name.items():
+                config.set_type(type_name, type_dict)
+        if dictionaries.constant_name:
+            for name, value in dictionaries.constant_name.items():
+                config.set_constant(name, value)
+        args.dictionaries = dictionaries
         return args
 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -6,7 +6,6 @@
 import os
 import sys
 import copy
-import pathlib
 import webbrowser
 
 from fprime_gds.executables.cli import (
@@ -40,12 +39,7 @@ def parse_args():
         CommParser,
         PluginArgumentParser,
     ]
-    # If the FPRIME_GDS_CONFIG_PATH environment variable is set, set its value to be the default
-    # config path
-    if "FPRIME_GDS_CONFIG_PATH" in os.environ:
-        ConfigDrivenParser.set_default_configuration(
-            pathlib.Path(os.environ["FPRIME_GDS_CONFIG_PATH"])
-        )
+
     # Parse the arguments, and refine through all handlers
     args, parser = ConfigDrivenParser.parse_args(
         arg_handlers, "Run F prime deployment and GDS"


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  https://github.com/nasa/fprime/issues/4770 |
|**_Has Unit Tests (y/n)_**|  No |
|**_Documentation Included (y/n)_**| y (code comments) |

---
## Change Description

1. Updated `fprime_test_api_session` in `pytest_integration.py` to include default GDS configuration using the ConfigDrivenParser  class 
2.  Updated ConfigDrivenParser class to check the `FPRIME_GDS_CONFIG_PATH` as part of its default behavior (previously the default file path was included in the class implementation but the environment variable override of that path was only checked in run_deployment.py)

## Rationale

The rationale for updating `fprime_test_api_session`  was so that running `pytest` would pick up the same GDS defaults as `fprime-gds`  - without that feature in my environment, we'd need to have a bunch of different pytest configuration files to ensure the correct dictionary got used for different deployments being tested 

Updating the ConfigDrivenParser class was required to avoid environment variable name that could override the default configuration path being specified and handled in multiple locations (previously only in run_deployment.py, but the updates to pytest_integration.py would've also required it) 

## Testing/Review Recommendations

To test: 
1. Create a fprime-gds.yml with unique configuration in a directory with tests, run pytest and verify those settings are picked up 
2. Create a fprime-gds.yml in a different location, set the FPRIME_GDS_CONFIG_PATH environment variable with the path to that file,  run pytest and verify those settings are picked up 
3. Verify pytest uses normal defaults when FPRIME_GDS_CONFIG_PATH  is not set and there's no prime-gds.yml in the current directory 

## Future Work

Note any additional work that will be done relating to this issue.
