### PR TITLE
fix hex display of telemetry and event ids in gds gui

### DIFF
--- a/src/fprime_gds/flask/static/js/datastore.js
+++ b/src/fprime_gds/flask/static/js/datastore.js
@@ -263,7 +263,7 @@ class DataStore {
         // because rendering of edit-views is still possible.
         let channels = {};
         for (let key in _dictionaries.channels) {
-            channels[key] = {id: key, time: null, datetime: null, val: null};
+            channels[key] = {id: Number(key), time: null, datetime: null, val: null};
         }
         Object.assign(this.channels, channels); // Forces new channel map into Vue maintaining the original object
         this.commands = _dictionaries.commands;

--- a/src/fprime_gds/flask/static/js/vue-support/channel.js
+++ b/src/fprime_gds/flask/static/js/vue-support/channel.js
@@ -6,7 +6,7 @@
  *
  * @author mstarch
  */
-import {listExistsAndItemNameNotInList, timeToString} from "./utils.js"
+import {listExistsAndItemNameNotInList, timeToString, formatHexId} from "./utils.js"
 import "./fptable.js";
 import {_datastore, _dictionaries} from "../datastore.js";
 
@@ -66,9 +66,9 @@ Vue.component("channel-table", {
         columnify(item) {
             let template = _dictionaries.channels[item.id];
             if (item.time == null || item.val == null) {
-                return ["", "0x" + item.id.toString(16), template.full_name, ""];
+                return ["", formatHexId(item.id), template.full_name, ""];
             }
-            return [timeToString(item.time), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time), formatHexId(item.id), template.full_name,
                 (typeof(item.display_text) !== "undefined")? item.display_text : item.val]
         },
         /**
@@ -150,7 +150,7 @@ Vue.component("channel-table", {
         clearChannels() {
             let channels = {}
             for (let key in _dictionaries.channels) {
-                channels[key] = {id: key, time: null, datetime: null, val: null};
+                channels[key] = {id: Number(key), time: null, datetime: null, val: null};
             }
             Object.assign(_datastore.channels, channels);
             this.$refs.fptable.send([]);

--- a/src/fprime_gds/flask/static/js/vue-support/event.js
+++ b/src/fprime_gds/flask/static/js/vue-support/event.js
@@ -7,7 +7,7 @@
  *
  * @author mstarch
  */
-import {listExistsAndItemNameNotInList, timeToString} from "./utils.js";
+import {listExistsAndItemNameNotInList, timeToString, formatHexId} from "./utils.js";
 import {_datastore,_dictionaries} from "../datastore.js";
 
 let OPREG = /Opcode (0x[0-9a-fA-F]+)/;
@@ -80,7 +80,7 @@ Vue.component("event-list", {
                 const msg = '<span title="' + groups[0] + '">' + command_mnemonic + '</span>'
                 display_text = display_text.replace(OPREG, msg);
             }
-            return [timeToString(item.time), "0x" + item.id.toString(16), template.full_name,
+            return [timeToString(item.time), formatHexId(item.id), template.full_name,
                 template.severity.value.replace("EventSeverity.", ""), display_text];
         },
         /**

--- a/src/fprime_gds/flask/static/js/vue-support/utils.js
+++ b/src/fprime_gds/flask/static/js/vue-support/utils.js
@@ -444,3 +444,13 @@ export class ScrollHandler {
         return user_scrolled;
     }
 }
+
+// converts id to proper hex string, handles both number and string ids
+// since js object keys are always strings, .toString(16) on a string
+// just returns the string as-is wich causes the decimal-with-0x-prefix bug
+export function formatHexId(id) {
+    if (id == null) {
+        return "";
+    }
+    return "0x" + BigInt(id).toString(16);
+}


### PR DESCRIPTION
## Summary

- fixed the channel and event id display in the gds gui - ids were showing 
  up as decimal values with a 0x prefix (eg 0x268455937 instead of 0x10005001)
- the root cause was that js object keys from the dictionary are always strings,
  and calling .toString(16) on a string just returns it as-is, ignoring the radix
- this was intermittent, it happend mostly before telemetry data arrived or 
  right after clicking "Clear" on channels, because thats when item.id was 
  still a string from the dictionary key initialization
- added a formatHexId() helper in utils.js that properly converts to hex 
  using BigInt, so it works regardless of wether the id comes in as a number, 
  string, or bigint

## Changes

- `datastore.js`: cast dictionary key to Number when initializing channel ids
- `channel.js`: same fix in clearChannels(), replaced manual hex conversion 
  with formatHexId()
- `event.js`: replaced manual hex conversion with formatHexId()
- `utils.js`: added formatHexId() utility function

## Test plan

- [ ] Start fprime-gds with a deployment that produces telemetry
- [ ] Check channel tab - ids should show proper hex (0x10005001 not 0x268455937)
- [ ] Check event tab - same thing
- [ ] Click "Clear" on channels and verify ids still display correctly
- [ ] Verify channels that havent received data yet also show hex correctly

Fixes nasa/fprime#4717