### PR TITLE
Fixed infinite busy-loop in the fprime GDS TCP server on a socket error + Unbounded client + UDP Handler errors

### DIFF
--- a/src/fprime_gds/executables/tcpserver.py
+++ b/src/fprime_gds/executables/tcpserver.py
@@ -197,19 +197,23 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
 
     def recv(self, l):
         """
-        Read l bytes from socket.
+        Read exactly l bytes from the socket.
+
+        Returns the l bytes on success, or b"" if the connection is closed or
+        broken before l bytes arrive. Callers treat b"" as "client gone".
         """
-        chunk = b""
-        msg = b""
-        n = 0
-        while l > n:
+        # Accumulate into a bytearray instead of rebuilding an immutable bytes
+        # object each iteration. "msg = msg + chunk" is O(n^2) and, combined
+        # with an unbounded length field, lets a client drive quadratic CPU and
+        # memory use on a large read.
+        msg = bytearray()
+        while len(msg) < l:
             try:
-                chunk = self.request.recv(l - n)
+                chunk = self.request.recv(l - len(msg))
                 if chunk == b"":
                     print("read data from socket is empty!")
                     return b""
-                msg = msg + chunk
-                n = len(msg)
+                msg.extend(chunk)
             except socket.timeout:
                 if shutdown_event.is_set():
                     print("socket timed out and shutdown is requested")
@@ -222,7 +226,12 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
                     )
                 else:
                     print(f"Socket error {str(err.errno)} occurred on recv().")
-        return msg
+                # The socket is in a broken state; retrying recv() would raise
+                # the same error immediately and spin the thread at 100% CPU
+                # forever. Return b"" to signal a dead connection, consistent
+                # with the empty-read case above.
+                return b""
+        return bytes(msg)
 
     def readHeader(self):
         """
@@ -243,28 +252,77 @@ class ThreadedTCPRequestHandler(socketserver.StreamRequestHandler):
             return header + header2
         return
 
+    #: Maximum accepted size (in bytes) for a single client-declared payload.
+    #:
+    #: The length prefix is an unbounded ``U32`` supplied by the connecting
+    #: client, so without this cap a malformed or malicious value (up to ~4 GiB)
+    #: would drive an unbounded socket read and allocation -- a memory/CPU denial
+    #: of service. The default (64 MiB) is far above any legitimate GDS packet.
+    #: Raise it only if a deployment genuinely sends larger single payloads (for
+    #: example, large file-downlink chunks); it bounds resource use, not protocol
+    #: correctness.
+    MAX_PAYLOAD_SIZE = 64 * 1024 * 1024
+
+    def _read_payload_size(self):
+        """
+        Read and validate a 4-byte big-endian length prefix.
+
+        Returns (size, raw_4_bytes) on success, or (None, raw) if the connection
+        died (short read) or the declared size exceeds MAX_PAYLOAD_SIZE.
+        """
+        sizeb = self.recv(4)
+        if len(sizeb) < 4:
+            return None, sizeb
+        (size,) = struct.unpack(">I", sizeb)
+        if size > self.MAX_PAYLOAD_SIZE:
+            print(
+                f"[WARNING] Declared payload size {size} exceeds maximum "
+                f"{self.MAX_PAYLOAD_SIZE}; dropping packet."
+            )
+            return None, sizeb
+        return size, sizeb
+
     def readData(self, header):
         """
         Read the data part of the message sent to either GUI or FSW.
         GUI receives telemetry.
         FSW receives commands of various lengths.
+
+        Returns b"" if the connection closed or the framing is malformed
+        (missing destination, truncated length prefix, out-of-range size, or a
+        short payload read).
         """
         data = b""
         if header in [b"List", b"Quit"]:
             return b""
-        dst = header.split(b" ")[1].strip(b" ")
+        parts = header.split(b" ")
+        if len(parts) < 2:
+            print("[WARNING] Malformed header, missing destination field.")
+            return b""
+        dst = parts[1].strip(b" ")
         if dst == b"FSW":
             # Read variable length command data here...
             desc = self.recv(4)
-            sizeb = self.recv(4)
-            size = struct.unpack(">I", sizeb)[0]
-            data = desc + sizeb + self.recv(size)
+            if len(desc) < 4:
+                return b""
+            size, sizeb = self._read_payload_size()
+            if size is None:
+                return b""
+            payload = self.recv(size)
+            if len(payload) < size:
+                print("[WARNING] Truncated FSW payload; dropping packet.")
+                return b""
+            data = desc + sizeb + payload
         elif dst == b"GUI":
             # Read telemetry data here...
-            tlm_packet_size = self.recv(4)
-            size = struct.unpack(">I", tlm_packet_size)[0]
-            data = tlm_packet_size + self.recv(size)
-
+            size, sizeb = self._read_payload_size()
+            if size is None:
+                return b""
+            payload = self.recv(size)
+            if len(payload) < size:
+                print("[WARNING] Truncated GUI payload; dropping packet.")
+                return b""
+            data = sizeb + payload
         else:
             msg = f"unrecognized client {dst.decode(DATA_ENCODING)}"
             raise RuntimeError(msg)
@@ -367,7 +425,15 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
         """
         Read the 9 byte header (e.g. "A5A5 GUI " or "A5A5 FSW "),
         or just read the "List\n" command.
