### PR TITLE
Serializable ArrayType Optimization

### DIFF
--- a/src/fprime_gds/common/dp/decoder.py
+++ b/src/fprime_gds/common/dp/decoder.py
@@ -185,7 +185,7 @@ class DataProductDecoder:
             array_size = array_size_type.val
 
             element_array_type = ArrayType.construct_type(
-                record_template.get_name(), record_type, array_size, "{}"
+                f'{record_template.get_name()}_{array_size}', record_type, array_size, "{}"
             )
 
             element_instance = read_element(element_array_type)

--- a/src/fprime_gds/common/dp/decoder.py
+++ b/src/fprime_gds/common/dp/decoder.py
@@ -26,6 +26,7 @@ from fprime_gds.common.dp.common import (
     get_dp_header_type,
 )
 from fprime_gds.common.models.dictionaries import Dictionaries
+from fprime_gds.common.models.serialize.array_type import ArrayType
 from fprime_gds.common.utils.config_manager import ConfigManager
 from fprime_gds.common.templates.dp_record_template import DpRecordTemplate
 
@@ -183,13 +184,12 @@ class DataProductDecoder:
             array_size_type.deserialize(array_size_data, 0)
             array_size = array_size_type.val
 
-            record['Size'] = array_size
-            record['Data'] = []
+            element_array_type = ArrayType.construct_type(
+                record_template.get_name(), record_type, array_size, "{}"
+            )
 
-            # Read each array element
-            for _ in range(array_size):
-                element_instance = read_element(record_type)
-                record['Data'].append(element_instance.to_jsonable())
+            element_instance = read_element(element_array_type)
+            record['Data'] = element_instance.to_jsonable()
         else:
             # For scalar records, read the single value
             element_instance = read_element(record_type)

--- a/src/fprime_gds/common/models/serialize/array_type.py
+++ b/src/fprime_gds/common/models/serialize/array_type.py
@@ -77,11 +77,15 @@ class ArrayType(DictionaryType):
         :return a formatted array
         """
         result = []
-        for item in self._val:
-            if hasattr(item, "formatted_val"):
-                result.append(item.formatted_val)
-            else:
-                result.append(self.FORMAT.format(item.val))
+        if self._is_numerical_array():
+            for item in self._val:
+                result.append(self.FORMAT.format(item))
+        else:
+            for item in self._val:
+                if hasattr(item, "formatted_val"):
+                    result.append(item.formatted_val)
+                else:
+                    result.append(self.FORMAT.format(item.val))
         return result
 
     @val.setter

--- a/src/fprime_gds/common/models/serialize/array_type.py
+++ b/src/fprime_gds/common/models/serialize/array_type.py
@@ -143,7 +143,7 @@ class ArrayType(DictionaryType):
 
     def deserialize(self, data, offset):
         """Deserialize the members of the array"""
-        if issubclass(self.MEMBER_TYPE, NumericalType) and self.LENGTH > 0:
+        if self._is_numerical_array() and self.LENGTH > 0:
             try:
                 value_format_raw = self.MEMBER_TYPE().get_serialize_format()
                 value_endian = ''

--- a/src/fprime_gds/common/models/serialize/array_type.py
+++ b/src/fprime_gds/common/models/serialize/array_type.py
@@ -64,7 +64,7 @@ class ArrayType(DictionaryType):
         if self._val is None:
             return None
         elif self._is_numerical_array():
-            return [item for item in self._val]
+            return list(self._val)
         else:
             return [item.val for item in self._val]
 
@@ -95,7 +95,7 @@ class ArrayType(DictionaryType):
         """
         self.validate(val)
         if self._is_numerical_array():
-            items = [item for item in val]
+            items = list(val)
         else:
             items = [self.MEMBER_TYPE(item) for item in val]
         self._val = items
@@ -104,11 +104,12 @@ class ArrayType(DictionaryType):
         """
         JSONable array object format
         """
-        if self._is_numerical_array():
-            vals = self._val
+        if self._val is None:
+            vals = None
+        elif self._is_numerical_array():
+            vals = list(self._val)
         else:
