### PR TITLE
Run GDS app from its binary directory

### DIFF
--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -53,7 +53,7 @@ def parse_args():
     return args
 
 
-def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
+def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5, cwd=None):
     """
     Launch a child subprocess. This subprocess will allow the child to run outside of the memory context of Python.
 
@@ -62,13 +62,14 @@ def launch_process(cmd, logfile=None, name=None, env=None, launch_time=5):
     :param name: (optional) short name for printing messages.
     :param env: (optional) environment to run in. Allows for special environment contexts.
     :param launch_time: (optional) time to launch the process, before rendering an error.
+    :param cwd: (optional) working directory to run the process from.
     :return: running process
     """
     if name is None:
         name = str(cmd)
     print(f"[INFO] Ensuring {name} is stable for at least {launch_time} seconds")
     try:
-        return run_wrapped_application(cmd, logfile, env, launch_time)
+        return run_wrapped_application(cmd, logfile, env, launch_time, cwd=cwd)
     except AppWrapperException as awe:
         print(f"[ERROR] {str(awe)}.", file=sys.stderr)
         try:
@@ -166,7 +167,11 @@ def launch_app(parsed_args):
         parsed_args.address,
     ]
     return launch_process(
-        app_cmd, name=f"{app_path.name} Application", logfile=logfile, launch_time=1
+        app_cmd,
+        name=f"{app_path.name} Application",
+        logfile=logfile,
+        launch_time=1,
+        cwd=app_path.parent,
     )
 
 

--- a/src/fprime_gds/executables/utils.py
+++ b/src/fprime_gds/executables/utils.py
@@ -85,7 +85,9 @@ def register_process_assassin(process, log=None):
     atexit.register(assassin)
 
 
-def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None):
+def run_wrapped_application(
+    arguments, logfile=None, env=None, launch_time=None, cwd=None
+):
     """
     Run an application and ensure that it is logged immediately to the logfile. This will allow the application to have
     up-to-date logs. This is a wrapper for pexpect to ensure that the application runs and log effectively. It has been
@@ -95,6 +97,7 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
     :param logfile: (optional) path to logfile to log to. Will overwrite.
     :param env: (optional) environment for the subprocess
     :param launch_time: (optional) time to wait before declaring the process stable
+    :param cwd: (optional) working directory to run the process from.
     :return: child process should it be needed.
     """
     # Write out run information for the calling user
@@ -112,7 +115,7 @@ def run_wrapped_application(arguments, logfile=None, env=None, launch_time=None)
     # the output. That way the log file is fully up-to-date.
     try:
         child = subprocess.Popen(
-            arguments, stdout=file_handler, stderr=subprocess.STDOUT, env=env
+            arguments, stdout=file_handler, stderr=subprocess.STDOUT, env=env, cwd=cwd
         )
         register_process_assassin(child, file_handler)
         # If launch time is specified, then wait for it to be stable

--- a/test/fprime_gds/executables/test_run_deployment.py
+++ b/test/fprime_gds/executables/test_run_deployment.py
@@ -2,6 +2,7 @@ import platform
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
 from fprime_gds.executables import run_deployment
@@ -17,6 +18,36 @@ class TestRunDeployment(unittest.TestCase):
             self.create_fake_deployment_structure(temporary_directory)
             with mock.patch("sys.argv", ["main", "-g", "html", "-d", str(Path(temporary_directory) / platform.system() / "Test")]):
                 run_deployment.parse_args()
+
+    def test_launch_app_runs_from_app_directory(self):
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            app_path = Path(temporary_directory) / "bin" / "TestApp"
+            app_path.parent.mkdir()
+            logs_path = Path(temporary_directory) / "logs"
+            logs_path.mkdir()
+            parsed_args = SimpleNamespace(
+                app=app_path,
+                logs=str(logs_path),
+                port=50000,
+                address="127.0.0.1",
+            )
+
+            with mock.patch.object(run_deployment, "launch_process") as launch_process:
+                run_deployment.launch_app(parsed_args)
+
+            launch_process.assert_called_once_with(
+                [
+                    app_path.absolute(),
+                    "-p",
+                    str(parsed_args.port),
+                    "-a",
+                    parsed_args.address,
+                ],
+                name=f"{app_path.name} Application",
+                logfile=str(logs_path / f"{app_path.name}.log"),
+                launch_time=1,
+                cwd=app_path.parent,
+            )
 
     def create_fake_deployment_structure(self, temporary_directory):
         system_dir = Path(temporary_directory) / platform.system() / "Test"

--- a/test/fprime_gds/executables/test_utils.py
+++ b/test/fprime_gds/executables/test_utils.py
@@ -1,5 +1,6 @@
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from fprime_gds.executables import utils
 
@@ -15,3 +16,15 @@ class TestFormatString(unittest.TestCase):
         path_with_no_dict = Path("")
         with self.assertRaises(SystemExit):
             utils.find_app(path_with_no_dict)
+
+    def test_run_wrapped_application_uses_supplied_cwd(self):
+        cwd = Path("deployment") / "bin"
+        child = mock.Mock(returncode=None)
+
+        with mock.patch.object(utils.subprocess, "Popen", return_value=child) as popen:
+            result = utils.run_wrapped_application(["app"], cwd=cwd)
+
+        self.assertIs(result, child)
+        popen.assert_called_once_with(
+            ["app"], stdout=None, stderr=utils.subprocess.STDOUT, env=None, cwd=cwd
+        )


### PR DESCRIPTION
 | | |
  |:---|:---|
  |**_Related Issue(s)_**| nasa/fprime#5185 |
  |**_Has Unit Tests (y/n)_**| y |
  |**_Documentation Included (y/n)_**| n |

  ---
  ## Change Description

  When `fprime-gds` auto-launches the deployment app, it now runs that process from the app binary's directory. The launch wrapper accepts an optional `cwd` value and forwards it to `subprocess.Popen`.

  ## Rationale

  This fixes relative paths in deployment binaries that expect to run from their own `bin` directory. Without this, an app launched by `fprime-gds` inherited the operator's current directory instead.

  ## Testing/Review Recommendations

  - `python -m pytest test/fprime_gds/executables/test_run_deployment.py test/fprime_gds/executables/test_utils.py -q`
  - `python -m pytest test -q`
  - `fprime-cli events --list --dictionary ./.github/resources/RefTopologyAppDictionary.xml`
  - `fprime-cli channels --list --dictionary ./.github/resources/RefTopologyAppDictionary.xml`
  - `fprime-cli command-send --list --dictionary ./.github/resources/RefTopologyAppDictionary.xml`

  ## Future Work

  None.