### PR TITLE
fix: replace datetime.UTC with timezone.utc for Python 3.10 compatibility

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
     - name: check-spelling
       id: spelling
-      uses: check-spelling/check-spelling@v0.0.24
+      uses: check-spelling/check-spelling@v0.0.26
       with:
         suppress_push_for_open_pull_request: 1
         checkout: true

--- a/src/fprime_gds/common/files/helpers.py
+++ b/src/fprime_gds/common/files/helpers.py
@@ -149,7 +149,7 @@ class TransmitFile:
 
         self.__state = "TRANSMITTING"
         self.__fd = open(filepath, filemode)
-        self.__start = datetime.datetime.now(datetime.UTC)
+        self.__start = datetime.datetime.now(datetime.timezone.utc)
         if self.__log_dir is not None:
             self.__log_handler = logging.FileHandler(
                 os.path.join(self.__log_dir, f"{os.path.basename(filepath)}.log"),
@@ -203,7 +203,7 @@ class TransmitFile:
         if self.__fd is not None:
             self.__fd.close()
             self.__fd = None
-            self.__end = datetime.datetime.now(datetime.UTC)
+            self.__end = datetime.datetime.now(datetime.timezone.utc)
 
     @property
     def start(self):


### PR DESCRIPTION
Fixes a Python compatibility issue where `datetime.UTC` is used, which is not available in Python 3.10.

Replaced with `datetime.timezone.utc`, which is compatible with Python 3.9+ as required by the project.

Tested locally on Python 3.10.14.

| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4996 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Replaced datetime.UTC with datetime.timezone.utc in helpers.py. This fixes the specific failure in GDS caused by using datetime.UTC on Python 3.10.

## Rationale

The project's README specifies a Python 3.9+ requirement. However, datetime.UTC was introduced in Python 3.11, causing an AttributeError on Python 3.10. Using datetime.timezone.utc maintains the same functionality while ensuring broad compatibility.

## Testing/Review Recommendations

Tested locally on Python 3.10.14. Verified locally that the AttributeError no longer occurs and the sequence uplink process starts successfully in a Python 3.10 environment.
## Future Work

Note any additional work that will be done relating to this issue.
