### PR TITLE
Add configurable GDS application root for reverse-proxy deployments

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1296,7 +1296,15 @@ class GdsParser(ParserBase):
                 "dest": "browser_auto_open",
                 "action": "store_false",
                 "help": "Run server without auto-launching the default web browser"
-                }
+                },
+            ("--gui-root-path",): {
+                "dest": "gui_root_path",
+                "action": "store",
+                "default": "",
+                "required": False,
+                "type": str,
+                "help": "URL prefix when serving behind a reverse proxy (e.g. /fprime-gds-2). [default: %(default)s]",
+            },
         }
 
     def handle_arguments(self, args, **kwargs):

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -20,6 +20,7 @@ from fprime_gds.executables.cli import (
     PluginArgumentParser,
 )
 from fprime_gds.executables.utils import AppWrapperException, run_wrapped_application
+from fprime_gds.flask.prefix import normalize_application_root
 from fprime_gds.plugin.system import Plugins
 
 BASE_MODULE_ARGUMENTS = [sys.executable, "-u", "-m"]
@@ -118,11 +119,13 @@ def launch_html(parsed_args):
     if "--log-directly" not in reproduced_arguments:
         reproduced_arguments += ["--log-directly"]
     flask_env = os.environ.copy()
+    root_path = normalize_application_root(getattr(parsed_args, "gui_root_path", "") or "")
     flask_env.update(
         {
             "FLASK_APP": "fprime_gds.flask.app",
             "STANDARD_PIPELINE_ARGUMENTS": "|".join(reproduced_arguments),
             "SERVE_LOGS": "YES",
+            "FP_GDS_APPLICATION_ROOT": root_path,
         }
     )
     if parsed_args.hash_file:
@@ -136,7 +139,7 @@ def launch_html(parsed_args):
         str(parsed_args.gui_port),
     ]
     ret = launch_process(gse_args, name="HTML GUI", env=flask_env, launch_time=2)
-    ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
+    ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}{root_path}/"
     print(f"[INFO] Launched UI at: {ui_url}")
     
     if parsed_args.browser_auto_open:

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -30,6 +30,7 @@ import fprime_gds.flask.sequence
 import fprime_gds.flask.stats
 import fprime_gds.flask.updown
 from fprime_gds.executables.cli import ParserBase, StandardPipelineParser, ConfigDrivenParser
+from fprime_gds.flask.prefix import ScriptNameMiddleware, normalize_application_root
 
 from . import components
 
@@ -75,6 +76,13 @@ def construct_app():
     # Load app configuration from file
     for key, value in args_ns.config_values.get("flask", {}).items():
         app.config[key] = value
+
+    application_root = normalize_application_root(
+        getattr(args_ns, "gui_root_path", "") or app.config.get("APPLICATION_ROOT", "") or ""
+    )
+    app.config["APPLICATION_ROOT"] = application_root
+    if application_root:
+        app.wsgi_app = ScriptNameMiddleware(app.wsgi_app, application_root)
 
     pipeline = components.setup_pipelined_components(app.debug, args_ns)
 
@@ -197,6 +205,14 @@ def handle_unexpected_error(error):
     status_code = 500
     response = {"errors": [fprime_gds.flask.errors.build_error_object(error)]}
     return flask.jsonify(response), status_code
+
+
+@app.route("/js/bootstrap-config.js")
+def bootstrap_config_serve():
+    """Inject runtime apiBasePath for subpath / reverse-proxy deployments."""
+    base = normalize_application_root(flask.current_app.config.get("APPLICATION_ROOT", ""))
+    body = f'import {{config}} from "./config_init.js";\nconfig.apiBasePath = "{base}";\n'
+    return flask.Response(body, mimetype="application/javascript")
 
 
 @app.route("/js/config.js")

--- a/src/fprime_gds/flask/default_settings.py
+++ b/src/fprime_gds/flask/default_settings.py
@@ -10,9 +10,13 @@
 ####
 import os
 
-STANDARD_PIPELINE_ARGUMENTS = os.environ.get("STANDARD_PIPELINE_ARGUMENTS").split("|")
+_standard_pipeline = os.environ.get("STANDARD_PIPELINE_ARGUMENTS", "")
+STANDARD_PIPELINE_ARGUMENTS = _standard_pipeline.split("|") if _standard_pipeline else []
 
 SERVE_LOGS = os.environ.get("SERVE_LOGS", "YES") == "YES"
+
+# Optional subpath for reverse-proxy deployments (nasa/fprime#3854).
+APPLICATION_ROOT = os.environ.get("FP_GDS_APPLICATION_ROOT", "")
 
 MAX_CONTENT_LENGTH = 32 * 1024 * 1024  # Max length of request is 32MiB
 

