### PR TITLE
Add `fprime-cli send-raw` command for raw packets

### DIFF
--- a/src/fprime_gds/common/gds_cli/base_commands.py
+++ b/src/fprime_gds/common/gds_cli/base_commands.py
@@ -149,7 +149,7 @@ class BaseCommand(abc.ABC):
             pipeline_parser.handle_arguments(args, **kwargs, client=True)
 
             # If the user is just listing all possible items, do that and exit
-            if args.is_printing_list:
+            if hasattr(args, "is_printing_list") and args.is_printing_list:
                 search_filter = cls._get_search_filter(
                     args.ids, args.components, args.search, args.json
                 )
@@ -164,6 +164,13 @@ class BaseCommand(abc.ABC):
             pipeline = pipeline_parser.pipeline_factory(args)
             api = IntegrationTestAPI(pipeline)
             api.setup()
+
+            if hasattr(args, "zmq") and args.zmq:
+                import time
+                # Brief delay to allow ZMQ PUB/SUB subscription propagation to complete.
+                # Without this, one-shot commands are silently dropped due to the
+                # ZMQ "slow joiner" problem.
+                time.sleep(0.1)
 
             # Execute the command logic
             cls._execute_command(args, api)

--- a/src/fprime_gds/common/gds_cli/send_raw.py
+++ b/src/fprime_gds/common/gds_cli/send_raw.py
@@ -2,6 +2,7 @@
 Handles executing the "send-raw" CLI command for the GDS
 """
 
+import struct
 import sys
 from pathlib import Path
 
@@ -72,10 +73,18 @@ class SendRawCommand(BaseCommand):
             cls._log("Error: Either --bin-path or --hex-string must be provided")
             sys.exit(1)
 
-        # Send raw data through the client socket (framing layer)
+        # Send raw data through the client socket (to comm.py)
+        # The ZMQ transport strips the
+        # first 4 bytes on the receiving end (ZmqGround.receive_all) because the
+        # normal encoder path (via CmdEncoder) includes them after the ZZZZ marker.
         try:
-            cls._log(f"Sending {len(raw_data)} bytes of raw data...")
-            api.pipeline.client_socket.send(raw_data)
+            data_to_send = raw_data
+            if args.zmq:
+                # If using ZMQ, prepend the length of the data as a 4-byte big-endian integer
+                data_to_send = struct.pack(">I", len(raw_data)) + raw_data
+            
+            cls._log(f"Sending {len(raw_data)} bytes of raw data: {raw_data.hex()}")
+            api.pipeline.client_socket.send(data_to_send)
             cls._log("Raw data sent successfully")
         except Exception as e:
             cls._log(f"Error sending raw data: {e}")

--- a/src/fprime_gds/common/gds_cli/send_raw.py
+++ b/src/fprime_gds/common/gds_cli/send_raw.py
@@ -65,7 +65,6 @@ class SendRawCommand(BaseCommand):
                 # Remove '0x' prefix if present and any whitespace
                 hex_str = args.hex_string.replace('0x', '').replace('0X', '').replace(' ', '')
                 raw_data = bytes.fromhex(hex_str)
-                cls._log(f"Parsed {len(raw_data)} bytes from hex string")
             except ValueError as e:
                 cls._log(f"Error parsing hex string: {e}")
                 sys.exit(1)
@@ -82,10 +81,9 @@ class SendRawCommand(BaseCommand):
             if args.zmq:
                 # If using ZMQ, prepend the length of the data as a 4-byte big-endian integer
                 data_to_send = struct.pack(">I", len(raw_data)) + raw_data
-            
-            cls._log(f"Sending {len(raw_data)} bytes of raw data: {raw_data.hex()}")
+            if args.verbose:
+                cls._log(f"Sending {len(raw_data)} bytes of raw data: {raw_data.hex()}")
             api.pipeline.client_socket.send(data_to_send)
-            cls._log("Raw data sent successfully")
         except Exception as e:
             cls._log(f"Error sending raw data: {e}")
             sys.exit(1)

--- a/src/fprime_gds/common/gds_cli/send_raw.py
+++ b/src/fprime_gds/common/gds_cli/send_raw.py
@@ -1,0 +1,82 @@
+"""
+Handles executing the "send-raw" CLI command for the GDS
+"""
+
+import sys
+from pathlib import Path
+
+from fprime_gds.common.gds_cli.base_commands import BaseCommand
+from fprime_gds.common.models.dictionaries import Dictionaries
+from fprime_gds.common.testing_fw import predicates
+from fprime_gds.common.testing_fw.api import IntegrationTestAPI
+
+
+class SendRawCommand(BaseCommand):
+    """
+    The implementation for sending raw data via the GDS to the spacecraft
+    without further serialization (data is sent through framing only)
+    """
+
+    @classmethod
+    def _get_item_list(
+        cls,
+        project_dictionary: Dictionaries,
+        filter_predicate: predicates.predicate,
+    ):
+        """
+        Not applicable for send-raw command as it doesn't use dictionary items
+        """
+        return []
+
+    @classmethod
+    def _get_item_string(
+        cls,
+        item,
+        json: bool = False,
+    ) -> str:
+        """
+        Not applicable for send-raw command
+        """
+        return ""
+
+    @classmethod
+    def _execute_command(cls, args, api: IntegrationTestAPI):
+        """
+        Logic for sending raw data through the framing layer
+        """
+        raw_data = None
+
+        # Get raw data from either bin file or hex string
+        if args.bin_path:
+            try:
+                bin_path = Path(args.bin_path)
+                if not bin_path.exists():
+                    cls._log(f"Error: Binary file not found at {args.bin_path}")
+                    sys.exit(1)
+                with open(bin_path, 'rb') as f:
+                    raw_data = f.read()
+                cls._log(f"Read {len(raw_data)} bytes from {args.bin_path}")
+            except Exception as e:
+                cls._log(f"Error reading binary file: {e}")
+                sys.exit(1)
+        elif args.hex_string:
+            try:
+                # Remove '0x' prefix if present and any whitespace
+                hex_str = args.hex_string.replace('0x', '').replace('0X', '').replace(' ', '')
+                raw_data = bytes.fromhex(hex_str)
+                cls._log(f"Parsed {len(raw_data)} bytes from hex string")
+            except ValueError as e:
+                cls._log(f"Error parsing hex string: {e}")
+                sys.exit(1)
+        else:
+            cls._log("Error: Either --bin-path or --hex-string must be provided")
+            sys.exit(1)
+
+        # Send raw data through the client socket (framing layer)
+        try:
+            cls._log(f"Sending {len(raw_data)} bytes of raw data...")
+            api.pipeline.client_socket.send(raw_data)
+            cls._log("Raw data sent successfully")
+        except Exception as e:
+            cls._log(f"Error sending raw data: {e}")
+            sys.exit(1)

--- a/src/fprime_gds/executables/fprime_cli.py
+++ b/src/fprime_gds/executables/fprime_cli.py
@@ -318,6 +318,62 @@ class EventsSubparserInjector(CliSubparserInjectorBase):
         events.EventsCommand.handle_arguments(parsed_args, **kwargs)
 
 
+class SendRawSubparserInjector(CliSubparserInjectorBase):
+    """
+    A parser for the "send-raw" CLI command, which lets users send raw data
+    through the framing layer without further serialization
+    """
+
+    @classmethod
+    def create_subparser(cls, parent_parser: argparse.ArgumentParser):
+        """
+        Creates the send-raw sub-command as a subparser, and then returns it
+        """
+        send_raw_parser = parent_parser.add_parser(
+            "send-raw",
+            description="sends raw data through the framing layer without further serialization",
+        )
+        return send_raw_parser
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser):
+        """
+        Add all the required and optional arguments for this command to the
+        given parser
+        """
+        add_connection_arguments(parser)
+        
+        input_group = parser.add_mutually_exclusive_group(required=True)
+        input_group.add_argument(
+            "--bin-path",
+            type=str,
+            help="path to binary file containing raw data to send",
+            metavar="PATH",
+        )
+        input_group.add_argument(
+            "--hex-string",
+            type=str,
+            help="hex string of raw data to send (e.g., '0xDEADBEEF' or 'DEADBEEF')",
+            metavar="HEX",
+        )
+
+    @classmethod
+    def validate_args(cls, parser: argparse.ArgumentParser, args: argparse.Namespace):
+        """
+        Validates the parsed arguments for send-raw; send-raw doesn't need a dictionary
+        """
+        return args
+
+    @classmethod
+    def command_func(cls, parsed_args, **kwargs):
+        """
+        Executes the appropriate function when "send-raw" is called
+        """
+        import fprime_gds.common.gds_cli.send_raw as send_raw
+
+        send_raw.SendRawCommand.handle_arguments(parsed_args, **kwargs)
+
+
 def create_parser():
     parser = argparse.ArgumentParser(
         description="provides utilities for interacting with the F' Ground Data System (GDS)"
@@ -330,6 +386,7 @@ def create_parser():
     ChannelsSubparserInjector.inject_subparser(subparser_root)
     CommandSubparserInjector.inject_subparser(subparser_root)
     EventsSubparserInjector.inject_subparser(subparser_root)
+    SendRawSubparserInjector.inject_subparser(subparser_root)
 
     return parser
 

--- a/src/fprime_gds/executables/fprime_cli.py
+++ b/src/fprime_gds/executables/fprime_cli.py
@@ -342,7 +342,11 @@ class SendRawSubparserInjector(CliSubparserInjectorBase):
         given parser
         """
         add_connection_arguments(parser)
-        
+        parser.add_argument(
+            "--verbose",
+            action="store_true",
+            help="print the raw data being sent in hex format before sending",
+        )
         input_group = parser.add_mutually_exclusive_group(required=True)
         input_group.add_argument(
             "--bin-path",
@@ -353,7 +357,7 @@ class SendRawSubparserInjector(CliSubparserInjectorBase):
         input_group.add_argument(
             "--hex-string",
             type=str,
-            help="hex string of raw data to send (e.g., '0xDEADBEEF' or 'DEADBEEF')",
+            help="hex string of raw data to send (e.g., '0xDEADBEEF', 'deadbeef')",
             metavar="HEX",
         )
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Fix https://github.com/nasa/fprime/issues/4576
Fix https://github.com/nasa/fprime/issues/4902

Adds the ability to send raw packets. Raw frames can be supported by having a Null framer and using raw packets. Bypassing the framers is not practical, so sending raw frames is not supported in this first iteration.