+
+        Returns (b"", b"") if the datagram is too short to contain a header,
+        which the caller treats as "nothing to process".
         """
+        # Need at least the 9-byte "A5A5 XXX " header. Slicing a short datagram
+        # would otherwise yield a runt header and push the failure downstream.
+        if len(packet) < 9:
+            print("[WARNING] UDP datagram too short for header; dropping.")
+            return (b"", b"")
         header = packet[:4]
         header2 = packet[4:9]
         packet = packet[9:]
@@ -378,14 +444,28 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
         Read the data part of the message sent to either GUI or FSW.
         GUI receives telemetry.
         FSW receives commands of various lengths.
-        """
-        data = ""
-        header.split(b" ")[1].strip(b" ")
-        # Read telemetry data here...
-        tlm_packet_size = packet[:4]
-        size = struct.unpack(">I", tlm_packet_size)[0]
-        data = tlm_packet_size + packet[4 : 4 + size]
 
+        Returns b"" if the datagram is too short for a length prefix or the
+        declared size runs past the bytes actually delivered.
+        """
+        # A datagram must contain at least the 4-byte length prefix. Without
+        # this guard struct.unpack raises struct.error on a runt packet.
+        if len(packet) < 4:
+            print("[WARNING] UDP datagram too short for length prefix; dropping.")
+            return b""
+        tlm_packet_size = packet[:4]
+        (size,) = struct.unpack(">I", tlm_packet_size)
+        # UDP delivers the whole datagram at once, so anything beyond its length
+        # is simply absent; a bare slice would silently truncate. Reject rather
+        # than hand a short buffer downstream.
+        available = len(packet) - 4
+        if size > available:
+            print(
+                f"[WARNING] UDP declared size {size} exceeds datagram payload "
+                f"{available}; dropping."
+            )
+            return b""
+        data = tlm_packet_size + packet[4 : 4 + size]
         return data
 
     def processNewPkt(self, header, data):
@@ -397,11 +477,16 @@ class ThreadedUDPRequestHandler(socketserver.BaseRequestHandler):
         """
         dest_list = []
         # Process data here...
-        head, dst = header.strip(b" ").split(b" ")
+        parts = header.strip(b" ").split(b" ")
+        if len(parts) != 2:
+            # Avoid a ValueError (and a dead handler) on a malformed header.
+            print("[WARNING] Malformed UDP header; dropping packet.")
+            return
+        head, dst = parts
         if head != b"A5A5":
             raise RuntimeError("Telemetry missing A5A5 header")
         # print "Received Packet: %s %s...\n" % (head,dst)
-        if data == "":
+        if data == b"":
             print(" Data is empty, returning.")
         if b"GUI" in dst:
             dest_list = GUI_clients

