### PR TITLE
Remove PID from default ZMQ socket name

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -982,8 +982,8 @@ class MiddleWareParser(ParserBase):
                 "nargs": 2,
                 "help": "Pair of URLs used with --zmq to setup ZeroMQ transportation [default: %(default)s]",
                 "default": [
-                    f"ipc:///tmp/fprime-server-in-{getpass.getuser()}-{os.getpid()}",
-                    f"ipc:///tmp/fprime-server-out-{getpass.getuser()}-{os.getpid()}",
+                    f"ipc:///tmp/fprime-server-in-{getpass.getuser()}",
+                    f"ipc:///tmp/fprime-server-out-{getpass.getuser()}",
                 ],
                 "metavar": ("serverInUrl", "serverOutUrl"),
             },


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Appending PID to socket name is a problem because running in two shells `fprime-gds` and `pytest` will not use the same socket names. Reverting