### PR TITLE
Updated fprime_test_api to pickup config in FPRIME_GDS_CONFIG_PATH

### DIFF
--- a/src/fprime_gds/common/testing_fw/pytest_integration.py
+++ b/src/fprime_gds/common/testing_fw/pytest_integration.py
@@ -1,4 +1,4 @@
-""" pytest_integration.py: F´ fixture API fixture
+"""pytest_integration.py: F´ fixture API fixture
 
 pytest uses fixtures to provide for extra functionality when writing tests. This fixture sets up the F´ stack allowing
 our tests to use a configured test API without needing to create any specific setup to use that API. i.e. write a test
@@ -14,19 +14,20 @@ Here a test (defined by starting the name with test_) uses the fprime_test_api f
 
 @author lestarch
 """
+
 import itertools
 import sys
 from pathlib import Path
 import pytest
 
 from fprime_gds.common.testing_fw.api import IntegrationTestAPI
-from fprime_gds.executables.cli import StandardPipelineParser
+from fprime_gds.executables.cli import StandardPipelineParser, ConfigDrivenParser
 
 SEQUENCE_COUNTER = itertools.count()
 
 
 def pytest_addoption(parser):
-    """ Add fprime-gds options to the pytest parser
+    """Add fprime-gds options to the pytest parser
 
     Pytest allows users to add options to its parser. These options act very similar to argparse options and thus can be
     reused from the standard GDS command line processing. Note: pytest restricts the use of short flags (-[a-z]) thus we
@@ -39,7 +40,7 @@ def pytest_addoption(parser):
         # Reduce flags to only the long option (i.e. --something) form
         flags = [flag for flag in flags if flag.startswith("--")]
         parser.addoption(*flags, **specifiers)
-        
+
     # Add an option to specify JUnit XML report file
     parser.addoption(
         "--junit-xml-file",
@@ -51,7 +52,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--gen-junitxml",
         action="store_true",
-        help="Enable JUnitXML report generation to a specified location"
+        help="Enable JUnitXML report generation to a specified location",
     )
     # Add an option to specify a json config file that maps components
     parser.addoption(
@@ -64,19 +65,20 @@ def pytest_addoption(parser):
     parser.addoption(
         "--use-yamcs",
         action="store_true",
-        help="Use YAMCS transport instead of TCP socket"
+        help="Use YAMCS transport instead of TCP socket",
     )
     parser.addoption(
         "--yamcs-url",
         action="store",
         default="http://localhost:8090",
-        help="YAMCS server URL [default: %(default)s]"
+        help="YAMCS server URL [default: %(default)s]",
     )
 
+
 def pytest_configure(config):
-    """ This is a hook to allow plugins and conftest files to perform initial configuration
-    
-    This hook is called for every initial conftest file after command line options have been parsed. After that, the 
+    """This is a hook to allow plugins and conftest files to perform initial configuration
+
+    This hook is called for every initial conftest file after command line options have been parsed. After that, the
     hook is called for other conftest files as they are registered.
     """
     # Create a JUnit XML report file to capture the test result in a specified location
@@ -86,9 +88,10 @@ def pytest_configure(config):
             raise pytest.UsageError("--gen-junitxml requires --logs to be specified")
         config.option.xmlpath = Path(logs) / config.getoption("--junit-xml-file")
 
-@pytest.fixture(scope='session')
+
+@pytest.fixture(scope="session")
 def fprime_test_api_session(request):
-    """ Create a session-level fprime test API
+    """Create a session-level fprime test API
 
     This is a pytest session fixture. Using the options added above, this will parse the necessary options for
     connecting the standard pipeline to the running GDS. This pipeline is supplied to the fprime test API returned as
@@ -106,11 +109,24 @@ def fprime_test_api_session(request):
         fprime test API connected to the GDS.  Note: a second call will shut down that object.
     """
     pipeline_parser = StandardPipelineParser()
+
+    # Use the ConfigDrivenParser to retrieve default configuration from a file (so that pytest
+    # behavior matches fprime-gds CLI behavior). ConfigDrivenParser.parse_known_args() can NOT
+    # be called with arguments=None here, as that defaults to sys.argv[1:] which is pytest's own
+    # command line (e.g. -v, --color=yes) and not fprime-gds options. Instead, reproduce only the
+    # standard-pipeline flags that pytest actually parsed explicitly, and let ConfigDrivenParser
+    # fill in the rest from the configuration file.
+    reproduced_args = pipeline_parser.reproduce_cli_args(
+        request.config.known_args_namespace
+    )
+    arg_ns, _, _ = ConfigDrivenParser.parse_known_args(
+        [StandardPipelineParser], arguments=reproduced_args, client=True
+    )
+
     pipeline = None
     api = None
     deployment_config = None
     try:
-        arg_ns = pipeline_parser.handle_arguments(request.config.known_args_namespace, client=True)
 
         if request.config.getoption("--use-yamcs"):
             try:
@@ -154,9 +170,9 @@ def fprime_test_api_session(request):
             print(f"[WARNING] Exception in pipeline teardown: {exc}", file=sys.stderr)
 
 
-@pytest.fixture(scope='function')
+@pytest.fixture(scope="function")
 def fprime_test_api(fprime_test_api_session, request):
-    """ Provide a per-testcase fixture
+    """Provide a per-testcase fixture
 
     Although the test API should exist across all testcases and thus be created at the "session" level, individual test
     cases need a clean test API that has logged the testcases has started. Thus, the session API is refined into a

--- a/src/fprime_gds/executables/cli.py
+++ b/src/fprime_gds/executables/cli.py
@@ -38,7 +38,6 @@ from fprime_gds.plugin.definitions import PluginType
 from fprime_gds.plugin.system import Plugins, PluginsNotLoadedException
 from fprime_gds.common.zmq_transport import ZmqClient
 
-
 GUIS = ["none", "html"]
 
 
@@ -55,7 +54,11 @@ class ParserBase(ABC):
     @property
     def description(self) -> str:
         """Return parser description"""
-        return self.DESCRIPTION if self.DESCRIPTION is not None else "Unknown command line parser"
+        return (
+            self.DESCRIPTION
+            if self.DESCRIPTION is not None
+            else "Unknown command line parser"
+        )
 
     @abstractmethod
     def get_arguments(self) -> Dict[Tuple[str, ...], Dict[str, Any]]:
@@ -318,14 +321,30 @@ class ConfigDrivenParser(ParserBase):
 
     DEFAULT_CONFIGURATION_PATH = Path("fprime-gds.yml")
 
+    # Takes precedence over DEFAULT_CONFIGURATION_PATH
+    DEFAULT_CONFIGURATION_PATH_ENV = "FPRIME_GDS_CONFIG_PATH"
+
     @classmethod
     def set_default_configuration(cls, path: Path):
         """Set path for (global) default configuration file
 
         Set the path for default configuration file. If unset, will use 'fprime-gds.yml'. Set to None to disable default
