### PR TITLE
Fix fprime-prm-write dropping falsy parameter values

### DIFF
--- a/src/fprime_gds/common/tools/params.py
+++ b/src/fprime_gds/common/tools/params.py
@@ -158,8 +158,10 @@ def parse_json(param_value_json, name_dict: dict[str, PrmTemplate], include_impl
                 # get the value
                 prm_val = comp_json[prm_template.prm_name]
         
-        if not prm_val:
+        if prm_val is None:
             # not writing a val for this prm
+            # NOTE: must be an explicit None check: falsy values (0, 0.0,
+            # False, "") are valid parameter values and must be written
             continue
 
         templates_to_values.append((prm_template, prm_val))

--- a/test/fprime_gds/common/tools/test_prm_falsy.py
+++ b/test/fprime_gds/common/tools/test_prm_falsy.py
@@ -1,0 +1,48 @@
+"""Regression tests for nasa/fprime#5451: parse_json must not drop
+parameters whose explicit value is falsy (0, 0.0, False, "")."""
+from pathlib import Path
+
+import pytest
+
+from fprime_gds.common.loaders.prm_json_loader import PrmJsonLoader
+from fprime_gds.common.tools.params import parse_json
+
+DICT_FILE = Path(__file__).parent / "resources" / "simple_dictionary.json"
+
+
+@pytest.fixture()
+def name_dict():
+    loader = PrmJsonLoader(str(DICT_FILE.resolve()))
+    _, name_dict, _ = loader.construct_dicts(str(DICT_FILE.resolve()))
+    assert name_dict, "test dictionary should define at least one parameter"
+    return name_dict
+
+
+def _first_param(name_dict):
+    fqn, template = next(iter(name_dict.items()))
+    return fqn, template
+
+
+@pytest.mark.parametrize("falsy_value", [0, 0.0, False, ""])
+def test_explicit_falsy_value_is_kept(name_dict, falsy_value):
+    fqn, template = _first_param(name_dict)
+    param_value_json = {template.comp_name: {template.prm_name: falsy_value}}
+
+    result = parse_json(param_value_json, name_dict, False)
+
+    matches = [val for tmpl, val in result if tmpl is template]
+    assert matches == [falsy_value], (
+        f"explicit value {falsy_value!r} for {fqn} was dropped"
+    )
+
+
+def test_explicit_falsy_overrides_default(name_dict):
+    """With implicit defaults enabled, an explicit falsy value must win
+    over the dictionary default instead of vanishing entirely."""
+    fqn, template = _first_param(name_dict)
+    param_value_json = {template.comp_name: {template.prm_name: 0}}
+
+    result = parse_json(param_value_json, name_dict, True)
+
+    matches = [val for tmpl, val in result if tmpl is template]
+    assert matches == [0], f"falsy override for {fqn} was dropped"


### PR DESCRIPTION
## Change Description
`parse_json` decided whether a parameter had a value with `if not prm_val`, which silently drops explicit falsy values (`0`, `0.0`, `false`, `""`). Changed to an explicit `is None` check and added regression tests covering each falsy value plus the implicit-defaults override case.

## Rationale
Addresses nasa/fprime#5451. A parameter file that silently omits explicitly-set values is dangerous for operations: the tool reports success while the uplinked file leaves the parameter at its previous value.

## Testing
New tests in `test/fprime_gds/common/tools/test_prm_falsy.py`; all pass locally alongside the existing `test_prm_decode.py` suite.