--- a/test/fprime_gds/executables/test_tcpserver.py
+++ b/test/fprime_gds/executables/test_tcpserver.py
@@ -1,0 +1,302 @@
+"""
+Unit tests for fprime_gds.executables.tcpserver hardening.
+
+Covers two fixes and the related UDP hardening:
+
+  Fix #1 -- recv() must not busy-loop on a socket error. On any OSError the
+            socket is broken; retrying recv() would spin the handler thread at
+            100% CPU forever. recv() must return b"" after a bounded number of
+            calls. socket.timeout, by contrast, must keep looping (intended).
+
+  Fix #3 -- readData() must bound the client-declared payload length (a U32,
+            up to ~4 GiB) so a malicious/garbled size cannot drive an unbounded
+            read/allocation; must not raise struct.error on a short length
+            prefix; and must drop (not silently truncate) a short payload. The
+            recv() accumulator must also reassemble correctly across many
+            partial chunks (the bytearray.extend path that replaced the O(n^2)
+            "msg = msg + chunk").
+
+  UDP     -- readHeader/readData/processNewPkt must tolerate runt datagrams and
+            malformed headers without raising.
+
+The handlers normally run inside socketserver, which connects and serves on
+construction. To unit-test the parsing/recv methods in isolation we build a
+bare instance with object.__new__(...) and inject a scripted fake request.
+
+These tests follow the repo convention (unittest.TestCase, run under pytest)
+and live at test/fprime_gds/executables/test_tcpserver.py.
+"""
+
+import errno
+import socket
+import struct
+import threading
+import unittest
+
+from fprime_gds.executables.tcpserver import (
+    ThreadedTCPRequestHandler,
+    ThreadedUDPRequestHandler,
+)
+
+
+class FakeRequest:
+    """A stand-in for the socket handed to a request handler.
+
+    Scripted with a list of "actions", each of which is either:
+      * a bytes object -> returned from the next recv() call, or
+      * an Exception instance/class -> raised from the next recv() call.
+    When the script is exhausted, recv() returns b"" (EOF), mirroring a
+    closed socket. Every recv() call is counted so tests can assert that a
+    broken socket is not polled repeatedly (the busy-loop regression guard)
+    and that an oversized length is rejected without ever reading the payload.
+    """
+
+    def __init__(self, actions=None, max_calls=10_000):
+        self._actions = list(actions or [])
+        self.calls = 0
+        self.recv_sizes = []
+        self._max_calls = max_calls
+
+    def recv(self, n):
+        self.calls += 1
+        self.recv_sizes.append(n)
+        # Hard stop so a regression of the busy-loop fails fast instead of
+        # hanging the whole test suite.
+        if self.calls > self._max_calls:
+            raise AssertionError(
+                f"recv() called more than {self._max_calls} times -- "
+                "likely an infinite busy-loop regression"
+            )
+        if not self._actions:
+            return b""  # EOF
+        action = self._actions.pop(0)
+        if isinstance(action, BaseException) or (
+            isinstance(action, type) and issubclass(action, BaseException)
+        ):
+            raise action
+        return action
+
+
+def make_tcp_handler(request):
+    """Build a ThreadedTCPRequestHandler without running socketserver setup."""
+    handler = object.__new__(ThreadedTCPRequestHandler)
+    handler.request = request
+    handler.name = b"TEST_CLIENT"
+    return handler
+
+
+def make_udp_handler():
+    """Build a ThreadedUDPRequestHandler without running socketserver setup."""
+    return object.__new__(ThreadedUDPRequestHandler)
+
+
+class TestRecvBusyLoop(unittest.TestCase):
+    """Fix #1: recv() must terminate on a socket error, not spin."""
+
+    def test_econnreset_returns_empty_after_single_call(self):
+        req = FakeRequest([OSError(errno.ECONNRESET, "reset")])
+        handler = make_tcp_handler(req)
+        result = handler.recv(13)
+        self.assertEqual(result, b"")
+        # The decisive assertion: the broken socket was polled exactly once.
+        self.assertEqual(req.calls, 1)
+
+    def test_other_oserror_returns_empty_after_single_call(self):
+        for err in (errno.EPIPE, errno.EBADF, errno.ECONNABORTED):
+            with self.subTest(errno=err):
+                req = FakeRequest([OSError(err, "broken")])
+                handler = make_tcp_handler(req)
+                self.assertEqual(handler.recv(13), b"")
+                self.assertEqual(req.calls, 1)
+
+    def test_empty_read_eof_returns_empty(self):
+        # A zero-byte read means the peer closed the connection cleanly.
+        req = FakeRequest([b""])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.recv(8), b"")
+
+    def test_timeout_keeps_looping_then_succeeds(self):
+        # socket.timeout must NOT be treated as a disconnect: recv() should
+        # retry and ultimately return the full payload.
+        req = FakeRequest([socket.timeout(), b"AB", socket.timeout(), b"CDE"])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.recv(5), b"ABCDE")
+
+    def test_recv_terminates_within_timeout_on_persistent_error(self):
+        # Belt-and-suspenders: even if the call-count guard were removed, the
+        # call must not hang. Run it on a worker thread and require completion.
+        # A persistent OSError every call would be an infinite loop pre-fix.
+        req = FakeRequest(
+            [OSError(errno.ECONNRESET, "reset")] * 50_000, max_calls=10_000
+        )
+        handler = make_tcp_handler(req)
+        done = threading.Event()
+        out = {}
+
+        def run():
+            out["result"] = handler.recv(13)
+            done.set()
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        self.assertTrue(done.wait(timeout=5), "recv() did not return within 5s")
+        self.assertEqual(out["result"], b"")
+
+
+class TestRecvAccumulation(unittest.TestCase):
+    """Fix #3 (accumulator): recv() reassembles correctly across chunks."""
+
+    def test_reassembles_partial_chunks_in_order(self):
+        req = FakeRequest([b"AB", b"CDE", b"FGHIJKLM"])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.recv(13), b"ABCDEFGHIJKLM")
+
+    def test_reassembles_many_small_chunks(self):
+        # Exercises the bytearray.extend path with many appends; asserts exact
+        # byte-for-byte reassembly (the correctness guarantee behind the O(n^2)
+        # -> O(n) accumulator change).
+        expected = bytes(range(256)) * 8  # 2048 bytes
+        chunks = [expected[i : i + 3] for i in range(0, len(expected), 3)]
+        req = FakeRequest(chunks)
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.recv(len(expected)), expected)
+
+    def test_returns_bytes_type(self):
+        req = FakeRequest([b"XYZ"])
+        handler = make_tcp_handler(req)
+        self.assertIsInstance(handler.recv(3), bytes)
+
+
+class TestReadPayloadSize(unittest.TestCase):
+    """Fix #3 (bound): the U32 length prefix is validated."""
+
+    def test_accepts_size_at_limit(self):
+        size = ThreadedTCPRequestHandler.MAX_PAYLOAD_SIZE
+        req = FakeRequest([struct.pack(">I", size)])
+        handler = make_tcp_handler(req)
+        got_size, raw = handler._read_payload_size()
+        self.assertEqual(got_size, size)
+        self.assertEqual(raw, struct.pack(">I", size))
+
+    def test_rejects_size_above_limit(self):
+        size = ThreadedTCPRequestHandler.MAX_PAYLOAD_SIZE + 1
+        req = FakeRequest([struct.pack(">I", size)])
+        handler = make_tcp_handler(req)
+        got_size, _ = handler._read_payload_size()
+        self.assertIsNone(got_size)
+
+    def test_rejects_max_u32(self):
+        req = FakeRequest([struct.pack(">I", 0xFFFFFFFF)])
+        handler = make_tcp_handler(req)
+        got_size, _ = handler._read_payload_size()
+        self.assertIsNone(got_size)
+
+    def test_short_prefix_returns_none_without_struct_error(self):
+        # Fewer than 4 bytes then EOF: must not raise struct.error.
+        req = FakeRequest([b"\x00\x00"])
+        handler = make_tcp_handler(req)
+        try:
+            got_size, _ = handler._read_payload_size()
+        except struct.error:
+            self.fail("_read_payload_size raised struct.error on short prefix")
+        self.assertIsNone(got_size)
+
+
+class TestReadDataTCP(unittest.TestCase):
+    """Fix #3 (readData): bound, robustness, and the no-allocation property."""
+
+    def test_gui_valid_payload(self):
+        req = FakeRequest([struct.pack(">I", 4), b"PING"])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.readData(b"A5A5 GUI "), struct.pack(">I", 4) + b"PING")
+
+    def test_fsw_valid_payload(self):
+        req = FakeRequest([b"DESC", struct.pack(">I", 3), b"CMD"])
+        handler = make_tcp_handler(req)
+        self.assertEqual(
+            handler.readData(b"A5A5 FSW "), b"DESC" + struct.pack(">I", 3) + b"CMD"
+        )
+
+    def test_gui_oversized_size_is_rejected_without_reading_payload(self):
+        # The key security property: reject on the length field alone; never
+        # attempt the giant recv(size) that would allocate ~4 GiB.
+        req = FakeRequest([struct.pack(">I", 0xFFFFFFFF)])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.readData(b"A5A5 GUI "), b"")
+        # Only the 4-byte length prefix was read; no payload recv attempted.
+        self.assertEqual(req.calls, 1)
+        self.assertNotIn(0xFFFFFFFF, req.recv_sizes)
+
+    def test_gui_truncated_payload_is_dropped(self):
+        # Declares 8 bytes, delivers 2 then EOF -> drop, do not return a runt.
+        req = FakeRequest([struct.pack(">I", 8), b"AB"])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.readData(b"A5A5 GUI "), b"")
+
+    def test_fsw_truncated_descriptor_is_dropped(self):
+        req = FakeRequest([b"DE"])  # short descriptor then EOF
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.readData(b"A5A5 FSW "), b"")
+
+    def test_missing_destination_returns_empty(self):
+        req = FakeRequest([])
+        handler = make_tcp_handler(req)
+        self.assertEqual(handler.readData(b"A5A5"), b"")
+
+    def test_list_and_quit_headers_return_empty(self):
+        for header in (b"List", b"Quit"):
+            with self.subTest(header=header):
+                handler = make_tcp_handler(FakeRequest([]))
+                self.assertEqual(handler.readData(header), b"")
+
+    def test_unknown_destination_raises_runtimeerror(self):
+        # Preserves existing behavior for a genuinely unrecognized client.
+        handler = make_tcp_handler(FakeRequest([]))
+        with self.assertRaises(RuntimeError):
+            handler.readData(b"A5A5 XXX ")
+
+
+class TestUDPHardening(unittest.TestCase):
+    """UDP datagram parsing must tolerate runt/malformed input."""
+
+    def test_readheader_short_datagram(self):
+        handler = make_udp_handler()
+        self.assertEqual(handler.readHeader(b"A5A5"), (b"", b""))
+
+    def test_readheader_full(self):
+        handler = make_udp_handler()
+        packet = b"A5A5 GUI " + struct.pack(">I", 3) + b"XYZ"
+        header, rest = handler.readHeader(packet)
+        self.assertEqual(header, b"A5A5 GUI ")
+        self.assertEqual(rest, struct.pack(">I", 3) + b"XYZ")
+
+    def test_readdata_runt_length_prefix(self):
+        # Fewer than 4 bytes: must not raise struct.error.
+        handler = make_udp_handler()
+        try:
+            self.assertEqual(handler.readData(b"A5A5 GUI ", b"\x00\x00"), b"")
+        except struct.error:
+            self.fail("UDP readData raised struct.error on runt datagram")
+
+    def test_readdata_declared_size_exceeds_datagram(self):
+        handler = make_udp_handler()
+        packet = struct.pack(">I", 1000) + b"XYZ"  # claims 1000, has 3
+        self.assertEqual(handler.readData(b"A5A5 GUI ", packet), b"")
+
+    def test_readdata_valid(self):
+        handler = make_udp_handler()
+        packet = struct.pack(">I", 3) + b"XYZ"
+        self.assertEqual(handler.readData(b"A5A5 GUI ", packet), struct.pack(">I", 3) + b"XYZ")
+
+    def test_processnewpkt_malformed_header_does_not_raise(self):
+        # A header with no space split into two parts must not raise ValueError
+        # (which would kill the handler thread).
+        handler = make_udp_handler()
+        try:
+            handler.processNewPkt(b"GARBAGE", b"")
+        except ValueError:
+            self.fail("processNewPkt raised ValueError on malformed header")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| Y |
|**_Documentation Included (y/n)_**| Y |

