### PR TITLE
Fix send_and_assert_command assuming dispatch always precedes completion

### DIFF
--- a/src/fprime_gds/common/testing_fw/api.py
+++ b/src/fprime_gds/common/testing_fw/api.py
@@ -618,27 +618,46 @@ class IntegrationTestAPI(DataHandler):
         within the F' deployment. This helper can retroactively check that the delay between
         dispatch and completion is less than a maximum allowable delay.
 
+        Note: dispatch and completion are searched for independently of their relative arrival
+        order. A synchronous command dispatcher can log OpCodeCompleted before OpCodeDispatched,
+        since the command executes inline before the dispatch EVR is generated, so this does not
+        assume dispatch arrives first the way a single ordered sequence search would.
+
         Args:
             command: the mnemonic (str) or ID (int) of the command to send
             args: a list of command arguments.
             max_delay: the maximum allowable delay between dispatch and completion (int/float)
             timeout: the number of seconds to wait before terminating the search (int)
-            events: extra event predicates to check between  dispatch and complete
+            events: extra event predicates to check for between dispatch and complete
             commander: the command dispatching component. Defaults to cmdDisp
         Return:
-            returns a list of the EventData objects found by the search
+            returns a list of the EventData objects found by the search, positioned as
+            [dispatch, *events, complete] regardless of the order they actually arrived in
         """
         if args is None:
             args = []
         cmd_id = self.translate_command_name(command)
-        dispatch = [
-            self.get_event_pred(f"{commander}.OpCodeDispatched", [cmd_id, None])
-        ]
-        complete = [self.get_event_pred(f"{commander}.OpCodeCompleted", [cmd_id])]
-        events = dispatch + (events if events else []) + complete
-        results = self.send_and_assert_event(command, args, events, timeout=timeout)
+        dispatch_pred = self.get_event_pred(f"{commander}.OpCodeDispatched", [cmd_id, None])
+        complete_pred = self.get_event_pred(f"{commander}.OpCodeCompleted", [cmd_id])
+        extra_preds = [self.get_event_pred(event) for event in (events or [])]
+        all_preds = [dispatch_pred, *extra_preds, complete_pred]
+
+        start = self.event_history.size()
+        self.send_command(command, args)
+        results = self.find_history_unordered_set(
+            all_preds, self.event_history, start=start, timeout=timeout
+        )
+        found_count = sum(1 for result in results if result is not None)
+        len_pred = predicates.equal_to(len(all_preds))
+        msg = "checks if the dispatch, completion, and any extra events were all found"
+        self.__assert_pred("Command dispatch/completion", len_pred, found_count, msg)
+
         if max_delay is not None:
-            delay = results[-1].get_time() - results[0].get_time()
+            dispatch_result, complete_result = results[0], results[-1]
+            if dispatch_result.get_time() > complete_result.get_time():
+                delay = dispatch_result.get_time() - complete_result.get_time()
+            else:
+                delay = complete_result.get_time() - dispatch_result.get_time()
             msg = f"The delay, {delay}, between the two events should be < {max_delay}"
             assert delay < max_delay, msg
         return results
@@ -1476,6 +1495,54 @@ class IntegrationTestAPI(DataHandler):
         searcher = __SequenceSearcher(self.__log, seq_preds)
         return self.__search_test_history(
             searcher, "Sequence search", history, start, timeout
+        )
+
+    def find_history_unordered_set(self, preds, history, start=None, timeout=0):
+        """
+        This function can both search and await for a set of elements in a history, the same as
+        find_history_sequence, except the items may satisfy the given predicates in any relative
+        order. Each predicate must still be satisfied by a distinct history item. The function
+        will return when every predicate has been matched, or the timeout occurs.
+        Note: this search will always return a list of objects, positioned to match the order of
+        preds (not the order the items were found in). The user should check if the search was
+        completed; unmatched predicates are represented as None in the returned list.
+
+        Args:
+            preds: a list of predicate objects; each must be matched by a distinct history item
+            history: the history that the function will search and await
+            start: an index or predicate to specify the earliest item from the history to search
+            timeout: the number of seconds to wait before terminating the search (int)
+        Returns:
+            a list of data objects satisfying preds, ordered to match preds
+        """
+
+        class __UnorderedSetSearcher(self.__HistorySearcher):
+            def __init__(self, log, preds):
+                super().__init__()
+                self.log = log
+                self.remaining = list(enumerate(preds))
+                self.ret_val = [None] * len(preds)
+                self.repeats = True
+                msg = f"Beginning an unordered search of {len(preds)} items."
+                self.log(msg, TestLogger.YELLOW)
+
+            def search_current_history(self, items):
+                for item in items:
+                    self.incremental_search(item)
+                return len(self.remaining) == 0
+
+            def incremental_search(self, item):
+                for position, (original_index, pred) in enumerate(self.remaining):
+                    if pred(item):
+                        self.log(f"Unordered search found an item: {item}")
+                        self.ret_val[original_index] = item
+                        del self.remaining[position]
+                        break
+                return len(self.remaining) == 0
+
+        searcher = __UnorderedSetSearcher(self.__log, preds)
+        return self.__search_test_history(
+            searcher, "Unordered search", history, start, timeout
         )
 
     def find_history_count(

--- a/test/fprime_gds/common/testing_fw/UnitTestDictionary.xml
+++ b/test/fprime_gds/common/testing_fw/UnitTestDictionary.xml
@@ -47,6 +47,17 @@
     </event>
     <event component="apiTester2" name="SeverityFATAL" id="0xA" severity="FATAL" format_string="Unit Test EVR with FATAL Severity">
     </event>
+    <event component="cmdDisp" name="OpCodeDispatched" id="0xB" severity="COMMAND" format_string="Opcode %d dispatched to port %d">
+      <args>
+        <arg name="Opcode" type="U32"/>
+        <arg name="port" type="I32"/>
+      </args>
+    </event>
+    <event component="cmdDisp" name="OpCodeCompleted" id="0xC" severity="COMMAND" format_string="Opcode %d completed">
+      <args>
+        <arg name="Opcode" type="U32"/>
+      </args>
+    </event>
   </events>
   <channels>
     <channel component="apiTester" name="CommandCounter" id="1" description="Counts number of commands sent by the unit test" type="U32"/>

--- a/test/fprime_gds/common/testing_fw/api_unit_test.py
+++ b/test/fprime_gds/common/testing_fw/api_unit_test.py
@@ -27,6 +27,10 @@ class UTPipeline(StandardPipeline):
     def __init__(self):
         self.command_count = 0
         self.t0 = TimeType()
+        # When set to "dispatch_first" or "complete_first", send_command also emits
+        # cmdDisp.OpCodeDispatched/OpCodeCompleted events in the given order, simulating an
+        # async (dispatch-then-complete) or synchronous (complete-then-dispatch) dispatcher.
+        self.dispatch_complete_order = None
         StandardPipeline.__init__(self)
 
     def connect(self, address, port):
@@ -58,6 +62,25 @@ class UTPipeline(StandardPipeline):
         ch_temp = self.dictionaries.channel_name["apiTester.CommandCounter"]
         update = ChData(U32Type(self.command_count), self.t0 + time.time(), ch_temp)
         self.enqueue_telemetry(update)
+
+        if self.dispatch_complete_order is not None:
+            dispatched_temp = self.dictionaries.event_name["cmdDisp.OpCodeDispatched"]
+            dispatched = EventData(
+                (U32Type(cmd_data.get_id()), I32Type(0)),
+                self.t0 + time.time(),
+                dispatched_temp,
+            )
+            completed_temp = self.dictionaries.event_name["cmdDisp.OpCodeCompleted"]
+            completed = EventData(
+                (U32Type(cmd_data.get_id()),), self.t0 + time.time(), completed_temp
+            )
+            ordered = (
+                [dispatched, completed]
+                if self.dispatch_complete_order == "dispatch_first"
+                else [completed, dispatched]
+            )
+            for event in ordered:
+                self.enqueue_event(event)
 
     def enqueue_event(self, event):
         """
