### PR TITLE
Issue#457-Add ability to send raw packets as a command to an F' deployment

### DIFF
--- a/src/fprime_gds/common/gds_cli/send_raw.py
+++ b/src/fprime_gds/common/gds_cli/send_raw.py
@@ -1,0 +1,86 @@
+"""
+Handles executing the "send-raw" CLI command for the GDS
+"""
+import sys
+import struct
+from typing import Iterable
+
+from fprime_gds.common.gds_cli.base_commands import BaseCommand
+from fprime_gds.common.models.dictionaries import Dictionaries
+from fprime_gds.common.testing_fw import predicates
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+
+
+def frame_ccsds(payload: bytes, apid: int = 0x64) -> bytes:
+    """Standard CCSDS Primary Header (6 bytes)."""
+    word1 = 0x1000 | (apid & 0x7FF)
+    word2 = 0xC000
+    length_field = len(payload) - 1
+    return struct.pack(">HHH", word1, word2, length_field) + payload
+
+
+def frame_native(payload: bytes) -> bytes:
+    """Standard Native F Prime framing (8 bytes: Sync + Length)."""
+    sync = 0x55555555
+    length = len(payload)
+    return struct.pack(">II", sync, length) + payload
+
+
+def _get_fsw_routing_dest():
+    try:
+        from fprime_gds.common.transport import RoutingTag
+        return RoutingTag.FSW
+    except (ImportError, AttributeError):
+        return "FSW"
+
+
+def _send_to_fsw(client_socket, payload: bytes) -> None:
+    import inspect
+    sig = inspect.signature(client_socket.send)
+    if len(sig.parameters) >= 2:
+        dest = _get_fsw_routing_dest()
+        client_socket.send(payload, dest)
+    else:
+        client_socket.send(payload)
+
+
+class SendRawCommand(BaseCommand):
+    @classmethod
+    def _get_item_list(cls, project_dictionary, filter_predicate) -> Iterable:
+        return []
+
+    @classmethod
+    def _get_item_string(cls, item, json: bool = False) -> str:
+        return ""
+
+    @classmethod
+    def _execute_command(cls, args, api: IntegrationTestAPI):
+        # 1. Parse hex input
+        try:
+            hex_data = "".join(args.hex_strings).replace(" ", "")
+            raw_input = bytes.fromhex(hex_data)
+        except ValueError as e:
+            cls._log(f"ERROR: Invalid hex: {e}")
+            sys.exit(1)
+
+        # 2. Apply chosen framing
+        if args.format == "none":
+            payload = raw_input
+            mode_str = "BYPASS (Verbatim)"
+        elif args.format == "native":
+            payload = frame_native(raw_input)
+            mode_str = "NATIVE (0x55555555)"
+        else:
+            payload = frame_ccsds(raw_input)
+            mode_str = "CCSDS (APID 0x64)"
+
+        cls._log(f"[send-raw] Mode    : {mode_str}")
+        cls._log(f"[send-raw] Sending : {payload.hex().upper()}")
+
+        # 3. Transmit
+        try:
+            _send_to_fsw(api.pipeline.client_socket, payload)
+            cls._log("[send-raw] Status  : SUCCESS")
+        except Exception as exc:
+            cls._log(f"[send-raw] ERROR   : {exc}")
+            sys.exit(1)

--- a/src/fprime_gds/executables/fprime_cli.py
+++ b/src/fprime_gds/executables/fprime_cli.py
@@ -21,6 +21,7 @@ import importlib.metadata
 # import fprime_gds.common.gds_cli.channels as channels
 # import fprime_gds.common.gds_cli.command_send as command_send
 # import fprime_gds.common.gds_cli.events as events
