### PR TITLE
Added --skip-browser-open flag

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1287,6 +1287,13 @@ class GdsParser(ParserBase):
                 "type": str,
                 "help": "Set the GUI server address [default: %(default)s]",
             },
+            ("--gui-auto-open",):{
+                "dest": "gui_auto_open",
+                "default": False,
+                "required": False,
+                "type": bool,
+                "help": "Initializes GUI server without auto opening browser [default: %(default)s]"
+                }
         }
 
     def handle_arguments(self, args, **kwargs):

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1289,9 +1289,10 @@ class GdsParser(ParserBase):
             },
             ("--gui-auto-open",):{
                 "dest": "gui_auto_open",
-                "default": False,
+                "action": "store",
+                "default": "True",
                 "required": False,
-                "type": bool,
+                "type": str,
                 "help": "Initializes GUI server without auto opening browser [default: %(default)s]"
                 }
         }

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1287,13 +1287,10 @@ class GdsParser(ParserBase):
                 "type": str,
                 "help": "Set the GUI server address [default: %(default)s]",
             },
-            ("--gui-auto-open",):{
-                "dest": "gui_auto_open",
-                "action": "store",
-                "default": "True",
-                "required": False,
-                "type": str,
-                "help": "Initializes GUI server without auto opening browser [default: %(default)s]"
+            ("--skip-browser-open",):{
+                "dest": "browser_auto_open",
+                "action": "store_false",
+                "help": "Run server without auto-launching the default web browser"
                 }
         }
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -138,12 +138,13 @@ def launch_html(parsed_args):
     ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
     print(f"[INFO] Launched UI at: {ui_url}")
     
-    if parsed_args.gui_auto_open in ["TRUE","True", "true", "t"]:
+    if parsed_args.browser_auto_open:
         webbrowser.open(
             ui_url,
             new=0,
             autoraise=True,
         )
+
     return ret
 
 

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -138,7 +138,7 @@ def launch_html(parsed_args):
     ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
     print(f"[INFO] Launched UI at: {ui_url}")
     
-    if not parsed_args.gui_auto_open:
+    if parsed_args.gui_auto_open in ["TRUE","True", "true", "t", "n", "No"]:
         webbrowser.open(
             ui_url,
             new=0,

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -138,7 +138,7 @@ def launch_html(parsed_args):
     ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
     print(f"[INFO] Launched UI at: {ui_url}")
     
-    if parsed_args.gui_auto_open in ["TRUE","True", "true", "t", "n", "No"]:
+    if parsed_args.gui_auto_open in ["TRUE","True", "true", "t"]:
         webbrowser.open(
             ui_url,
             new=0,

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -137,11 +137,13 @@ def launch_html(parsed_args):
     ret = launch_process(gse_args, name="HTML GUI", env=flask_env, launch_time=2)
     ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
     print(f"[INFO] Launched UI at: {ui_url}")
-    webbrowser.open(
-        ui_url,
-        new=0,
-        autoraise=True,
-    )
+    
+    if not parsed_args.gui_auto_open:
+        webbrowser.open(
+            ui_url,
+            new=0,
+            autoraise=True,
+        )
     return ret
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  #5409 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Added the flag to fprime-gds 
--gui-auto-open False

This disables the main command fprime-gds from opening the gui automatically.

## Rationale

When learning,testing,deploying and what not, it is annoying to have a kabajillion tabs opening just to test 1 function change. Adding this flag allows for having one tab open and simply refreshing upon redeploying, allowing for a smoother work flow imo.

It is also an issue opened on the main fprime issues \#5409

## Testing/Review Recommendations

For the most part it should not affect functionality, as it just checks if the flag is true to call webbrowser.open(...) in run_deployment.py. Regardless if this function exists or not the gui still opens on hte port and is acessable 

## Future Work

Perhaps work on the wording of the flag? 
Also change the implimentation from str to bool to make foolproof

## Note 

I chose to use str, as when i tried to use bool, it would not replace the default value with the passed argument. This might be a different issue in itself, however the implentation has no noticable negatives, rather --gui-auto-open f also is a valid response and works in testing, so more of a positive.
