### PR TITLE
Fix JSON value serialization in command generation

### DIFF
--- a/src/fprime_gds/common/tools/params.py
+++ b/src/fprime_gds/common/tools/params.py
@@ -111,7 +111,7 @@ def parsed_json_to_seq(templates_and_values: list[tuple[PrmTemplate, dict]], inc
     for template_and_value in templates_and_values:
         template, json_value = template_and_value
         set_cmd_name = template.comp_name + "." + template.prm_name.upper() + "_PRM_SET"
-        cmd = "R00:00:00 " + set_cmd_name + " " + str(json_value)
+        cmd = "R00:00:00 " + set_cmd_name + " " + js.dumps(json_value)
         cmds.append(cmd)
         if include_save:
             save_cmd = template.comp_name + "." + template.prm_name.upper() + "_PRM_SAVE"


### PR DESCRIPTION
Double quotation marks no longer replaced with apostrophes, which allows sequence files to be converted into bin files.

| | |
|:---|:---|
|**_Related Issue(s)_**| #5248 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

One line changed in params.py to allow double quotations around strings in a JSON file to be converted into the sequence file as quotation marks by the fprime-prm-write tool. Previously, the quotation marks were being converted as apostrophes, which does not allow the sequence file to be converted into a .bin file by fprime-seqgen.

## Rationale

I honestly do not know if this is the best fix or way to go about fixing a small bug like this, but it worked when I tried to create my own bin file from a sequence file locally.

## Testing/Review Recommendations
Someone else may also want to try creating a json with a string type parameter, creating a sequence file using fprime-prm-write, and then converting to .bin using fprime-seqgen.

## Future Work
No further work required.
