### PR TITLE
Fix event decoder corrupting events after the first in a multi-event buffer

### DIFF
--- a/src/fprime_gds/common/decoders/event_decoder.py
+++ b/src/fprime_gds/common/decoders/event_decoder.py
@@ -88,11 +88,11 @@ class EventDecoder(decoder.Decoder):
 
             event_temp = self.__dict[event_id]
 
-            (size, arg_vals) = self.decode_args(data, ptr, event_temp)
+            (arg_end_offset, arg_vals) = self.decode_args(data, ptr, event_temp)
 
             event_list.append(event_data.EventData(arg_vals, event_time, event_temp))
-            # add up argument sizes
-            ptr += size
+            # decode_args returns the absolute offset past the arguments; advance to it
+            ptr = arg_end_offset
         return event_list
 
     @staticmethod
@@ -110,10 +110,12 @@ class EventDecoder(decoder.Decoder):
                       arg_data goes to.
 
         Returns:
-            Parsed arguments in a tuple (order the same as they were parsed in).
-            Each element in the tuple is an instance of the same class as the
-            corresponding arg_type object in the template parameter. Returns
-            none if the arguments can't be parsed
+            A two element list ``[end_offset, args]``. ``end_offset`` is the
+            absolute offset into ``arg_data`` one past the last argument; the
+            caller uses it as the start of the next event in the buffer. ``args``
+            is a tuple of the parsed arguments in order, each an instance of the
+            same class as the corresponding arg_type object in the template.
+            Raises DecodingException if an argument cannot be parsed.
         """
         arg_results = []
         args = template.get_args()

--- a/test/fprime_gds/common/decoders/test_event_decoder.py
+++ b/test/fprime_gds/common/decoders/test_event_decoder.py
@@ -1,0 +1,63 @@
+"""
+Tests the event decoder, in particular decoding several events packed into a
+single buffer (as delivered when the flight software emits events in quick
+succession).
+
+Regression test for nasa/fprime#4620: the decoder advanced its read pointer by
+the absolute end offset returned from ``decode_args`` instead of using it as the
+new position, so every event after the first in a multi-event buffer was parsed
+from the wrong offset and came back corrupted.
+"""
+
+from fprime_gds.common.decoders.event_decoder import EventDecoder
+from fprime_gds.common.models.serialize.numerical_types import U32Type
+from fprime_gds.common.models.serialize.time_type import TimeType
+from fprime_gds.common.templates.event_template import EventTemplate
+from fprime_gds.common.utils.config_manager import ConfigManager
+from fprime_gds.common.utils.event_severity import EventSeverity
+
+
+def _make_template():
+    return EventTemplate(
+        101,
+        "test_evr",
+        "test_comp",
+        [("value", "the value", U32Type)],
+        EventSeverity["ACTIVITY_LO"],
+        "value {}",
+    )
+
+
+def _serialize_event(event_id, useconds, value):
+    """Build the raw bytes the decoder consumes: id + time + args."""
+    id_obj = ConfigManager().get_type("FwEventIdType")()
+    id_obj.val = event_id
+    time_obj = TimeType(
+        TimeType.TimeBase("TB_WORKSTATION_TIME"), 0, 1533758629, useconds
+    )
+    return id_obj.serialize() + time_obj.serialize() + U32Type(value).serialize()
+
+
+def test_event_decoder_single_event():
+    decoder = EventDecoder({101: _make_template()})
+
+    events = decoder.decode_api(_serialize_event(101, 100, 42))
+
+    assert len(events) == 1
+    assert events[0].time.useconds == 100
+    assert events[0].args[0].val == 42
+
+
+def test_event_decoder_multiple_events_in_one_buffer():
+    decoder = EventDecoder({101: _make_template()})
+
+    buffer = (
+        _serialize_event(101, 111, 23351024)
+        + _serialize_event(101, 222, 23351023)
+        + _serialize_event(101, 333, 23351022)
+    )
+    events = decoder.decode_api(buffer)
+
+    assert len(events) == 3
+    decoded = [(event.time.useconds, event.args[0].val) for event in events]
+    assert decoded == [(111, 23351024), (222, 23351023), (333, 23351022)]


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| #4620 |
|**_Has Unit Tests (y/n)_**| y |
|**_Documentation Included (y/n)_**| y |

---
## Change Description

`EventDecoder.decode_api` decodes a buffer that may hold several events, looping over each one the way `ChannelDecoder` loops over a multi-item telemetry packet. It advanced past each event's arguments with:

```python
(size, arg_vals) = self.decode_args(data, ptr, event_temp)
ptr += size
```

`decode_args` returns the absolute offset one past the arguments, not a length, so `ptr += size` jumped roughly a whole event too far. Every event after the first was then read from the wrong offset and came back corrupted, or raised `DecodingException` when the stray bytes did not match a known event id. The fix sets `ptr` to the returned offset. It also rewrites the `decode_args` docstring, which never stated that its first return value is that offset, to document the contract whose misreading caused the bug.

## Rationale

Addresses #4620, where events arriving close together came back duplicated or garbled through `send_and_await_event`. A buffer with a single event decodes correctly, which is why the bug stayed hidden.

## Testing/Review Recommendations

Added `test/fprime_gds/common/decoders/test_event_decoder.py`: a single-event case and a three-event buffer. On `devel` the multi-event case fails (`Event 23351023 not found in dictionary`, the second event's argument read as an id) and passes with this change. Run `pytest test/fprime_gds/common/decoders`. Other suite failures (history, seq_parser, plugins) are present on unmodified `devel`. Verified on Python 3.10; CI covers 3.9 to 3.13.

## Future Work

None.