@@ -102,6 +125,7 @@ class APITestCases(unittest.TestCase):
         self.case_list.append(1)
         self.tHistory = TestHistory()
         self.t0 = TimeType()
+        self.pipeline.dispatch_complete_order = None
 
     @classmethod
     def tearDownClass(cls):
@@ -641,6 +665,44 @@ class APITestCases(unittest.TestCase):
 
         for i in range(6):
             assert results1[i] != results2[i], "These sequences should be unique items"
+
+    def test_send_and_assert_command(self):
+        # Async-style dispatcher: OpCodeDispatched logged before OpCodeCompleted
+        self.pipeline.dispatch_complete_order = "dispatch_first"
+        results = self.api.send_and_assert_command(
+            "apiTester.TEST_CMD_1", max_delay=5, timeout=5
+        )
+        assert len(results) == 2
+        dispatched, completed = results
+        assert dispatched.template.get_name() == "OpCodeDispatched"
+        assert completed.template.get_name() == "OpCodeCompleted"
+
+        self.api.clear_histories()
+
+        # Synchronous-style dispatcher: OpCodeCompleted logged before OpCodeDispatched.
+        # This is the exact ordering that used to make send_and_assert_command fail, since it
+        # searched for OpCodeDispatched then OpCodeCompleted as a strict ordered sequence.
+        self.pipeline.dispatch_complete_order = "complete_first"
+        results = self.api.send_and_assert_command(
+            "apiTester.TEST_CMD_1", max_delay=5, timeout=5
+        )
+        assert len(results) == 2
+        dispatched, completed = results
+        assert dispatched.template.get_name() == "OpCodeDispatched"
+        assert completed.template.get_name() == "OpCodeCompleted"
+
+        self.api.clear_histories()
+
+        # Extra events between dispatch and complete are still required, regardless of order
+        self.pipeline.dispatch_complete_order = "complete_first"
+        results = self.api.send_and_assert_command(
+            "apiTester.TEST_CMD_1", events=["CommandReceived"], timeout=5
+        )
+        assert len(results) == 3
+        dispatched, extra, completed = results
+        assert dispatched.template.get_name() == "OpCodeDispatched"
+        assert extra.template.get_name() == "CommandReceived"
+        assert completed.template.get_name() == "OpCodeCompleted"
 
     def test_translate_telemetry_name(self):
         assert self.api.translate_telemetry_name("apiTester.CommandCounter") == 1


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| nasa/fprime#4632 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| n |

