### PR TITLE
seqgen: narrow the bare except when opening the output file

### DIFF
--- a/src/fprime_gds/common/tools/seqgen.py
+++ b/src/fprime_gds/common/tools/seqgen.py
@@ -114,9 +114,9 @@ def generateSequence(inputFile, outputFile, dictionary, timebase, cont=False):
         outputFile = f"{os.path.splitext(inputFile)[0]}.bin"
     try:
         writer.open(outputFile)
-    except:
-        msg = f"Encountered problem opening output file '{outputFile}'."
-        raise SeqGenException(msg)
+    except OSError as exc:
+        msg = f"Encountered problem opening output file '{outputFile}': {exc}"
+        raise SeqGenException(msg) from exc
 
     writer.write(command_list)
     writer.close()


### PR DESCRIPTION
## What

`generateSequence` in `src/fprime_gds/common/tools/seqgen.py` wraps `writer.open(outputFile)` in a bare `except:`. This narrows it to `OSError`, includes the underlying error in the message, and chains the original exception.

```diff
     try:
         writer.open(outputFile)
-    except:
-        msg = f"Encountered problem opening output file '{outputFile}'."
-        raise SeqGenException(msg)
+    except OSError as exc:
+        msg = f"Encountered problem opening output file '{outputFile}': {exc}"
+        raise SeqGenException(msg) from exc
```

## Why

`fprime-seqgen` is a user-facing entry point (`[project.scripts]` in `pyproject.toml`), so both effects are visible to users.

**1. `Ctrl+C` is swallowed.** A bare `except:` catches `KeyboardInterrupt` and `SystemExit`. Pressing `Ctrl+C` while the output file is being opened does not interrupt the run — it produces a misleading "problem opening output file" error instead. Reproduced against the current code:

```
current  -> Ctrl+C swallowed, user sees: Encountered problem opening output file 'out.bin'.
patched  -> KeyboardInterrupt propagates
```

**2. The cause is discarded.** The message names the file but never says why it could not be opened. A missing directory, a permission error and a read-only filesystem are all reported identically, and because the exception is re-raised without `from`, the original traceback is gone too. After the change:

```
Encountered problem opening output file '/nonexistent/out.bin': [Errno 2] No such file or directory: '/nonexistent/out.bin'
```

`OSError` is the right width here: `SeqBinaryWriter.open` does `self.__fd = open(filename, "wb")` (`seq_writer.py:34`), so `FileNotFoundError`, `PermissionError`, `IsADirectoryError` and the rest are all `OSError` subclasses and stay caught. Nothing that was previously handled becomes unhandled, except the control-flow exceptions that should never have been caught.

## Scope

This is the only bare `except:` in `src/` — I checked the rest of the tree rather than assuming, and did not touch anything else. There are also ~63 places that re-raise inside an `except` without `from`, but many of those look like deliberate choices to hide internals, so I left them alone rather than sweeping them into an unrelated diff.

## Testing

- `pytest test/fprime_gds/common/tools/seqgen_unit_test.py` — 2 passed.
- `python -m py_compile` on the changed file.
- The `Ctrl+C` behaviour above was reproduced with a stub writer that raises `KeyboardInterrupt` from `open`, before and after the change.

## AI disclosure

AI-assisted (Claude Code), disclosed here in the spirit of the `AI_POLICY.md` that `nasa/fprime` carries — this repository does not have one of its own. The tool was used to scan the tree for exception-handling anti-patterns and to draft this description. The finding was checked before opening: `SeqBinaryWriter.open` was read to confirm `OSError` is the correct width, the bare-`except` count was verified across `src/`, and the reproduction and unit tests above were run. I have reviewed and understood the change and take responsibility for it.
