### PR TITLE
Add configurable base URL support to the GDS

### DIFF
--- a/docs/base-url.rst
+++ b/docs/base-url.rst
@@ -1,0 +1,18 @@
+Serving the GDS below a base URL
+================================
+
+The HTML GDS can be served below a URL path instead of the web-server root. This is useful when the GDS is placed behind a reverse proxy or when multiple GDS instances share one host.
+
+Use ``--base-url`` when starting the GDS::
+
+   fprime-gds --base-url /mission/gds
+
+The UI and REST resources are then available below ``/mission/gds/``. Omitting ``--base-url`` preserves the existing root-path behavior.
+
+The value must be a URL path, not a complete URL. Schemes, hosts, queries, fragments, empty path segments, and parent-directory segments are rejected.
+
+For example, an nginx location can forward the prefixed path directly to the GDS::
+
+   location /mission/gds/ {
+       proxy_pass http://127.0.0.1:5000/mission/gds/;
+   }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ Table of Contents
 .. toctree::
    :maxdepth: 2
 
+   Serving below a base URL <base-url.rst>
    API <api/index.rst>
 
 

--- a/src/fprime_gds/executables/base_url.py
+++ b/src/fprime_gds/executables/base_url.py
@@ -1,0 +1,62 @@
+"""Utilities and command-line parsing for serving the GDS below a URL prefix."""
+
+from typing import Any, Dict, Tuple
+from urllib.parse import unquote, urlsplit
+
+from fprime_gds.executables.cli import ParserBase
+
+
+def normalize_base_url(value: str) -> str:
+    """Normalize a GDS base URL path.
+
+    The GDS accepts a path prefix only, not an absolute URL. The root path is
+    represented internally as an empty string so that prefixing ``/channels``
+    preserves the existing route.
+    """
+    value = (value or "").strip()
+    if value in ("", "/"):
+        return ""
+
+    parsed = urlsplit(value)
+    if parsed.scheme or parsed.netloc or parsed.query or parsed.fragment:
+        raise ValueError("base URL must be a path without scheme, host, query, or fragment")
+
+    path = f"/{parsed.path.strip('/')}"
+    decoded_segments = [unquote(segment) for segment in path.split("/")[1:]]
+    if any(
+        not segment
+        or segment in (".", "..")
+        or "/" in segment
+        or "\\" in segment
+        for segment in decoded_segments
+    ):
+        raise ValueError("base URL contains an invalid path segment")
+    return path
+
+
+def with_base_url(base_url: str, path: str) -> str:
+    """Prefix an application route with ``base_url``."""
+    if not path.startswith("/"):
+        path = f"/{path}"
+    return f"{normalize_base_url(base_url)}{path}"
+
+
+class BaseUrlParser(ParserBase):
+    """Parse the URL prefix used to serve the HTML GDS."""
+
+    DESCRIPTION = "Web UI path options"
+
+    def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
+        return {
+            ("--base-url",): {
+                "dest": "base_url",
+                "action": "store",
+                "default": "",
+                "required": False,
+                "type": normalize_base_url,
+                "help": "Serve the HTML GDS below this URL path (for example: /mission/gds).",
+            }
+        }
+
+    def handle_arguments(self, args, **kwargs):
+        return args

--- a/src/fprime_gds/executables/run_deployment.py
+++ b/src/fprime_gds/executables/run_deployment.py
@@ -9,6 +9,7 @@ import copy
 import pathlib
 import webbrowser
 
+from fprime_gds.executables.base_url import BaseUrlParser, normalize_base_url
 from fprime_gds.executables.cli import (
     BinaryDeployment,
     ConfigDrivenParser,
@@ -36,6 +37,7 @@ def parse_args():
     arg_handlers = [
         StandardPipelineParser,
         GdsParser,
+        BaseUrlParser,
         BinaryDeployment,
         CommParser,
         PluginArgumentParser,
@@ -117,12 +119,14 @@ def launch_html(parsed_args):
     reproduced_arguments = StandardPipelineParser().reproduce_cli_args(parsed_args)
     if "--log-directly" not in reproduced_arguments:
         reproduced_arguments += ["--log-directly"]
+    base_url = normalize_base_url(parsed_args.base_url)
     flask_env = os.environ.copy()
     flask_env.update(
         {
             "FLASK_APP": "fprime_gds.flask.app",
             "STANDARD_PIPELINE_ARGUMENTS": "|".join(reproduced_arguments),
             "SERVE_LOGS": "YES",
+            "FPRIME_GDS_BASE_URL": base_url,
         }
     )
     if parsed_args.hash_file:
@@ -136,9 +140,9 @@ def launch_html(parsed_args):
         str(parsed_args.gui_port),
     ]
     ret = launch_process(gse_args, name="HTML GUI", env=flask_env, launch_time=2)
-    ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}/"
+    ui_url = f"http://{str(parsed_args.gui_addr)}:{str(parsed_args.gui_port)}{base_url}/"
     print(f"[INFO] Launched UI at: {ui_url}")
