### PR TITLE
changing send command to send and assert command for set tlm level so…

### DIFF
--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -519,7 +519,7 @@ class IntegrationTestAPI(DataHandler):
         """
         for name in self.pipeline.dictionaries.command_name:
             if name.endswith(".SET_LEVEL"):
-                self.send_command(name, [level])
+                self.send_and_assert_command(name, [level], timeout=5)
                 return
         self.__log("SET_LEVEL command not found in dictionary; skipping set_tlm_packet_level", TestLogger.YELLOW)
 

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -506,7 +506,7 @@ class IntegrationTestAPI(DataHandler):
         command = self.translate_command_name(command)
         self.pipeline.send_command(command, args)
 
-    def set_tlm_packet_level(self, level=3):
+    def set_tlm_packet_level(self, level=3,timeout=10):
         """
         Set the telemetry packet level on FSW to enable/disable telemetry packet groups.
 
@@ -516,10 +516,11 @@ class IntegrationTestAPI(DataHandler):
 
         Args:
             level: telemetry packet level to set (default 3 enables all)
+            timeout: the number of seconds to wait before terminating the search (int)
         """
         for name in self.pipeline.dictionaries.command_name:
             if name.endswith(".SET_LEVEL"):
-                self.send_and_assert_command(name, [level], timeout=10)
+                self.send_and_assert_command(name, [level], timeout=timeout)
                 return
         self.__log("SET_LEVEL command not found in dictionary; skipping set_tlm_packet_level", TestLogger.YELLOW)
 

--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -519,7 +519,7 @@ class IntegrationTestAPI(DataHandler):
         """
         for name in self.pipeline.dictionaries.command_name:
             if name.endswith(".SET_LEVEL"):
-                self.send_and_assert_command(name, [level], timeout=5)
+                self.send_and_assert_command(name, [level], timeout=10)
                 return
         self.__log("SET_LEVEL command not found in dictionary; skipping set_tlm_packet_level", TestLogger.YELLOW)
 


### PR DESCRIPTION
… that we have to wait for completion

| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

send_command --> send_and_assert in order to wait for command completion

## Rationale

A rationale for this change. e.g. fixes bug, or most projects need XYZ feature.

## Testing/Review Recommendations

Fill in testing procedures, specific items to focus on for review, or other info to help the team verify these changes are flight-quality.

## Future Work

Note any additional work that will be done relating to this issue.