--- a/src/fprime_gds/flask/prefix.py
+++ b/src/fprime_gds/flask/prefix.py
@@ -1,0 +1,30 @@
+"""URL prefix helpers for reverse-proxy and subpath GDS deployments."""
+
+from __future__ import annotations
+
+
+def normalize_application_root(value: str | None) -> str:
+    """Normalize CLI/env root path to '' or '/segment' without trailing slash."""
+    if not value:
+        return ""
+    root = value.strip()
+    if not root.startswith("/"):
+        root = f"/{root}"
+    return root.rstrip("/")
+
+
+class ScriptNameMiddleware:
+    """Strip a configured SCRIPT_NAME prefix from incoming WSGI requests."""
+
+    def __init__(self, app, script_name: str):
+        self.app = app
+        self.script_name = normalize_application_root(script_name)
+
+    def __call__(self, environ, start_response):
+        if self.script_name:
+            environ["SCRIPT_NAME"] = self.script_name
+            path_info = environ.get("PATH_INFO", "")
+            if path_info.startswith(self.script_name):
+                stripped = path_info[len(self.script_name) :]
+                environ["PATH_INFO"] = stripped if stripped else "/"
+        return self.app(environ, start_response)

--- a/src/fprime_gds/flask/static/index.html
+++ b/src/fprime_gds/flask/static/index.html
@@ -32,6 +32,7 @@ Note: Vue.js annotations are used, as Vue is the data-to-view framework of choic
         <!-- Third-party JavaScript files, hosted locally to remove internet dependence -->
         <script src="third-party/js/vue.min.js"></script>
         <script src="third-party/js/luxon.min.js"></script>
+        <script type="module" src="js/bootstrap-config.js"></script>
         <!-- JavaScript GDS files -->
         <script type="module" src="js/gds.js"></script>
     </head>

--- a/src/fprime_gds/flask/static/js/config_init.js
+++ b/src/fprime_gds/flask/static/js/config_init.js
@@ -49,6 +49,9 @@ export let config = {
     //
     // Thus dashboards are disabled by default and projects must opt-in thus taking the responsibility
     // to validate and review the safety of the dashboards they use.
-    enableDashboards: false
+    enableDashboards: false,
+
+    // Prefix for REST API calls when GDS is served behind a reverse proxy subpath.
+    apiBasePath: ""
 };
 

--- a/src/fprime_gds/flask/static/js/loader.js
+++ b/src/fprime_gds/flask/static/js/loader.js
@@ -203,7 +203,7 @@ class Loader {
                     reject(this.responseText);
                 }
             };
-            let url = endpoint;
+            let url = (config.apiBasePath || "") + endpoint;
             let session = (_self.endpoints["session"].data || {}).session || null;
 
             let arg_pairs = [["session", session], ["limit", _settings.miscellaneous.response_object_limit]];

--- a/test/fprime_gds/flask/test_prefix.py
+++ b/test/fprime_gds/flask/test_prefix.py
@@ -1,0 +1,34 @@
+"""Tests for GDS application root / reverse-proxy support."""
+
+from fprime_gds.flask.prefix import ScriptNameMiddleware, normalize_application_root
+
+
+def test_normalize_application_root_empty():
+    assert normalize_application_root("") == ""
+    assert normalize_application_root(None) == ""
+
+
+def test_normalize_application_root_adds_leading_slash():
+    assert normalize_application_root("fprime-gds-2") == "/fprime-gds-2"
+
+
+def test_normalize_application_root_strips_trailing_slash():
+    assert normalize_application_root("/fprime-gds-2/") == "/fprime-gds-2"
+
+
+def test_script_name_middleware_strips_prefix():
+    captured = {}
+
+    def app(environ, start_response):
+        captured["PATH_INFO"] = environ["PATH_INFO"]
+        captured["SCRIPT_NAME"] = environ["SCRIPT_NAME"]
+        start_response("200 OK", [])
+        return [b""]
+
+    wrapped = ScriptNameMiddleware(app, "/fprime-gds-2")
+    wrapped(
+        {"PATH_INFO": "/fprime-gds-2/dictionary/commands", "SCRIPT_NAME": ""},
+        lambda status, headers: None,
+    )
+    assert captured["PATH_INFO"] == "/dictionary/commands"
+    assert captured["SCRIPT_NAME"] == "/fprime-gds-2"


### PR DESCRIPTION
## Summary

Implements configurable path-prefix support for the GDS web UI and API, addressing nasa/fprime#3854 (CCB-approved by @LeStarch).

- Add `FP_GDS_APPLICATION_ROOT` env var and `--gui-root-path` CLI flag
- Serve static assets and API routes under the configured prefix via `ScriptNameMiddleware`
- Inject `bootstrap-config.js` so the browser prefixes fetch URLs correctly
- Fix `ui_url` printed at startup to include the prefix

## Test plan

- [x] `pytest test/fprime_gds/flask/test_prefix.py` (4 tests)
- [ ] Manual: `fprime-gds --gui-root-path /fprime-gds-2` behind a reverse proxy
- [ ] Manual: verify default behavior unchanged when prefix is unset