### PR TITLE
Miscellaneous Python linting fixes

### DIFF
--- a/src/fprime_gds/common/communication/adapters/base.py
+++ b/src/fprime_gds/common/communication/adapters/base.py
@@ -29,7 +29,7 @@ class BaseAdapter(abc.ABC):
         """Null default implementation"""
 
     @abc.abstractmethod
-    def read(self, timeout=0.500):
+    def read(self, timeout=0.500) -> bytes:
         """
         Read from the interface. Must be overridden by the child adapter. Throw no fatal errors, reconnect instead. This
         call is expected to block waiting on incoming data.
@@ -38,15 +38,17 @@ class BaseAdapter(abc.ABC):
         :param timeout: timeout for the block, default: 0.500 (500ms) as blocking w/o timeout may be uninterruptible
         :return: byte array of data, or b'' if no data was read
         """
+        return NotImplemented
 
     @abc.abstractmethod
-    def write(self, frame):
+    def write(self, frame) -> bool:
         """
         Write to the interface. Must be overridden by the child adapter. Throw no fatal errors, reconnect instead.
 
         :param frame: framed data to uplink
         :return: True if data sent through adapter, False otherwise
         """
+        return NotImplemented
 
     @classmethod
     @gds_plugin_specification

--- a/src/fprime_gds/common/communication/adapters/ip.py
+++ b/src/fprime_gds/common/communication/adapters/ip.py
@@ -113,7 +113,7 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
             self.data_chunks.put(handler.read())
         handler.close()
 
-    def write(self, frame):
+    def write(self, frame) -> bool:
         """
         Send a given framed bit of data by sending it out the serial interface. It will attempt to reconnect if there
         was a problem previously. This function will return true on success, or false on error.
@@ -123,6 +123,8 @@ class IpAdapter(fprime_gds.common.communication.adapters.base.BaseAdapter):
         """
         if self.tcp.connected == IpHandler.CONNECTED:
             return self.tcp.write(frame)
+        else:
+            return False
 
     def read(self, timeout=0.500):
         """

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -24,7 +24,7 @@ import yaml
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 # Required to set the checksum as a module variable
 import fprime_gds.common.logger
@@ -50,12 +50,12 @@ class ParserBase(ABC):
     handling arguments.
     """
 
-    DESCRIPTION = None
+    DESCRIPTION: Optional[str] = None
 
     @property
-    def description(self):
+    def description(self) -> str:
         """Return parser description"""
-        return self.DESCRIPTION if self.DESCRIPTION else "Unknown command line parser"
+        return self.DESCRIPTION if self.DESCRIPTION is not None else "Unknown command line parser"
 
     @abstractmethod
     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
@@ -390,7 +390,6 @@ class ConfigDrivenParser(ParserBase):
             parsers = [ConfigDrivenParser] + parser_classes
             ParserBase.parse_args(parsers, description, arguments, **kwargs)
             sys.exit(0)
-        
 
         # Custom flow involving parsing the arguments of this parser first, then passing the configured values
         # as part of the argument source


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

A few minor fixes to resolve errors that are reported when the VSCode `python.analysis.typeCheckingMode` setting is set to "standard". In particular:

`fprime_gds.common.communication.adapters.base.BaseAdapter`: Add type annotations to `read` and `write` functions to match what is described in the doc string. Without these, the type checker assumes the return type is `None` and reports errors when the overridden functions in the derived class return bytes/boolean values respectively. Also updates the `IpAdapter` accordingly.

```
Method "read" overrides class "BaseAdapter" in an incompatible manner
  Return type mismatch: base method returns type "None", override returns type "bytes"
    "bytes" is not assignable to "None" Pylance (reportIncompatibleMethodOverride)
```

`fprime_gds.executables.cli.ParserBase`: Add type annotations for the `DESCRIPTION` member. Without this, the type checker assumes the type is `None` and reports errors when trying to assign a description string to one of the derived classes such as `ConfigDrivenParser`.

```
Cannot assign to attribute "DESCRIPTION" for class "type[ConfigDrivenParser]"
  Expression of type "Literal['Here is a placeholder string']" cannot be assigned to attribute "DESCRIPTION" of class "ConfigDrivenParser"
    "Literal['Here is a placeholder string']" is not assignable to "None" Pylance (reportAttributeAccessIssue)
```

## Rationale

Python linting and type-checking improvements

## Testing/Review Recommendations

## Future Work

N/A
