### PR TITLE
Optimize DataProductDecoder for large numerical arrays

### DIFF
--- a/src/fprime_gds/common/dp/decoder.py
+++ b/src/fprime_gds/common/dp/decoder.py
@@ -14,11 +14,12 @@ Key differences from the original implementation:
 @date: January 2026
 """
 
+import dataclasses
 import json
+import struct
 import sys
 from pathlib import Path
 from typing import Dict, List, Any, Optional
-import dataclasses
 
 from fprime_gds.common.dp.common import (
     ChecksumConfig,
@@ -26,6 +27,7 @@ from fprime_gds.common.dp.common import (
     get_dp_header_type,
 )
 from fprime_gds.common.models.dictionaries import Dictionaries
+from fprime_gds.common.models.serialize.numerical_types import NumericalType
 from fprime_gds.common.utils.config_manager import ConfigManager
 from fprime_gds.common.templates.dp_record_template import DpRecordTemplate
 
@@ -101,6 +103,34 @@ class DataProductDecoder:
         else:
             self.output_json_path = output_json_path
         
+    @staticmethod
+    def _batch_deserialize_numerical_array(file_handle, record_type, array_size) -> List[Dict[str, Any]]:
+        """Batch-read and deserialize an array of fixed-size numerical types.
+
+        Reads the entire array in one I/O operation and uses struct.unpack_from
+        with a batched format string, avoiding per-element overhead.
+
+        Args:
+            file_handle: file handle positioned at the start of the array data
+            record_type: NumericalType subclass (e.g. U8Type, U32Type, F64Type)
+            array_size: number of elements in the array
+
+        Returns:
+            List of JSON-serializable dicts, one per element
+        """
+        element_size = record_type.getSize()
+        total_bytes = array_size * element_size
+        buffer = file_handle.read(total_bytes)
+
+        # Build a batch format string (e.g. ">10000B" for 10000 U8s)
+        base_format = record_type.get_serialize_format().lstrip(">")
+        batch_format = f">{array_size}{base_format}"
+        values = struct.unpack_from(batch_format, buffer, 0)
+
+        # Build JSON list with type name computed once
+        type_name = record_type.get_canonical_name()
+        return [{"value": val, "type": type_name} for val in values]
+
     def decode_header(self, file_handle) -> Dict[str, Any]:
         """Decode the data product header.
 
@@ -184,12 +214,17 @@ class DataProductDecoder:
             array_size = array_size_type.val
 
             record['Size'] = array_size
-            record['Data'] = []
 
-            # Read each array element
-            for _ in range(array_size):
-                element_instance = read_element(record_type)
-                record['Data'].append(element_instance.to_jsonable())
+            if issubclass(record_type, NumericalType) and array_size > 0:
+                record['Data'] = self._batch_deserialize_numerical_array(
+                    file_handle, record_type, array_size
+                )
+            else:
+                # General path for complex or variable-length types
+                record['Data'] = []
+                for _ in range(array_size):
+                    element_instance = read_element(record_type)
+                    record['Data'].append(element_instance.to_jsonable())
         else:
             # For scalar records, read the single value
             element_instance = read_element(record_type)
@@ -267,4 +302,3 @@ class DataProductDecoder:
         except Exception as e:
             print(f"Unexpected error: {e}", file=sys.stderr)
             raise
-


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [nasa/fprime#4784](https://github.com/nasa/fprime/issues/4784) |
|**_Has Unit Tests (y/n)_**| y (existing tests cover this change — 25/25 pass) |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Add a batch deserialization fast path in DataProductDecoder.decode_record() for arrays of NumericalType (U8, U16, U32, U64, I8, I16, I32, I64, F32, F64).

Instead of calling read_element() once per array element, the entire array is read in a single I/O operation and deserialized with one struct.unpack_from() call using a batched format string via a dedicated helper method [_batch_deserialize_numerical_array()](file:///home/uolabie/open-source/forked/fprime-gds/src/fprime_gds/common/dp/decoder.py#106-133). Non numerical types (structs, enums, strings) continue to use the original per element path.

The JSON output format is unchanged.

## Rationale

Fixes a performance bottleneck where decoding a 12MB data product with U8 arrays took ~45 seconds due to [read_element()](file:///home/uolabie/open-source/forked/fprime-gds/src/fprime_gds/common/dp/decoder.py#190-207) being called ~11.5 million times. Benchmarked by @kubiak-jpl at 1.451s after this change (~31x speedup).

## Benchmark

Profiling the U8 array test file (6 records × 300 U8 elements) decoded 200 times:

```
         317001 function calls (309801 primitive calls) in 0.241 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      200    0.010    0.000    0.241    0.001 decoder.py:235(decode)
     1200    0.009    0.000    0.102    0.000 decoder.py:160(decode_record)
      200    0.002    0.000    0.095    0.000 decoder.py:134(decode_header)
     1200    0.054    0.000    0.060    0.000 decoder.py:106(_batch_deserialize_numerical_array)
    15600    0.008    0.000    0.025    0.000 type_base.py:98(to_jsonable)
    20800    0.013    0.000    0.015    0.000 numerical_types.py:35(getSize)
    10800    0.007    0.000    0.011    0.000 numerical_types.py:57(deserialize)
    16000    0.006    0.000    0.010    0.000 type_base.py:45(__repr__)
```

[read_element](file:///home/uolabie/open-source/forked/fprime-gds/src/fprime_gds/common/dp/decoder.py#190-207) no longer appears in the profile — numerical arrays are fully handled by [_batch_deserialize_numerical_array](file:///home/uolabie/open-source/forked/fprime-gds/src/fprime_gds/common/dp/decoder.py#106-133) in a single I/O + struct.unpack_from call per record.

@kubiak-jpl also independently benchmarked this PR against the original 12MB data product from [#4784](https://github.com/nasa/fprime/issues/4784) and confirmed the improvement (45.6s → 1.45s).

## Testing/Review Recommendations

Run the decoder test suite:

`pytest test/fprime_gds/common/dp/test_decoder.py -v`

- All 25 existing tests pass without modification, including array type tests (test_decode_u8_array, test_decode_u32_array, test_decode_data_array, test_decode_fpp_array).
- The `issubclass(record_type, NumericalType)` check ensures only fixed-size types use the fast path. Variable-length or complex types fall through to the original loop.
- Review that the batch format string construction correctly strips and re-applies the big-endian prefix.

## Future Work

- The JSON output currently repeats `{"value": N, "type": "U8"}` for every element. A future optimization could store the type name once per array record rather than per element, further reducing memory and serialization overhead (as noted in the original issue discussion).

- An [issue](https://github.com/nasa/fprime/issues/4806) is already open for this.