-    
+
     if parsed_args.browser_auto_open:
         webbrowser.open(
             ui_url,

--- a/src/fprime_gds/flask/app.py
+++ b/src/fprime_gds/flask/app.py
@@ -29,6 +29,7 @@ import fprime_gds.flask.logs
 import fprime_gds.flask.sequence
 import fprime_gds.flask.stats
 import fprime_gds.flask.updown
+from fprime_gds.executables.base_url import normalize_base_url, with_base_url
 from fprime_gds.executables.cli import ParserBase, StandardPipelineParser, ConfigDrivenParser
 
 from . import components
@@ -52,7 +53,8 @@ def construct_app():
 
     :return: setup app
     """
-    app = flask.Flask(__name__, static_url_path="")
+    base_url = normalize_base_url(os.environ.get("FPRIME_GDS_BASE_URL", ""))
+    app = flask.Flask(__name__, static_url_path=base_url)
     # Enable compression if it is installed
     if Compress is not None:
         compress = Compress()
@@ -67,6 +69,7 @@ def construct_app():
     # JSON encoding settings
     app.json.default = fprime_gds.flask.json.default
     app.config["RESTFUL_JSON"] = {"default": app.json.default}
+    app.config["BASE_URL"] = base_url
     # Standard pipeline creation
     input_arguments = app.config["STANDARD_PIPELINE_ARGUMENTS"]
     args_ns, _ = ParserBase.parse_args(
@@ -75,12 +78,14 @@ def construct_app():
     # Load app configuration from file
     for key, value in args_ns.config_values.get("flask", {}).items():
         app.config[key] = value
+    # BASE_URL controls routes registered during application construction and
+    # therefore must remain consistent with FPRIME_GDS_BASE_URL.
+    app.config["BASE_URL"] = base_url
 
     pipeline = components.setup_pipelined_components(app.debug, args_ns)
 
-
     # Restful API registration
-    api = fprime_gds.flask.errors.setup_error_handling(app)
+    api = fprime_gds.flask.errors.setup_error_handling(app, prefix=base_url)
 
     # Application routes
     api.add_resource(
@@ -199,7 +204,7 @@ def handle_unexpected_error(error):
     return flask.jsonify(response), status_code
 
 
-@app.route("/js/config.js")
+@app.route(with_base_url(app.config["BASE_URL"], "/js/config.js"))
 def config_serve():
     """
     Serve the config.js file
@@ -208,7 +213,8 @@ def config_serve():
     """
     return flask.send_file(app.config["JS_CONFIGURATION_FILE"])
 
-@app.route("/js/<path:path>")
+
+@app.route(with_base_url(app.config["BASE_URL"], "/js/<path:path>"))
 def files_serve(path):
     """
     A function used to serve the JS files needed for the GUI layers.
@@ -218,7 +224,7 @@ def files_serve(path):
     return flask.send_from_directory("static/js", path)
 
 
-@app.route("/")
+@app.route(with_base_url(app.config["BASE_URL"], "/"))
 def index():
     """
     A function used to serve the JS files needed for the GUI layers.
@@ -226,7 +232,7 @@ def index():
     return flask.send_from_directory("static", "index.html")
 
 
-@app.route("/logs")
+@app.route(with_base_url(app.config["BASE_URL"], "/logs"))
 def log():
     """
     A function used to serve the JS files needed for the GUI layers.
@@ -234,7 +240,7 @@ def log():
     return flask.send_from_directory("static", "logs.html")
 
 
-@app.route("/session")
+@app.route(with_base_url(app.config["BASE_URL"], "/session"))
 def session():
     return flask.jsonify({"session": uuid.uuid4()}), 200
 

--- a/src/fprime_gds/flask/errors.py
+++ b/src/fprime_gds/flask/errors.py
@@ -49,7 +49,7 @@ class ErrorHandlingApi(Api):
         return handle_flask_error(error)
 
 
-def setup_error_handling(app: Flask):
+def setup_error_handling(app: Flask, prefix=""):
     """Setup the error handling for flask and get a flask_restful API with similar error handling
 
     Sets up a flask_restful API that will handle errors in the standard way and registers the same error handling to
@@ -57,9 +57,10 @@ def setup_error_handling(app: Flask):
 
     Args:
         app: flask application to register errors
+        prefix: optional URL prefix for all flask-restful resources
 
     Returns:
         flask restful api with standardized error handling
     """
     app.errorhandler(Exception)(handle_flask_error)
-    return Api(app)
+    return Api(app, prefix=prefix)

--- a/src/fprime_gds/flask/static/addons/image-display/addon.js
+++ b/src/fprime_gds/flask/static/addons/image-display/addon.js
@@ -36,7 +36,7 @@ Vue.component("image-display", {
                 return "";
             }
             let last = images[images.length - 1].destination.replace(regex, "");
-            return "/download/files/" + last;
+            return "download/files/" + last;
          }
     }
 }

