### PR TITLE
Fix ConstantJsonLoader crash when constants field is missing

### DIFF
--- a/src/fprime_gds/common/loaders/constant_json_loader.py
+++ b/src/fprime_gds/common/loaders/constant_json_loader.py
@@ -31,10 +31,11 @@ class ConstantJsonLoader(JsonLoader):
         """
         name_dict = {}
 
+        constants = self.json_dict.get(self.CONSTANTS_FIELD, [])
         if self.CONSTANTS_FIELD not in self.json_dict:
-            print(f"[WARNING] Ground Dictionary missing 'constants' field, relying on defaults. In: {str(self.json_file)}")
+            print(f"[WARNING] Ground Dictionary has no 'constants' field; no constants will be loaded. In: {str(self.json_file)}")
 
-        for constant in self.json_dict[self.CONSTANTS_FIELD]:
+        for constant in constants:
             try:
                 name_dict[constant["qualifiedName"]] = constant["value"]
             except KeyError as e:


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| https://github.com/nasa/fprime/issues/5252 |
|**_Has Unit Tests (y/n)_**| n |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Updates `ConstantJsonLoader` to handle a missing `constants` field by defaulting to an empty list rather than attempting to access a non-existent dictionary key.

## Rationale

`ConstantJsonLoader` currently emits a warning when the constants field is missing, but then still attempts to access the missing field, raising a `KeyError`.

This change aligns the implementation with the existing warning behaviour by treating missing constants as an empty collection and allowing startup to continue.

## Testing/Review Recommendations

1. Load a JSON dictionary containing a valid constants field and verify existing behaviour is unchanged.
2. Load a JSON dictionary without a constants field and verify:
    - A warning is emitted.
    - No exception is raised, and empty constants dictionary is returned.

## Future Work

None