-            vals = None if self._val is None \
-                        else [member.val for member in self._val] 
+            vals = [member.val for member in self._val]
         return {
             "name": self.__class__.__name__,
             "type": self.__class__.__name__,
@@ -149,7 +150,7 @@ class ArrayType(DictionaryType):
                 value_format = value_format_raw.strip('><')
 
                 array_format = f"{value_endian}{self.LENGTH}{value_format}"
-                values = struct.unpack_from(array_format, data, offset)
+                values = list(struct.unpack_from(array_format, data, offset))
             except Exception as exc:
                 raise DeserializeException(
                     f"Array NumericalType optimization failed to deserialize: {exc}"

--- a/src/fprime_gds/common/models/serialize/array_type.py
+++ b/src/fprime_gds/common/models/serialize/array_type.py
@@ -4,6 +4,8 @@ Created on May 29, 2020
 @author: jishii
 """
 
+import struct
+
 from .type_base import DictionaryType
 from .type_exceptions import (
     ArrayLengthException,
@@ -11,6 +13,7 @@ from .type_exceptions import (
     TypeMismatchException,
     DeserializeException,
 )
+from .numerical_types import NumericalType
 
 
 class ArrayType(DictionaryType):
@@ -47,6 +50,9 @@ class ArrayType(DictionaryType):
         for i in range(cls.LENGTH):
             cls.MEMBER_TYPE.validate(val[i])
 
+    def _is_numerical_array(self) -> bool:
+        return issubclass(self.MEMBER_TYPE, NumericalType)
+
     @property
     def val(self) -> list:
         """
@@ -55,7 +61,12 @@ class ArrayType(DictionaryType):
 
         :return dictionary of member names to python values of member keys
         """
-        return None if self._val is None else [item.val for item in self._val]
+        if self._val is None:
+            return None
+        elif self._is_numerical_array():
+            return [item for item in self._val]
+        else:
+            return [item.val for item in self._val]
 
     @property
     def formatted_val(self) -> list:
@@ -83,49 +94,86 @@ class ArrayType(DictionaryType):
         :param val: dictionary containing python types to key names. This
         """
         self.validate(val)
-        items = [self.MEMBER_TYPE(item) for item in val]
+        if self._is_numerical_array():
+            items = [item for item in val]
+        else:
+            items = [self.MEMBER_TYPE(item) for item in val]
         self._val = items
 
     def to_jsonable(self):
         """
         JSONable array object format
         """
+        if self._is_numerical_array():
+            vals = self._val
+        else:
+            vals = None if self._val is None \
+                        else [member.val for member in self._val] 
         return {
             "name": self.__class__.__name__,
             "type": self.__class__.__name__,
             "size": self.LENGTH,
             "format": self.FORMAT,
-            "values": (
-                None
-                if self._val is None
-                else [member.to_jsonable() for member in self._val]
-            ),
+            "value_type": repr(self.MEMBER_TYPE()),
+            "values": vals,
         }
 
     def serialize(self):
         """Serialize the array by serializing the elements one by one"""
         if self.val is None:
             raise NotInitializedException(type(self))
-        return b"".join([item.serialize() for item in self._val])
+        if self._is_numerical_array():
+            value_format_raw = self.MEMBER_TYPE().get_serialize_format()
+            value_endian = ''
+            if self.MEMBER_TYPE.getSize() > 1:
+                assert value_format_raw[0] in ('>', '<'), \
+                       f'Expected explicit endian numerical type format but found {value_format_raw}'
+                value_endian = value_format_raw[0]
+            value_format = value_format_raw.strip('><')
+
+            array_format = f"{value_endian}{self.LENGTH}{value_format}"
+            return struct.pack(array_format, *self._val)
+        else:
+            return b"".join([item.serialize() for item in self._val])
 
     def deserialize(self, data, offset):
         """Deserialize the members of the array"""
-        values = []
-        for field_index in range(self.LENGTH):
+        if issubclass(self.MEMBER_TYPE, NumericalType) and self.LENGTH > 0:
             try:
-                item = self.MEMBER_TYPE()
-                item.deserialize(data, offset)
-                offset += item.getSize()
-                values.append(item)
+                value_format_raw = self.MEMBER_TYPE().get_serialize_format()
+                value_endian = ''
+                if self.MEMBER_TYPE.getSize() > 1:
+                    assert value_format_raw[0] in ('>', '<'), \
+                           f'Expected explicit endian numerical type format but found {value_format_raw}'
+                    value_endian = value_format_raw[0]
+                value_format = value_format_raw.strip('><')
+
+                array_format = f"{value_endian}{self.LENGTH}{value_format}"
+                values = struct.unpack_from(array_format, data, offset)
             except Exception as exc:
                 raise DeserializeException(
-                    f"Array index {field_index} failed to deserialize: {exc}"
+                    f"Array NumericalType optimization failed to deserialize: {exc}"
                 )
+        else:
+            values = []
+            for field_index in range(self.LENGTH):
+                try:
+                    item = self.MEMBER_TYPE()
+                    item.deserialize(data, offset)
+                    offset += item.getSize()
+                    values.append(item)
+                except Exception as exc:
+                    raise DeserializeException(
+                        f"Array index {field_index} failed to deserialize: {exc}"
+                    )
         self._val = values
 
     def getSize(self):
         """Return the size in bytes of the array"""
-        return sum(item.getSize() for item in self._val)
+        if self._is_numerical_array():
+            return self.MEMBER_TYPE.getMaxSize() * len(self._val)
+        else:
+            return sum(item.getSize() for item in self._val)
 
     @classmethod
     def getMaxSize(cls):

--- a/test/fprime_gds/common/dp/test_decoder.py
+++ b/test/fprime_gds/common/dp/test_decoder.py
@@ -175,9 +175,9 @@ class TestDataProductDecoderArrayTypes:
         
         # Array records should have a Size field
         record = result["Records"][0]
-        assert "Size" in record
         assert "Data" in record
-        assert isinstance(record["Data"], list)
+        assert "size" in record["Data"]
+        assert isinstance(record["Data"]["values"], list)
     
     def test_decode_u32_array(self, load_dictionary, tmp_path):
         """Test decoding of U32 array data product."""
@@ -191,9 +191,9 @@ class TestDataProductDecoderArrayTypes:
         assert "Header" in result
         assert "Records" in result
         record = result["Records"][0]
-        assert "Size" in record
         assert "Data" in record
-        assert isinstance(record["Data"], list)
+        assert "size" in record["Data"]
+        assert isinstance(record["Data"]["values"], list)
     
     def test_decode_data_array(self, load_dictionary, tmp_path):
         """Test decoding of Data array data product."""
@@ -397,10 +397,10 @@ class TestDataProductDecoderRecordDecoding:
         assert len(records) > 0
         
         record = records[0]
-        assert "Size" in record
         assert "Data" in record
-        assert isinstance(record["Data"], list)
-        assert len(record["Data"]) == record["Size"]
+        assert "size" in record["Data"]
+        assert isinstance(record["Data"]["values"], list)
+        assert len(record["Data"]["values"]) == record["Data"]["size"]
 
 
 class TestDataProductDecoderIntegration:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/4848,  |
|**_Has Unit Tests (y/n)_**| Updated existing unit tests |
|**_Documentation Included (y/n)_**| no new documentation |

---
## Change Description

- Adds an optimization in ArrayType when handing NumericalArray instances
  - Decreases the memory needed for each entry
  - Decreases the time to deserialize an entry
- Change json format of ArrayTypes to encode the member type information once, instead of in each entry
- Updates the Data Product decoder script to parse ArrayRecords as ArrayType structures
  - ArrayRecord json format now matches the format of arrays inside serializables
  - Speed up decoding of ArrayRecord entries

This is a breaking change for any scripts using the data produce parsing framework or working with and array serializable types

This builds of work by @olabie2 here https://github.com/nasa/fprime-gds/pull/289

## Rationale

Address memory usage for large arrays
https://github.com/nasa/fprime/issues/4848

Decrease decoding speed for large numerical arrays
https://github.com/nasa/fprime/issues/4784

## Testing/Review Recommendations

I've tested the current state of this PR on the unit tests and the data product parsing scripts, but it still needs wider testing on a GDS instance. I also need to test with arrays of structures that don't hit the optimizations here

## Open Questions

- Capitalized record dictionary keys ("Data", "Record") vs. lower case serializable keys ("size", "value", "values")
  - Should this inconsistency be addressed?
- Should the special optimization cases be handled by a subtype of ArrayType or through if else statements?