--- a/src/fprime_gds/flask/static/js/loader.js
+++ b/src/fprime_gds/flask/static/js/loader.js
@@ -203,7 +203,10 @@ class Loader {
                     reject(this.responseText);
                 }
             };
-            let url = endpoint;
+            // Keep API requests relative to the loaded UI path. This preserves
+            // root deployments and allows the same front end to run under a
+            // reverse-proxy prefix such as /mission/gds/.
+            let url = endpoint.replace(/^\/+/, "");
             let session = (_self.endpoints["session"].data || {}).session || null;
 
             let arg_pairs = [["session", session], ["limit", _settings.miscellaneous.response_object_limit]];
@@ -212,7 +215,7 @@ class Loader {
             url += (arg_string !== "") ? ("?"+ arg_string) : "";
 
             let is_async = true; // all calls will be async
-            xhttp.open(method, url , is_async); 
+            xhttp.open(method, url , is_async);
             xhttp.setRequestHeader("Cache-Control", "no-cache");
             if (typeof(data) === "undefined") {
                 xhttp.send();

--- a/test/fprime_gds/executables/test_base_url.py
+++ b/test/fprime_gds/executables/test_base_url.py
@@ -1,0 +1,47 @@
+import pytest
+
+from fprime_gds.executables.base_url import BaseUrlParser, normalize_base_url, with_base_url
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("", ""),
+        ("/", ""),
+        ("gds", "/gds"),
+        ("/gds", "/gds"),
+        ("/mission/gds/", "/mission/gds"),
+    ],
+)
+def test_normalize_base_url(value, expected):
+    assert normalize_base_url(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "https://example.com/gds",
+        "//example.com/gds",
+        "/gds?mode=test",
+        "/gds#fragment",
+        "/gds//nested",
+        "/gds/../other",
+        "/gds/%2e%2e/other",
+        "/gds/%2fother",
+    ],
+)
+def test_normalize_base_url_rejects_non_path_or_ambiguous_values(value):
+    with pytest.raises(ValueError):
+        normalize_base_url(value)
+
+
+def test_with_base_url_preserves_root_routes_and_prefixes_nested_routes():
+    assert with_base_url("", "/channels") == "/channels"
+    assert with_base_url("/mission/gds", "/channels") == "/mission/gds/channels"
+    assert with_base_url("/mission/gds", "/") == "/mission/gds/"
+
+
+def test_base_url_parser_normalizes_command_line_value():
+    parser = BaseUrlParser().get_parser()
+    args = parser.parse_args(["--base-url", "mission/gds/"])
+    assert args.base_url == "/mission/gds"

--- a/test/fprime_gds/executables/test_base_url.py
+++ b/test/fprime_gds/executables/test_base_url.py
@@ -1,6 +1,9 @@
 import pytest
+from flask import Flask
+from flask_restful import Resource
 
 from fprime_gds.executables.base_url import BaseUrlParser, normalize_base_url, with_base_url
+from fprime_gds.flask.errors import setup_error_handling
 
 
 @pytest.mark.parametrize(
@@ -45,3 +48,17 @@ def test_base_url_parser_normalizes_command_line_value():
     parser = BaseUrlParser().get_parser()
     args = parser.parse_args(["--base-url", "mission/gds/"])
     assert args.base_url == "/mission/gds"
+
+
+def test_rest_api_prefix_moves_resource_below_base_url():
+    class Ping(Resource):
+        def get(self):
+            return {"ok": True}
+
+    app = Flask(__name__)
+    api = setup_error_handling(app, prefix="/mission/gds")
+    api.add_resource(Ping, "/ping")
+
+    client = app.test_client()
+    assert client.get("/mission/gds/ping").status_code == 200
+    assert client.get("/ping").status_code == 404


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#3854 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

Adds a `--base-url` option for serving the HTML GDS and REST API below a path prefix such as `/mission/gds`.

- normalizes and validates path-only base URLs
- passes the configured prefix to the Flask subprocess and browser-launch URL
- prefixes Flask and flask-restful routes while preserving existing root behavior by default
- makes browser API requests relative to the loaded UI path so reverse-proxy prefixes are retained
- keeps the image-display download URL base-relative
- adds unit coverage and user documentation

## Rationale

This implements the CCB-approved request in nasa/fprime#3854 and allows multiple GDS instances or reverse-proxy deployments to share a host without requiring a separate port for every GDS.

## Testing/Review Recommendations

Run `pytest test/fprime_gds/executables/test_base_url.py` and the normal repository checks. Review URL normalization, Flask route prefixing, and preservation of root-path behavior when `--base-url` is omitted.

## Future Work

None planned for this issue.
