### PR TITLE
Fixing occasional downlink CRC failure during uplink

### DIFF
--- a/src/fprime_gds/common/communication/ccsds/space_data_link.py
+++ b/src/fprime_gds/common/communication/ccsds/space_data_link.py
@@ -31,7 +31,6 @@ class SpaceDataLinkFramerDeframer(FramerDeframer):
         init_value=0xFFFF,
         final_xor_value=0x0000,
     )
-    CRC_CALCULATOR = crc.Calculator(CRC_CCITT_CONFIG)
 
     # For backwards compatibility if not found in dictionary (loaded by ConfigManager)
     FALLBACK_SCID = 0x44
@@ -68,6 +67,8 @@ class SpaceDataLinkFramerDeframer(FramerDeframer):
         # Priority order: command line arg > dictionary value > fallback value
         self.scid = scid or dict_scid or self.FALLBACK_SCID
         self.frame_size = frame_size or dict_frame_size or self.FALLBACK_FRAME_SIZE
+        self.framing_crc_calculator = crc.Calculator(self.CRC_CCITT_CONFIG)
+        self.deframing_crc_calculator = crc.Calculator(self.CRC_CCITT_CONFIG)
 
     def frame(self, data):
         """Frame the supplied data in a TC frame"""
@@ -114,7 +115,7 @@ class SpaceDataLinkFramerDeframer(FramerDeframer):
         ), "Malformed packet generated"
 
         full_bytes = full_bytes_no_crc + struct.pack(
-            ">H", self.CRC_CALCULATOR.checksum(full_bytes_no_crc)
+            ">H", self.framing_crc_calculator.checksum(full_bytes_no_crc)
         )
         return full_bytes
 
@@ -150,7 +151,7 @@ class SpaceDataLinkFramerDeframer(FramerDeframer):
             # Spacecraft ID and Virtual Channel ID match, so we look at end of frame for CRC
             crc_offset = self.frame_size - self.TM_TRAILER_SIZE
             transmitted_crc = struct.unpack_from(">H", data, crc_offset)[0]
-            if transmitted_crc == self.CRC_CALCULATOR.checksum(data[:crc_offset]):
+            if transmitted_crc == self.deframing_crc_calculator.checksum(data[:crc_offset]):
                 # CRC is valid, so we return the deframed data
                 deframed_data_len = (
                     self.frame_size

--- a/test/fprime_gds/common/communication/ccsds/test_space_data_link.py
+++ b/test/fprime_gds/common/communication/ccsds/test_space_data_link.py
@@ -4,6 +4,7 @@ import struct
 from fprime_gds.common.communication.ccsds.space_data_link import (
     SpaceDataLinkFramerDeframer,
 )
+from crc import Calculator
 
 SCID_TEST_VALUE = 0x77
 VCID_TEST_VALUE = 5
@@ -53,7 +54,8 @@ def test_deframe_valid_frame(framer_deframer):
         )
         + payload
     )
-    crc = framer_deframer.CRC_CALCULATOR.checksum(input_data_no_crc)
+    crc_calculator = Calculator(framer_deframer.CRC_CCITT_CONFIG)
+    crc = crc_calculator.checksum(input_data_no_crc)
     input_data = input_data_no_crc + struct.pack(">H", crc)
     deframed_data, remaining_data, discarded = framer_deframer.deframe(input_data)
     assert deframed_data == payload
@@ -82,7 +84,8 @@ def test_deframe_incorrect_crc(framer_deframer):
         )
         + payload
     )
-    crc = framer_deframer.CRC_CALCULATOR.checksum(input_data_no_crc) + 1  # Intentionally incorrect CRC
+    crc_calculator = Calculator(framer_deframer.CRC_CCITT_CONFIG)
+    crc = crc_calculator.checksum(input_data_no_crc) + 1  # Intentionally incorrect CRC
     input_data = input_data_no_crc + struct.pack(">H", crc)
     deframed_data, remaining_data, discarded = framer_deframer.deframe(input_data)
     assert deframed_data is None


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

The SpaceDataLink framer/deframer were sharing the same instantiation of a CRC object.  As such, when deframing is calculaing a checksum and uplink sends a frame, the CRC for one, or the other, or both is corrupted.

This splits it into two objects for thread safety!

## Rationale

This can cause random bad failures.

## Testing/Review Recommendations

## Future Work

Next is the lag problem.