### PR TITLE
Append user name and PID to default ZMQ pipe names

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -176,6 +176,7 @@ gdiplus
 getattr
 getbootstrap
 getoption
+getpid
 github
 grayscales
 gse

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -980,7 +980,7 @@ class MiddleWareParser(ParserBase):
             ("--zmq-transport",): {
                 "dest": "zmq_transport",
                 "nargs": 2,
-                "help": "Pair of URls used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
+                "help": "Pair of URLs used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
                 "default": [
                     f"ipc:///tmp/fprime-server-in-{getpass.getuser()}-{os.getpid()}",
                     f"ipc:///tmp/fprime-server-out-{getpass.getuser()}-{os.getpid()}",

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -982,8 +982,8 @@ class MiddleWareParser(ParserBase):
                 "nargs": 2,
                 "help": "Pair of URls used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
                 "default": [
-                    "ipc:///tmp/fprime-server-in",
-                    "ipc:///tmp/fprime-server-out",
+                    f"ipc:///tmp/fprime-server-in-{getpass.getuser()}-{os.getpid()}",
+                    f"ipc:///tmp/fprime-server-out-{getpass.getuser()}-{os.getpid()}",
                 ],
                 "metavar": ("serverInUrl", "serverOutUrl"),
             },


### PR DESCRIPTION

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Default ipc:///tmp/fprime-server-in and -out pipe names caused collisions between users and limited the GDS to one instance per machine. Append the username and GDS process ID to deconflict users and allow multiple GDS instances on the same host.

Fixes nasa/fprime#3967