-        configuration.
+        configuration. Calling this function disables the environment variable override.
         """
         cls.DEFAULT_CONFIGURATION_PATH = path
+        os.environ.pop(cls.DEFAULT_CONFIGURATION_PATH_ENV, None)
+
+    @classmethod
+    def get_default_configuration(cls):
+        """Get path for (global) default configuration file
+
+        If set, the environment variable (DEFAULT_CONFIGURATION_PATH_ENV) overrides
+        DEFAULT_CONFIGURATION_PATH. Get the path for default configuration file. If unset, will
+        use 'fprime-gds.yml'.
+        """
+        if cls.DEFAULT_CONFIGURATION_PATH_ENV in os.environ:
+            return Path(os.environ[cls.DEFAULT_CONFIGURATION_PATH_ENV])
+        return cls.DEFAULT_CONFIGURATION_PATH
 
     @classmethod
     def parse_args(
@@ -450,7 +469,7 @@ class ConfigDrivenParser(ParserBase):
             ("-c", "--config"): {
                 "dest": "config",
                 "required": False,
-                "default": self.DEFAULT_CONFIGURATION_PATH,
+                "default": self.get_default_configuration(),
                 "type": Path,
                 "help": "Argument configuration file path. [default: %(default)s]",
             },
@@ -969,7 +988,9 @@ class LogDeployParser(ParserBase):
                 args.log_prefix = tool_name
 
             timestamp = datetime.datetime.now().strftime("%Y_%m_%d-%H_%M_%S")
-            dir_name = f"{args.log_prefix}-{timestamp}" if args.log_prefix else timestamp
+            dir_name = (
+                f"{args.log_prefix}-{timestamp}" if args.log_prefix else timestamp
+            )
             args.logs = os.path.abspath(os.path.join(args.logs, dir_name))
             # A dated directory has been set, all log handling must now be direct
             args.log_directly = True
@@ -1175,7 +1196,6 @@ class FileHandlingParser(ParserBase):
                 "type": str,
                 "help": "Directory to store uplink and downlink files. Default: %(default)s",
             },
-
             ("--file-uplink-cooldown",): {
                 "dest": "file_uplink_cooldown",
                 "action": "store",
@@ -1334,11 +1354,11 @@ class GdsParser(ParserBase):
                 "type": str,
                 "help": "Set the GUI server address [default: %(default)s]",
             },
-            ("--skip-browser-open",):{
+            ("--skip-browser-open",): {
                 "dest": "browser_auto_open",
                 "action": "store_false",
-                "help": "Run server without auto-launching the default web browser"
-                }
+                "help": "Run server without auto-launching the default web browser",
+            },
         }
 
     def handle_arguments(self, args, **kwargs):


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**|  |
|**_Has Unit Tests (y/n)_**|  n |
|**_Documentation Included (y/n)_**|  |

---
## Change Description

Updated files for the fprime_test_api pytext fixture to use the configuration from the file in the FPRIME_GDS_CONFIG_PATH environment variabl

## Rationale

fprime-gds will pick up default configuration from the file in the FPRIME_GDS_CONFIG_PATH environment variable (if that's set). It would make using fprime_test_api simpler if configuration for that tool also picked up the options from the file in FPRIME_GDS_CONFIG_PATH

## Testing/Review Recommendations

Specify configuration (e.g. see example below)  in a file , then set environment variable FPRIME_GDS_CONFIG to point to that. Then start fprime-gds and verify it picks up the correct option and then run a test that uses fprime_test_api and verify it picks up those options 

Below is an example of the config file we're using (with dictionary path anonymized)
```
command-line-options:
  communication-selection: jlink-comm
  dictionary: /workspaces/project/build-artifacts/va416x0-baremetal/DemoDeployment/dict/DemoDeployment.json
  framing-selection: fprime
  jlink-speed: 2000
  no-app:
  no-clear-history:
  no-zmq:
```

## Future Work

Note any additional work that will be done relating to this issue.
