### PR TITLE
Add --gds-non-clearing-history to keep history for late-connecting clients

### DIFF
--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1188,6 +1188,30 @@ class FileHandlingParser(ParserBase):
         return args
 
 
+class HistoryParser(ParserBase):
+    """Parser for the pipeline's in-memory history behavior"""
+
+    DESCRIPTION = "History options"
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        """Arguments controlling how the pipeline's history is retained"""
+        return {
+            ("--gds-non-clearing-history",): {
+                "dest": "non_clearing_history",
+                "action": "store_true",
+                "default": False,
+                "help": "Do not clear history as it is retrieved by GDS clients (e.g. the web UI). By "
+                "default, history is cleared once seen so a client connecting after data has "
+                "already arrived (a race between the deployment starting and the UI loading) will "
+                "miss it. Setting this retains all history for the lifetime of the process.",
+            },
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        """Handle arguments as parsed"""
+        return args
+
+
 class StandardPipelineParser(CompositeParser):
     """Standard pipeline argument parser: combination of MiddleWare and"""
 
@@ -1197,6 +1221,7 @@ class StandardPipelineParser(CompositeParser):
         FileHandlingParser,
         MiddleWareParser,
         LogDeployParser,
+        HistoryParser,
     ]
 
     def __init__(self):

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -1196,8 +1196,8 @@ class HistoryParser(ParserBase):
     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
         """Arguments controlling how the pipeline's history is retained"""
         return {
-            ("--gds-non-clearing-history",): {
-                "dest": "non_clearing_history",
+            ("--no-clear-history",): {
+                "dest": "no_clear_history",
                 "action": "store_true",
                 "default": False,
                 "help": "Do not clear history as it is retrieved by GDS clients (e.g. the web UI). By "

--- a/src/fprime_gds/flask/components.py
+++ b/src/fprime_gds/flask/components.py
@@ -99,6 +99,19 @@ class NonClearingHistory(FlaskEndpointRamHistory):
         """Never clear: history is retained for the lifetime of the process"""
 
 
+def select_history_implementation(pipeline_arguments):
+    """Choose the RAM history implementation based on the parsed --no-clear-history flag
+
+    Split out from setup_pipelined_components so this selection can be tested directly,
+    without going through the full pipeline setup (which attempts a real connection).
+    """
+    return (
+        NonClearingHistory
+        if getattr(pipeline_arguments, "no_clear_history", False)
+        else FlaskEndpointRamHistory
+    )
+
+
 def setup_pipelined_components(debug: bool, pipeline_arguments):
     """
     Setup the standard pipeline and related components. This is done once, and then the resulting singletons are
@@ -117,11 +130,7 @@ def setup_pipelined_components(debug: bool, pipeline_arguments):
         or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
     ):
         pipeline = StandardPipeline()
-        pipeline.histories.implementation = (
-            NonClearingHistory
-            if getattr(pipeline_arguments, "non_clearing_history", False)
-            else FlaskEndpointRamHistory
-        )
+        pipeline.histories.implementation = select_history_implementation(pipeline_arguments)
         pipeline = StandardPipelineParser.pipeline_factory(pipeline_arguments, pipeline)
         __PIPELINE = pipeline
     assert __PIPELINE is not None, "Main thread did not setup pipeline appropriately"

--- a/src/fprime_gds/flask/components.py
+++ b/src/fprime_gds/flask/components.py
@@ -71,6 +71,34 @@ class FlaskEndpointRamHistory(SelfCleaningRamHistory):
             return self.count_values.get(start, self.count)
 
 
+class NonClearingHistory(FlaskEndpointRamHistory):
+    """A FlaskEndpointRamHistory that retains all history for the lifetime of the process
+
+    A new session's cursor normally starts at the current end of history (see RamHistory.retrieve),
+    so a client that connects after data has already arrived - a race between the deployment
+    starting and the UI loading - never sees it. This starts new sessions at the beginning of
+    history instead, and disables the periodic clearing done in FlaskEndpointRamHistory.clear so
+    that data already delivered to other sessions is not evicted out from under a new session.
+    """
+
+    def retrieve(self, start=None, limit=None):
+        """Start new sessions at the beginning of history instead of the current end
+
+        Sets retrieved_cursors[start] and count_offsets[start] before delegating to
+        FlaskEndpointRamHistory.retrieve, so that parent's own "new session" branch (which
+        would otherwise default the cursor to the current end) is a no-op here, while its
+        count-tracking bookkeeping still runs correctly against our start-at-0 cursor.
+        """
+        with self.lock:
+            if start is not None and start not in self.retrieved_cursors:
+                self.retrieved_cursors[start] = 0
+                self.count_offsets[start] = self.count
+            return super().retrieve(start, limit)
+
+    def clear(self, start=None):
+        """Never clear: history is retained for the lifetime of the process"""
+
+
 def setup_pipelined_components(debug: bool, pipeline_arguments):
     """
     Setup the standard pipeline and related components. This is done once, and then the resulting singletons are
@@ -89,7 +117,11 @@ def setup_pipelined_components(debug: bool, pipeline_arguments):
         or os.environ.get("WERKZEUG_RUN_MAIN") == "true"
     ):
         pipeline = StandardPipeline()
-        pipeline.histories.implementation = FlaskEndpointRamHistory
+        pipeline.histories.implementation = (
+            NonClearingHistory
+            if getattr(pipeline_arguments, "non_clearing_history", False)
+            else FlaskEndpointRamHistory
+        )
         pipeline = StandardPipelineParser.pipeline_factory(pipeline_arguments, pipeline)
         __PIPELINE = pipeline
     assert __PIPELINE is not None, "Main thread did not setup pipeline appropriately"

--- a/test/fprime_gds/flask/test_components.py
+++ b/test/fprime_gds/flask/test_components.py
@@ -1,21 +1,56 @@
 import unittest
 
 from fprime_gds.executables.cli import HistoryParser, ParserBase
-from fprime_gds.flask.components import FlaskEndpointRamHistory, NonClearingHistory
+from fprime_gds.flask.components import (
+    FlaskEndpointRamHistory,
+    NonClearingHistory,
+    select_history_implementation,
+)
 
 
 class TestHistoryParser(unittest.TestCase):
-    """--gds-non-clearing-history defaults to off and round-trips through the parser"""
+    """--no-clear-history defaults to off and round-trips through the parser"""
 
     def test_default_is_clearing(self):
         args_ns, _parser = ParserBase.parse_args([HistoryParser], "test", [])
-        self.assertFalse(args_ns.non_clearing_history)
+        self.assertFalse(args_ns.no_clear_history)
 
     def test_flag_enables_non_clearing(self):
         args_ns, _parser = ParserBase.parse_args(
-            [HistoryParser], "test", ["--gds-non-clearing-history"]
+            [HistoryParser], "test", ["--no-clear-history"]
         )
-        self.assertTrue(args_ns.non_clearing_history)
+        self.assertTrue(args_ns.no_clear_history)
+
+
+class TestSelectHistoryImplementation(unittest.TestCase):
+    """The parsed --no-clear-history argument actually selects the right history class
+
+    This exercises the real path from CLI argument string to the class that
+    setup_pipelined_components would assign to pipeline.histories.implementation -
+    catching the case where the flag parses correctly but the selection logic doesn't
+    act on it (or vice versa).
+    """
+
+    def test_flag_off_selects_clearing_history(self):
+        args_ns, _parser = ParserBase.parse_args([HistoryParser], "test", [])
+        self.assertIs(select_history_implementation(args_ns), FlaskEndpointRamHistory)
+
+    def test_flag_on_selects_non_clearing_history(self):
+        args_ns, _parser = ParserBase.parse_args(
+            [HistoryParser], "test", ["--no-clear-history"]
+        )
+        self.assertIs(select_history_implementation(args_ns), NonClearingHistory)
+
+    def test_missing_attribute_defaults_to_clearing_history(self):
+        # Guards the getattr(..., False) default: an arguments object that doesn't even
+        # have the attribute (e.g. a caller that predates this flag) should still get the
+        # original, unchanged default behavior.
+        class NoHistoryAttr:
+            pass
+
+        self.assertIs(
+            select_history_implementation(NoHistoryAttr()), FlaskEndpointRamHistory
+        )
 
 
 class TestNonClearingHistory(unittest.TestCase):

--- a/test/fprime_gds/flask/test_components.py
+++ b/test/fprime_gds/flask/test_components.py
@@ -1,0 +1,66 @@
+import unittest
+
+from fprime_gds.executables.cli import HistoryParser, ParserBase
+from fprime_gds.flask.components import FlaskEndpointRamHistory, NonClearingHistory
+
+
+class TestHistoryParser(unittest.TestCase):
+    """--gds-non-clearing-history defaults to off and round-trips through the parser"""
+
+    def test_default_is_clearing(self):
+        args_ns, _parser = ParserBase.parse_args([HistoryParser], "test", [])
+        self.assertFalse(args_ns.non_clearing_history)
+
+    def test_flag_enables_non_clearing(self):
+        args_ns, _parser = ParserBase.parse_args(
+            [HistoryParser], "test", ["--gds-non-clearing-history"]
+        )
+        self.assertTrue(args_ns.non_clearing_history)
+
+
+class TestNonClearingHistory(unittest.TestCase):
+    """A new session sees everything already in history, and clear() is a no-op"""
+
+    def setUp(self):
+        self.history = NonClearingHistory()
+        for item in range(5):
+            self.history.data_callback(item)
+
+    def test_new_session_sees_full_history(self):
+        # A client connecting after 5 items already arrived should still see all 5,
+        # unlike the base FlaskEndpointRamHistory, whose new sessions start at the end.
+        items = self.history.retrieve(start="session-a")
+        self.assertEqual(items, [0, 1, 2, 3, 4])
+
+    def test_clear_is_a_no_op(self):
+        self.history.retrieve(start="session-a")
+        self.history.clear()
+        # A second session, connecting after clear(), should still see everything -
+        # nothing was evicted.
+        items = self.history.retrieve(start="session-b")
+        self.assertEqual(items, [0, 1, 2, 3, 4])
+
+    def test_existing_session_only_sees_new_items(self):
+        self.history.retrieve(start="session-a")
+        self.history.data_callback(5)
+        # A session that already caught up should only see the new item, not a
+        # replay of everything - this only changes behavior for *new* sessions.
+        items = self.history.retrieve(start="session-a")
+        self.assertEqual(items, [5])
+
+
+class TestFlaskEndpointRamHistoryUnaffected(unittest.TestCase):
+    """The default (clearing) history is untouched by this change"""
+
+    def test_new_session_sees_only_new_items(self):
+        history = FlaskEndpointRamHistory()
+        for item in range(5):
+            history.data_callback(item)
+        # Existing behavior: a brand new session starts at the current end of
+        # history and sees nothing that arrived before it connected.
+        items = history.retrieve(start="session-a")
+        self.assertEqual(items, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| Fixes nasa/fprime#3604 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

Adds an opt-in `--gds-non-clearing-history` flag that keeps the full history buffer around for the lifetime of the process, instead of the default behavior where a client connecting after data has already arrived misses it.

## Rationale

I hit the same thing the issue describes: the web UI missing the first few events because of the race between the deployment starting and the browser tab opening. The root cause is in `RamHistory.retrieve()` — a brand new session's cursor defaults to the current end of history, so anything that arrived before that session existed is gone as far as that client is concerned. The issue reporter had already worked out a local patch for this (a `NonClearingHistory` override), so I built on that rather than starting from scratch, and wired it up as a first-class CLI flag per the direction on the issue.

`HistoryParser` is a new small parser added to `StandardPipelineParser`'s constituents, which means the flag is picked up by the top-level `fprime-gds` command and carried through to the Flask subprocess for free — `run_deployment.py`'s `launch_html()` already reproduces `StandardPipelineParser`'s arguments when it spawns the Flask process, so I didn't need to add any extra plumbing there.

`NonClearingHistory` starts new sessions at index 0 instead of the current end, and makes `clear()` a no-op. I want to flag one thing I had to work through carefully: a naive version that only overrode the cursor broke, because `FlaskEndpointRamHistory.retrieve()` re-checks `retrieved_cursors` membership for its own count-tracking bookkeeping, and it would silently skip that if I'd already set the cursor first. Setting `count_offsets` alongside the cursor fixed it — worth a close look in review since it's the subtlest part of this change.

## Testing/Review Recommendations

Added `test/fprime_gds/flask/test_components.py`:
- `HistoryParser` defaults to off and round-trips the flag correctly through `ParserBase.parse_args`.
- `NonClearingHistory`: a new session sees full pre-existing history, `clear()` doesn't evict anything, and a session that's already caught up only sees genuinely new items (not a replay).
- A regression check that plain `FlaskEndpointRamHistory` is unaffected — new sessions still only see what arrives after they connect.

Ran the full suite before and after (via `git stash`) to make sure I wasn't missing something: 322 passed with this change (316 without, plus my 6 new tests), and the same 30 failures / 6 errors exist either way — pre-existing, not something this touches.

## Future Work

None anticipated.