---
## Change Description

The fprime GDS TCP server has an infinite loop in the recv() function to process packet data. There is a bug processing an OS Exception.  The OSError exception branch only logs the error instead of handling it. So processing falls back into the loop with a broken socket.  This results in a rinse -> cycle -> repeat failure condition since the socket will be broken forever. 

The fix is simple - the code should treat a socket error the same way the code already treats a dead connection

I fixed some other things since I opened the hood on TCP server that are related.
 
1) I switched the packet read accumulator from msg = msg + chunk (rebuilds an immutable bytes every iteration) to a bytearray with .extend(). The is am improvement because "msg = msg + chunk"  builds a brand-new bytes object by copying all the bytes already accumulated, so reassembling an N-byte payload across many chunks copies roughly N² bytes total; a bytearray with .extend() appends in place, making it linear.

2) added MAX_PAYLOAD_SIZE = 64 MiB and a _read_payload_size() helper that validates the 4-byte prefix. A client can no longer declare a ~4 GiB length to force an unbounded read/allocation, and a truncated length prefix no longer throws struct.error. Truncated payloads are now dropped with a warning instead of silently passed downstream. I also added a docstring that informs the user that if their deployment is larger than 64 MiB, they should increase MAX_PAYLOAD_SIZE. This change improves the stability of the f prime GDS, since an unbounded client could cause "undesirable performance" of the GDS.

3) The UDP handler now rejects datagrams shorter than the 9-byte header instead of slicing a runt header.

4) The UDP handler now validates the datagram is long enough for the length prefix instead of truncating it and not telling the user. I also added guards in the header split so a malformed header logs and returns instead of crashing. Not only does this help debugging new deployments, but prevents the GDS from processing malformed data.

## Rationale

Infinite loop failure condition and improve the robustness of the GDS during off-nominal conditions.

## Testing/Review Recommendations

I created a new unit test for tcpserver that tests and verifies the fixes and robustness I described above.

## AI Usage

I had claude implement the code changes and create the new tcpserver unit test.

## Future Work

None.