### PR TITLE
Fix fprime-prm-write dropping parameters with falsy values

### DIFF
--- a/src/fprime_gds/common/tools/params.py
+++ b/src/fprime_gds/common/tools/params.py
@@ -158,7 +158,7 @@ def parse_json(param_value_json, name_dict: dict[str, PrmTemplate], include_impl
                 # get the value
                 prm_val = comp_json[prm_template.prm_name]
         
-        if not prm_val:
+        if prm_val is None:
             # not writing a val for this prm
             continue
 

--- a/test/fprime_gds/common/tools/test_paramdb_gen.py
+++ b/test/fprime_gds/common/tools/test_paramdb_gen.py
@@ -1,7 +1,10 @@
 import filecmp
 from pathlib import Path
+import pytest
 import tempfile
-from fprime_gds.common.tools.params import convert_json
+
+from fprime_gds.common.tools.params import convert_json, parse_json
+from fprime_gds.common.loaders.prm_json_loader import PrmJsonLoader
 
 
 def assert_prmdb_cfg(input: Path, expected_output: Path = None, should_fail=False):
@@ -37,3 +40,11 @@ def test_nominal_paramdb():
 def test_failure_paramdb():
     cfg_file = Path(__file__).parent / "input" / "simple_bad_paramdb.json"
     assert_prmdb_cfg(cfg_file, should_fail=True)
+
+@pytest.mark.parametrize("value", ["", 0, 0.0])
+def test_parse_json_keeps_falsy_values(value):
+    dict_file = Path(__file__).parent / "resources" / "simple_dictionary.json"
+    _, name_dict, _ = PrmJsonLoader(str(dict_file)).construct_dicts(str(dict_file))
+    result = parse_json({"cmdDisp": {"FAKE_PRM": value}}, name_dict, False)
+    names = [t.prm_name for t, _ in result]
+    assert "FAKE_PRM" in names

--- a/test/fprime_gds/common/tools/test_paramdb_gen.py
+++ b/test/fprime_gds/common/tools/test_paramdb_gen.py
@@ -41,7 +41,7 @@ def test_failure_paramdb():
     cfg_file = Path(__file__).parent / "input" / "simple_bad_paramdb.json"
     assert_prmdb_cfg(cfg_file, should_fail=True)
 
-@pytest.mark.parametrize("value", ["", 0, 0.0])
+@pytest.mark.parametrize("value", ["", 0, 0.0, False])
 def test_parse_json_keeps_falsy_values(value):
     dict_file = Path(__file__).parent / "resources" / "simple_dictionary.json"
     _, name_dict, _ = PrmJsonLoader(str(dict_file)).construct_dicts(str(dict_file))


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  nasa/fprime#5451 |
|**_Has Unit Tests (y/n)_**|  y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

parse_json() used `if not prm_val` to skip parameters that have no value, which also skipped parameters explicitly set to a falsy value (0, 0.0, "", False) -- silently omitting them from the output. An explicit falsy value overriding a truthy default dropped the parameter entirely. Test with `is None` so only genuinely absent values are skipped and explicit falsy values are preserved. AI-assisted development; I understand and take responsibility for every line.

## Rationale

Refs nasa/fprime#5451

## Testing/Review Recommendations

Added a regression test covering falsy parameter values.

## Future Work

None.
