### PR TITLE
Preserve literal percent placed directly before a conversion in C-style format strings

### DIFF
--- a/src/fprime_gds/common/utils/string_util.py
+++ b/src/fprime_gds/common/utils/string_util.py
@@ -89,7 +89,9 @@ def preprocess_c_style_format_str(format_str: str) -> str:
     def convert(match_obj: re.Match):
         if match_obj.group() is None:
             return match_obj
-        flags, width, precision, _, conversion_type = match_obj.groups()
+        literal_percents, flags, width, precision, _, conversion_type = (
+            match_obj.groups()
+        )
         format_template = ""
         if flags:
             format_template += f"{flags}"
@@ -101,9 +103,14 @@ def preprocess_c_style_format_str(format_str: str) -> str:
         if conversion_type and str(conversion_type).lower() in {"f", "x", "o", "e"}:
             format_template += f"{conversion_type}"
 
-        return "{}" if format_template == "" else "{:" + format_template + "}"
+        body = "{}" if format_template == "" else "{:" + format_template + "}"
+        # A leading run of "%%" pairs is literal text (each pair is one "%").
+        # Keep it in front of the converted field; the trailing replace below
+        # collapses "%%" -> "%" uniformly. Without this the literal percent is
+        # dropped when "%%" sits directly before a conversion, e.g. "%%%d".
+        return f"{literal_percents or ''}{body}"
 
-    pattern = r"(?<!%)(?:%%)*%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"  # NOSONAR
+    pattern = r"(?<!%)((?:%%)*)%([\-\+0\ \#])?(\d+|\*)?(\.\*|\.\d+)?([hLIw]|l{1,2}|I32|I64)?([cCdiouxXeEfgGaAnpsSZ])"  # NOSONAR
 
     match = re.compile(pattern)
 

--- a/test/fprime_gds/common/utils/test_string_util.py
+++ b/test/fprime_gds/common/utils/test_string_util.py
@@ -101,6 +101,22 @@ class TestFormatString(unittest.TestCase):
         actual = format_string_template(preprocess_c_style_format_str(template), values)
         self.assertEqual(expected, actual)
 
+    def test_format_percent_sign_before_conversion(self):
+        # A literal "%%" that comes right before a conversion must survive.
+        # C prints "%5" here, not "5".
+        template = "%%%d"
+        values = (5,)
+        expected = "%5"
+        actual = format_string_template(preprocess_c_style_format_str(template), values)
+        self.assertEqual(expected, actual)
+
+    def test_format_percent_sign_before_conversion_in_text(self):
+        template = "progress %%%d complete"
+        values = (50,)
+        expected = "progress %50 complete"
+        actual = format_string_template(preprocess_c_style_format_str(template), values)
+        self.assertEqual(expected, actual)
+
     def test_format_single_value(self):
         template = "%.2f%%"
         values = 1.23456


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| N/A |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

`preprocess_c_style_format_str` in `common/utils/string_util.py` converts C-style format strings to Python format strings. The pattern begins with `(?<!%)(?:%%)*%...`, so any run of literal `%%` pairs sitting right before a conversion is swallowed by that non-capturing group. `convert()` only rebuilt the field from the flags/width/precision/type groups, so those leading pairs were never re-emitted and the literal percent was lost.

Concretely, `%%%d` was turned into `{}` instead of `%{}`, and the full pipeline `format_string_template(preprocess_c_style_format_str("%%%d"), 5)` returned `"5"` where C prints `"%5"`.

The fix captures the `%%` run and puts it back in front of the converted field. The existing trailing `.replace("%%", "%")` still collapses the pairs to single percents uniformly, so no other case changes.

## Rationale

Fixes a correctness bug: a literal percent that immediately precedes a formatted value silently disappears from event and channel display text. Format strings like `"progress %%%d complete"` rendered as `"progress 50 complete"` instead of `"progress %50 complete"`.

## Testing/Review Recommendations

- `pytest test/fprime_gds/common/utils/test_string_util.py` (28 passed).
- Two tests were added, `test_format_percent_sign_before_conversion` and `test_format_percent_sign_before_conversion_in_text`. Both fail on `devel` and pass with this change.
- Worth confirming the unchanged cases still hold: standalone `%%` (`"%.2f%%"` -> `"1.23%"`), a plain `%d`, and text like `"100%% done: %d"`.

## Future Work

None.