+# import fprime_gds.common.gds_cli.send_raw as send_raw
 # from fprime_gds.common.pipeline.dictionaries import Dictionaries
 from fprime_gds.executables.cli import (
     RetrievalArgumentsParser,
@@ -318,6 +319,53 @@ class EventsSubparserInjector(CliSubparserInjectorBase):
         events.EventsCommand.handle_arguments(parsed_args, **kwargs)
 
 
+class SendRawSubparserInjector(CliSubparserInjectorBase):
+    """
+    A parser for the "send-raw" CLI command, which lets users send raw data
+    packets to an F' instance, either in the CCSDS format, native F' format, or
+    raw hex values. This is used for off-nominal command testing of an F' instance.
+    """
+    @classmethod
+    def create_subparser(cls, parent_parser: argparse.ArgumentParser):
+        return parent_parser.add_parser(
+            "send-raw",
+            description="Send raw hex bytes into the FSW stream with optional framing",
+        )
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser):
+        add_connection_arguments(parser)
+        add_search_arguments(parser, "send-raw") 
+        
+        parser.add_argument(
+            "hex_strings", 
+            nargs="+", 
+            help="Hex strings to send (e.g., DEADBEEF)"
+        )
+        parser.add_argument(
+            "--format",
+            choices=["ccsds", "native", "none"],
+            default="ccsds",
+            help="Framing format: 'ccsds' (6-byte), 'native' (F-Prime 8-byte), or 'none' (verbatim)"
+        )
+        parser.add_argument(
+            "--bypass-framer",
+            action="store_true",
+            help="Shortcut for --format none (Adversary Mode)"
+        )
+
+    @classmethod
+    def validate_args(cls, parser: argparse.ArgumentParser, args: argparse.Namespace):
+        if args.bypass_framer:
+            args.format = "none"
+        return super().validate_args(parser, args)
+
+    @classmethod
+    def command_func(cls, parsed_args, **kwargs):
+        import fprime_gds.common.gds_cli.send_raw as send_raw
+        send_raw.SendRawCommand.handle_arguments(parsed_args, **kwargs)
+
+
 def create_parser():
     parser = argparse.ArgumentParser(
         description="provides utilities for interacting with the F' Ground Data System (GDS)"
@@ -330,7 +378,7 @@ def create_parser():
     ChannelsSubparserInjector.inject_subparser(subparser_root)
     CommandSubparserInjector.inject_subparser(subparser_root)
     EventsSubparserInjector.inject_subparser(subparser_root)
-
+    SendRawSubparserInjector.inject_subparser(subparser_root)
     return parser
 
 


### PR DESCRIPTION
Issue#457-Add ability to send raw packets as a command to an F' deployment.

| | |
|:---|:---|
|** v4.1.1 **|  |
|**_N_**|  |
|**_N_**|  |

---
## Change Description

This PR is adding new functionality to the GDS fprime-cli command tool to send raw data packets to an F Prime deployment. 

## Rationale

While the standard command-send utility is sufficient for nominal operations, it enforces strict encoding based on the project dictionary. This feature is very beneficial to test how F Prime responds to commands that are malformed or corrupted. It also helps testing the robustness of F Prime to "Command Fuzzing" or "Command Packet Injection" conditions.  It also has three options when sending raw packets, CCSDS format, native "F Prime" format, and raw (bypass mode). The default format is CCSDS.

Below are examples of  the use of the new functionality:
1) fprime-cli send-raw DEADBEEF  --tts-addr 127.0.0.1
2) fprime-cli send-raw DEADBEEF  --format native  --tts-addr 127.0.0.1
3) fprime-cli send-raw 41414141  --bypass-framer  --tts-addr 127.0.0.1

## Testing/Review Recommendations

I performed the following regression testing to verify the core functionality of the fprime-cli utility was not impacted by this new functionality. 

Below is the output:
### Events
fprime-cli events -s ACTIVITY_HI --tts-addr 127.0.0.1
2026-03-13T00:28:33.282016: CdhCore.cmdDisp.NoOpReceived (16777223) (2(0)-1773386913:282016) EventSeverity.ACTIVITY_HI : Received a NO-OP command
2026-03-13T00:28:34.689026: CdhCore.cmdDisp.NoOpReceived (16777223) (2(0)-1773386914:689026) EventSeverity.ACTIVITY_HI : Received a NO-OP command

### Channels
fprime-cli channels -s cmdDisp.CommandsDispatched  --tts-addr 127.0.0.1
2026-03-13T00:30:02.202999: CdhCore.cmdDisp.CommandsDispatched (16777216) (2(0)-1773387002:202999) 10
2026-03-13T00:30:03.202981: CdhCore.cmdDisp.CommandsDispatched (16777216) (2(0)-1773387003:202981) 12

### Send Command
fprime-cli command-send  --tts-addr 127.0.0.1
2026-03-13T07:12:28.775Z | 0x1000001 | CdhCore.cmdDisp.OpCodeDispatched | COMMAND | CdhCore.cmdDisp.CMD_NO_OP dispatched to port 0
-- | -- | -- | -- | --
2026-03-13T07:12:28.775Z | 0x1000007 | CdhCore.cmdDisp.NoOpReceived | ACTIVITY_HI | Received a NO-OP command
2026-03-13T07:12:28.776Z | 0x1000002 | CdhCore.cmdDisp.OpCodeCompleted | COMMAND | CdhCore.cmdDisp.CMD_NO_OP completed

## Future Work

N/A