---
## Change Description

`send_and_assert_command()` searched for `OpCodeDispatched` followed by `OpCodeCompleted` as a single strict ordered sequence. That assumes dispatch always logs before completion, but a synchronous command dispatcher executes the command inline and can log `OpCodeCompleted` before `OpCodeDispatched` — see the trace into `PassiveCmdDispatcher.cpp` in the linked issue. When that happens the ordered sequence search never finds a match, so the call times out instead of returning a clear result.

I changed it to search for dispatch and completion independently (order-agnostic) via a new `find_history_unordered_set()` helper, which mirrors the existing `find_history_sequence()` machinery but doesn't require a fixed relative order between predicates. Any extra `events` passed in are still required, just no longer assumed to land strictly between dispatch and completion. `max_delay` is computed from whichever of the two events actually arrived first, rather than assuming dispatch comes first.

## Rationale

Fixes nasa/fprime#4632. I proposed this approach on the issue first since it touches the ordering contract of a public test API method, and got no objections before implementing.

## Testing/Review Recommendations

Added `test_send_and_assert_command` covering both orderings (dispatch-first and complete-first) plus the extra-`events` case. I confirmed the new test actually catches the bug by reverting only the `api.py` fix (`git stash`) and re-running it — it fails against the old code with `complete_first` ordering, then passes once the fix is restored. Ran the full `fprime-gds` test suite before and after the change (`git stash` again) to confirm the pre-existing 16 failures/6 errors on this Windows dev environment are unrelated to this change (identical failures either way — they're line-ending/path-separator differences in unrelated sequence-parser tests).

## Future Work

None.

---
AI-assisted development (Claude Code) — I traced the bug through the source, reviewed and tested the fix myself, and take responsibility for every line.
